### PR TITLE
Fix Supervisor container name reference in hassos-supervisor service

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -11,9 +11,9 @@ StartLimitBurst=5
 Type=simple
 Restart=always
 RestartSec=5s
-ExecStartPre=-/usr/bin/docker stop hassos_supervisor
+ExecStartPre=-/usr/bin/docker stop hassio_supervisor
 ExecStart=/usr/sbin/hassos-supervisor
-ExecStop=-/usr/bin/docker stop hassos_supervisor
+ExecStop=-/usr/bin/docker stop hassio_supervisor
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The systemd service for the hassos-supervisor service used incorrect references to the Supervisor container. This PR addresses that.