### PR TITLE
Add condition to run QEMU guest agent for QEMU hypervisor

### DIFF
--- a/buildroot-external/package/qemu-guest-agent/qemu-guest.service
+++ b/buildroot-external/package/qemu-guest-agent/qemu-guest.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=QEMU Guest Agent
 After=syslog.target network.target
-ConditionVirtualization=kvm
+ConditionVirtualization=|kvm
+ConditionVirtualization=|qemu
 
 [Service]
 ExecStart=/usr/libexec/qemu-ga -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0


### PR DESCRIPTION
The proposed changed is to run the qemu guest agent for QEMU hypervisor. QEMU hypervisor and KVM hypervisor are using the same guest agent.
systemd allow detecting the difference between the two hypervisors. The change is using OR trigger, meaning it will trigger if one of the "ConditionVirtualization" rules is true.