### PR TITLE
BACKUP fs support for HassOS

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -1,5 +1,8 @@
 # Configuration
 
+## Alternate Backup/Snapshot File system
+Format a USB stick/Drive with a FAT32/EXT4(Best without a journal on flash)/Ext-FAT(not yet supported) file system and label it `BACKUP` case sensitive. This is mounted at configuration only if the supervisor container is not running which is usually only at boot. **It is not safe to remove this unless HassOS is powered down.**
+
 ## Automatic
 
 You can use an USB drive with HassOS to configure network options, SSH access to the host and to install updates.

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data-supervisor-backup.mount
@@ -1,0 +1,10 @@
+[Unit]
+Description=HassOS data backup partition
+
+[Mount]
+What=/dev/disk/by-label/BACKUP
+Where=/mnt/data/supervisor/backup
+Type=auto
+Options=nosuid,relatime,noexec
+SloppyOptions=yes
+

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-config
@@ -5,6 +5,26 @@ USB_CONFIG="/mnt/config"
 CONFIG_DIR=""
 USE_USB=0
 
+
+# Check and mount usb BACKUP to folder
+if findfs LABEL="BACKUP" > /dev/null 2>&1; then
+    echo "[Info] Found USB stick for BACKUPS"
+
+    if ! systemctl -q is-active multi-user.target; then
+        echo "[Info] Use USB stick for BACKUPS"
+        systemctl start mnt-data-supervisor-backup.mount
+        if ! systemctl -q is-active mnt-data-supervisor-backup.mount; then
+            echo "[Error] Can't mount backup partition"
+        else
+		# We can end up occasionally(first boot) mounting after the supervisor so restart
+            if systemctl -q is-active hassos-supervisor.service; then
+                 echo "[Warning] Restarting supervisor for backup filesystem"
+	         systemctl -q restart hassos-supervisor.service
+	    fi
+        fi
+    fi
+fi
+
 # Check and mount usb CONFIG to folder
 if findfs LABEL="CONFIG" > /dev/null 2>&1; then
     echo "[Info] Use USB stick for import CONFIG"


### PR DESCRIPTION
These changes are the most not invasive way I could see to add the ability to do local backups onto a different device, that didn't adversely affect boot time.

At boot config time this change mounts a filesystem labeled BACKUP to /mnt/data/supervisor/backup

This has been tested using the ova image in a virtual box both with and without BACKUP fs present.

**Workflow for user.**
Insertion of device (pre boot) with correct fs label (Documented)

**UI support for this feature**
None needed, though an indicator that this is active might be useful, other than checking the logs.

**Possible issues**
Removal of device during running (Documented)
Supervisor starting before fs mounted (restarts supervisor as a result)

**Pros**

- It's simple
- uses existing methods already used for config usb stick
- Provides backup potentially to a different block device to that which hassio is running on (my backups have been enten more than once on the same sd card)
- Potential reduction of IO on hassio block device for backups (increasing speed & reducing wear on hassio sdcard)

**Cons**

- Only activated on boot
- Must power off device for removal
- restart of supervisor if running (seems to only happen on first boot)
