### PR TITLE
Attempt to fix bluetooth communication problem on rpi3b

### DIFF
--- a/buildroot-external/package/bluetooth-bcm43xx/0001-btuart-reduced-baud-rate-rpi3b.patch
+++ b/buildroot-external/package/bluetooth-bcm43xx/0001-btuart-reduced-baud-rate-rpi3b.patch
@@ -1,0 +1,16 @@
+Bluetooth: hci0: Frame reassembly failed (-84)
+https://github.com/raspberrypi/firmware/issues/1150
+
+Signed-off-by: Luca Giovenzana <luca@giovenzana.org>
+
+--- btuart.orig	2020-03-25 03:05:24.491176583 +0100
++++ btuart	2020-03-25 03:05:43.603107833 +0100
+@@ -19,7 +19,7 @@ if [ "$uart0" = "$serial1" ] ; then
+ 	if [ "$uart0_pins" = "16" ] ; then
+ 		$HCIATTACH /dev/serial1 bcm43xx 3000000 flow - $BDADDR
+ 	else
+-		$HCIATTACH /dev/serial1 bcm43xx 921600 noflow - $BDADDR
++		$HCIATTACH /dev/serial1 bcm43xx 460800 noflow - $BDADDR
+ 	fi
+ else
+ 	$HCIATTACH /dev/serial1 bcm43xx 460800 noflow - $BDADDR

--- a/buildroot-external/package/bluetooth-bcm43xx/Config.in
+++ b/buildroot-external/package/bluetooth-bcm43xx/Config.in
@@ -3,4 +3,4 @@ config BR2_PACKAGE_BLUETOOTH_BCM43XX
 	depends on BR2_PACKAGE_BLUEZ5_UTILS_CLIENT
 	select BR2_PACKAGE_BLUEZ5_UTILS_DEPRECATED
 	help
-	  Install bluetooth for bcm43xx. 
+	  Install bluetooth for bcm43xx.

--- a/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
+++ b/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
@@ -10,13 +10,15 @@ BLUETOOTH_BCM43XX_LICENSE_FILES = $(BR2_EXTERNAL_HASSOS_PATH)/../LICENSE
 BLUETOOTH_BCM43XX_SITE = $(BR2_EXTERNAL_HASSOS_PATH)/package/bluetooth-bcm43xx
 BLUETOOTH_BCM43XX_SITE_METHOD = local
 
-define BLUETOOTH_BCM43XX_BUILD_CMDS
+define BLUETOOTH_BCM43XX_FIRMWARE_AND_HELPERS_DOWNLOAD
 	curl -L -o $(@D)/BCM43430A1.hcd https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/fff76cb15527c435ce99a9787848eacd6288282c/broadcom/BCM43430A1.hcd
 	curl -L -o $(@D)/BCM4345C0.hcd https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/fff76cb15527c435ce99a9787848eacd6288282c/broadcom/BCM4345C0.hcd
 	curl -L -o $(@D)/btuart https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/usr/bin/btuart
 	curl -L -o $(@D)/bthelper https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/usr/bin/bthelper
 	curl -L -o $(@D)/90-pi-bluetooth.rules https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/lib/udev/rules.d/90-pi-bluetooth.rules
 endef
+
+BLUETOOTH_BCM43XX_PRE_PATCH_HOOKS += BLUETOOTH_BCM43XX_FIRMWARE_AND_HELPERS_DOWNLOAD
 
 define BLUETOOTH_BCM43XX_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/etc/systemd/system/hassos-hardware.target.wants


### PR DESCRIPTION
Attempt to fix bluetooth communication problem on rpi3b.
I couldn't test this pull request because of #613 
  
This problem is referenced in many different issues, some of them:
Bluetooth: hci0: Frame reassembly failed (-84)
https://github.com/raspberrypi/firmware/issues/1150
    
Error communicating with local bluetooth adapter (RPi3)
https://github.com/home-assistant/core/issues/30147
    
Xiaomi BLE Temperature and Humidity sensor no longer working after update from 0.95.4 to .096.5
https://github.com/home-assistant/core/issues/25704
    
Xiaomi BLE Temperature and Humidity sensor
https://github.com/home-assistant/core/issues/24313#issuecomment-578554315
    
Solution seemed to reeduce the boud rate of the serial connection to BT
on rpi3b where flow control is missing.
    
The patch to the original btuart file is to reduce the baudrate only for rpi3b models where flow control is missing:
    
    -               $HCIATTACH /dev/serial1 bcm43xx 921600 noflow - $BDADDR
    +               $HCIATTACH /dev/serial1 bcm43xx 460800 noflow - $BDADDR
    
I'm not a buildroot expert but the best way seemed to move the upstream btuart download in a PRE_PATCH_HOOK so that standard buildroot way of patching can be applied.