### PR TITLE
Fixed bluetooth-bcm43xx build

### DIFF
--- a/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
+++ b/buildroot-external/package/bluetooth-bcm43xx/bluetooth-bcm43xx.mk
@@ -10,15 +10,15 @@ BLUETOOTH_BCM43XX_LICENSE_FILES = $(BR2_EXTERNAL_HASSOS_PATH)/../LICENSE
 BLUETOOTH_BCM43XX_SITE = $(BR2_EXTERNAL_HASSOS_PATH)/package/bluetooth-bcm43xx
 BLUETOOTH_BCM43XX_SITE_METHOD = local
 
-define BLUETOOTH_BCM43XX_FIRMWARE_AND_HELPERS_DOWNLOAD
+define BLUETOOTH_BCM43XX_BUILD_CMDS
 	curl -L -o $(@D)/BCM43430A1.hcd https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/fff76cb15527c435ce99a9787848eacd6288282c/broadcom/BCM43430A1.hcd
 	curl -L -o $(@D)/BCM4345C0.hcd https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/fff76cb15527c435ce99a9787848eacd6288282c/broadcom/BCM4345C0.hcd
 	curl -L -o $(@D)/btuart https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/usr/bin/btuart
 	curl -L -o $(@D)/bthelper https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/usr/bin/bthelper
 	curl -L -o $(@D)/90-pi-bluetooth.rules https://raw.githubusercontent.com/RPi-Distro/pi-bluetooth/cbdbcb66bcc5b9af05f1a9fffe2254c872bb0ace/lib/udev/rules.d/90-pi-bluetooth.rules
-endef
 
-BLUETOOTH_BCM43XX_PRE_PATCH_HOOKS += BLUETOOTH_BCM43XX_FIRMWARE_AND_HELPERS_DOWNLOAD
+	patch $(@D)/btuart $(@D)/0001-btuart-reduced-baud-rate-rpi3b.patch
+endef
 
 define BLUETOOTH_BCM43XX_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/etc/systemd/system/hassos-hardware.target.wants


### PR DESCRIPTION
Fix for #614 I've been able to build the package and test my code (didn't work :)) this is a fixed version.
I'm still not able to build the whole image but I saw the patch applied in the target file system.

Long story short I brutally added patch command after download, more details below.

> I'm not a buildroot expert but the best way seemed to move the
> upstream btuart download in a PRE_PATCH_HOOK so that standard
> buildroot way of patching can be applied.

I've been finally able to test it and the PRE_PATCH_HOOK does not work
seems it's never triggered.
I tried also th POST_RSYNC_HOOK that works but still patch is not
applied.
I think that patch is not detected (odd, patch naming seems complient)
or since source code is not downloaded buildroot thinks that patch is
not needed, couldn't sort it out.