### PR TITLE
Bump dropbear to 2020.79

### DIFF
--- a/buildroot/package/dropbear/dropbear.mk
+++ b/buildroot/package/dropbear/dropbear.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DROPBEAR_VERSION = 2019.78
+DROPBEAR_VERSION = 2020.79
 DROPBEAR_SITE = https://matt.ucc.asn.au/dropbear/releases
 DROPBEAR_SOURCE = dropbear-$(DROPBEAR_VERSION).tar.bz2
 DROPBEAR_LICENSE = MIT, BSD-2-Clause, BSD-3-Clause


### PR DESCRIPTION
Most notable addition is support for ed25519 keys. [Full release notes here](https://github.com/mkj/dropbear/releases/tag/DROPBEAR_2020.79).