### PR TITLE
Add boot from USB mass storage device support for RPi 4 (#746)

### DIFF
--- a/Documentation/boards/raspberrypi.md
+++ b/Documentation/boards/raspberrypi.md
@@ -31,8 +31,13 @@ i2c-bcm2708
 
 ## USB Boot
 
-USB mass storage boot is available on Raspberry Pi 3B, 3B+, 3A+, and 2B v1.2.
-To enable USB boot, add `program_usb_boot_mode=1` into `config.txt`. Note that this **permanently** alters the one-time programmable memory of the device.
+USB mass storage boot is available on Raspberry Pi 4 (64-bit only), 3B, 3B+, 3A+, and 2B v1.2.
+
+For Raspberry 3B, 3A+ and 2B v1.2, to enable USB boot, add `program_usb_boot_mode=1` into `config.txt`. Note that this **permanently** alters the one-time programmable memory of the device.
+
+For Raspberry 4, make sure to update the bootloader to a stable release
+supporting USB mass storage boot (see
+[bcm2711_bootloader_config.md](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md#usbmassstorageboot). If no SD card is used add `sd_poll_once=on` to `dtparam` in `config.txt` (comma separated). This gets rid of `mmc0: timeout waiting for hardware interrupt` kernel errors.
 
 For more information see [RaspberryPi](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md).
 

--- a/buildroot-external/board/raspberrypi/patches/linux/0001-dt-bindings-reset-Add-a-binding-for-the-RPi-Firmware.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0001-dt-bindings-reset-Add-a-binding-for-the-RPi-Firmware.patch
@@ -1,0 +1,41 @@
+From a9f92163e6c07e5c6f57f00f4931098e0e1ee826 Mon Sep 17 00:00:00 2001
+Message-Id: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:18:37 +0200
+Subject: [PATCH 1/4] dt-bindings: reset: Add a binding for the RPi Firmware
+ reset controller
+
+The firmware running on the RPi VideoCore can be used to reset and
+initialize HW controlled by the firmware.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+[backport for RPi 4.19 kernel]
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ .../dt-bindings/reset/raspberrypi,firmware-reset.h  | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ create mode 100644 include/dt-bindings/reset/raspberrypi,firmware-reset.h
+
+diff --git a/include/dt-bindings/reset/raspberrypi,firmware-reset.h b/include/dt-bindings/reset/raspberrypi,firmware-reset.h
+new file mode 100644
+index 000000000000..1a4f4c792723
+--- /dev/null
++++ b/include/dt-bindings/reset/raspberrypi,firmware-reset.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (c) 2020 Nicolas Saenz Julienne
++ * Author: Nicolas Saenz Julienne <nsaenzjulienne@suse.com>
++ */
++
++#ifndef _DT_BINDINGS_RASPBERRYPI_FIRMWARE_RESET_H
++#define _DT_BINDINGS_RASPBERRYPI_FIRMWARE_RESET_H
++
++#define RASPBERRYPI_FIRMWARE_RESET_ID_USB	0
++#define RASPBERRYPI_FIRMWARE_RESET_NUM_IDS	1
++
++#endif
+-- 
+2.27.0
+

--- a/buildroot-external/board/raspberrypi/patches/linux/0002-ARM-dts-bcm2711-Add-firmware-usb-reset-node.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0002-ARM-dts-bcm2711-Add-firmware-usb-reset-node.patch
@@ -1,0 +1,38 @@
+From b15414057bc9a023fc865242f499807d82933e58 Mon Sep 17 00:00:00 2001
+Message-Id: <b15414057bc9a023fc865242f499807d82933e58.1595152741.git.stefan@agner.ch>
+In-Reply-To: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+References: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:18:39 +0200
+Subject: [PATCH 2/4] ARM: dts: bcm2711: Add firmware usb reset node
+
+Now that the reset driver exposing Raspberry Pi 4's firmware based USB
+reset routine is available, let's add the device tree node exposing it.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+[backport for RPi 4.19 kernel]
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index 42259dbf3919..ec0b3bb64de8 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -80,6 +80,11 @@
+ 				  "";
+ 		status = "okay";
+ 	};
++
++	reset: reset {
++		compatible = "raspberrypi,firmware-reset";
++		#reset-cells = <1>;
++	};
+ };
+ 
+ &uart0 {
+-- 
+2.27.0
+

--- a/buildroot-external/board/raspberrypi/patches/linux/0003-ARM-dts-bcm2711-Add-reset-controller-to-xHCI-node.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0003-ARM-dts-bcm2711-Add-reset-controller-to-xHCI-node.patch
@@ -1,0 +1,58 @@
+From 08558575c0f3d1437994590ad418d6c2cf18d96b Mon Sep 17 00:00:00 2001
+Message-Id: <08558575c0f3d1437994590ad418d6c2cf18d96b.1595152741.git.stefan@agner.ch>
+In-Reply-To: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+References: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:18:40 +0200
+Subject: [PATCH 3/4] ARM: dts: bcm2711: Add reset controller to xHCI node
+
+The chip is hardwired to the board's PCIe bus and needs to be properly
+setup trough a firmware routine after a PCI fundamental reset. Pass the
+reset controller phandle that takes care of triggering the
+initialization to the relevant PCI device.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+[backport for RPi 4.19 kernel]
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+index ec0b3bb64de8..2c6aa1933600 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+@@ -4,6 +4,8 @@
+ #include "bcm2711-rpi.dtsi"
+ #include "bcm283x-rpi-csi1-2lane.dtsi"
+ 
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
++
+ / {
+ 	compatible = "raspberrypi,4-model-b", "brcm,bcm2711";
+ 	model = "Raspberry Pi 4 Model B";
+@@ -87,6 +89,21 @@
+ 	};
+ };
+ 
++&pcie_0 {
++	pci@1,0 {
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		reg = <0 0 0 0 0>;
++
++		usb@1,0 {
++			reg = <0x10000 0 0 0 0>;
++			resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
++		};
++	};
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pins &bt_pins>;
+-- 
+2.27.0
+

--- a/buildroot-external/board/raspberrypi/patches/linux/0004-ARM-dts-bcm2838-add-upstream-property-to-enable-PCIe.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0004-ARM-dts-bcm2838-add-upstream-property-to-enable-PCIe.patch
@@ -1,0 +1,44 @@
+From dcfb930f9c271ad303a888ce94227d2d78974e39 Mon Sep 17 00:00:00 2001
+Message-Id: <dcfb930f9c271ad303a888ce94227d2d78974e39.1595152741.git.stefan@agner.ch>
+In-Reply-To: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+References: <a9f92163e6c07e5c6f57f00f4931098e0e1ee826.1595152741.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Sun, 19 Jul 2020 11:49:45 +0200
+Subject: [PATCH 4/4] ARM: dts: bcm2838: add upstream property to enable PCIe
+ spread-spectrum
+
+Add the upstream device tree property brcm,enable-ssc to enable
+spread-spectrum for PCIe. This is used by the upstream U-Boot.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/boot/dts/bcm2838.dtsi | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/boot/dts/bcm2838.dtsi b/arch/arm/boot/dts/bcm2838.dtsi
+index 36d250d7053b..d6cc876bc720 100644
+--- a/arch/arm/boot/dts/bcm2838.dtsi
++++ b/arch/arm/boot/dts/bcm2838.dtsi
+@@ -353,11 +353,14 @@
+ 			 */
+ 			ranges = <0x02000000 0x0 0xf8000000  0x6 0x00000000
+ 				  0x0 0x04000000>;
+-			/* Map inbound accesses from pci:0x0_00000000..ffffffff
+-			 * to scb:0x0_00000000-ffffffff
+-			 */
+-			dma-ranges = <0x02000000 0x0 0x00000000  0x0 0x00000000
+-				      0x1 0x00000000>;
++                        /*
++                         * The wrapper around the PCIe block has a bug
++                         * preventing it from accessing beyond the first 3GB of
++                         * memory.
++                         */
++                        dma-ranges = <0x02000000 0x0 0x00000000 0x0 0x00000000
++                                      0x0 0xc0000000>;
++			brcm,enable-ssc;
+ 			status = "okay";
+ 		};
+ 
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0002-usb-xhci-Add-missing-cache-flush-in-the-scratchpad-a.patch
+++ b/buildroot-external/patches/uboot/2020.07/0002-usb-xhci-Add-missing-cache-flush-in-the-scratchpad-a.patch
@@ -1,0 +1,41 @@
+From b39cd5ba642ddba46268e8d873b952604844c047 Mon Sep 17 00:00:00 2001
+Message-Id: <b39cd5ba642ddba46268e8d873b952604844c047.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Date: Mon, 25 May 2020 13:39:51 +0200
+Subject: [PATCH 02/20] usb: xhci: Add missing cache flush in the scratchpad
+ array initialization
+
+In current code there is no cache flush after initializing the scratchpad
+buffer array with the scratchpad buffer pointers. This leads to a failure
+of the "slot enable" command on the rpi4 board (Broadcom STB PCIe
+controller + VL805 USB hub) - the very first TRB transfer on the command
+ring fails and there is a timeout while waiting for the command completion
+event. After adding the missing cache flush everything seems to be working
+as expected.
+
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Bin Meng <bmeng.cn@gmail.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ drivers/usb/host/xhci-mem.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/usb/host/xhci-mem.c b/drivers/usb/host/xhci-mem.c
+index 2d968aafb0..f446520528 100644
+--- a/drivers/usb/host/xhci-mem.c
++++ b/drivers/usb/host/xhci-mem.c
+@@ -395,6 +395,9 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
+ 		scratchpad->sp_array[i] = cpu_to_le64(ptr);
+ 	}
+ 
++	xhci_flush_cache((uintptr_t)scratchpad->sp_array,
++			 sizeof(u64) * num_sp);
++
+ 	return 0;
+ 
+ fail_sp3:
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0003-usb-xhci-Use-only-32-bit-accesses-in-xhci_writeq-xhc.patch
+++ b/buildroot-external/patches/uboot/2020.07/0003-usb-xhci-Use-only-32-bit-accesses-in-xhci_writeq-xhc.patch
@@ -1,0 +1,69 @@
+From 71343be3dd8d7f04cea781c8369aa77a36ae7123 Mon Sep 17 00:00:00 2001
+Message-Id: <71343be3dd8d7f04cea781c8369aa77a36ae7123.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Date: Mon, 25 May 2020 13:39:52 +0200
+Subject: [PATCH 03/20] usb: xhci: Use only 32-bit accesses in
+ xhci_writeq/xhci_readq
+
+There might be hardware configurations where 64-bit data accesses
+to XHCI registers are not supported properly.  This patch removes
+the readq/writeq so always two 32-bit accesses are used to read/write
+64-bit XHCI registers, similarly as it is done in Linux kernel.
+
+This patch fixes operation of the XHCI controller on RPI4 Broadcom
+BCM2711 SoC based board, where the VL805 USB XHCI controller is
+connected to the PCIe Root Complex, which is attached to the system
+through the SCB bridge.
+
+Even though the architecture is 64-bit the PCIe BAR is 32-bit and likely
+the 64-bit wide register accesses initiated by the CPU are not properly
+translated to a sequence of 32-bit PCIe accesses.
+xhci_readq(), for example, always returns same value in upper and lower
+32-bits, e.g. 0xabcd1234abcd1234 instead of 0x00000000abcd1234.
+
+Cc: Sergey Temerkhanov <s.temerkhanov@gmail.com>
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Bin Meng <bmeng.cn@gmail.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ include/usb/xhci.h | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/include/usb/xhci.h b/include/usb/xhci.h
+index 20e4a21066..1170c0ac69 100644
+--- a/include/usb/xhci.h
++++ b/include/usb/xhci.h
+@@ -1114,28 +1114,20 @@ static inline void xhci_writel(uint32_t volatile *regs, const unsigned int val)
+  */
+ static inline u64 xhci_readq(__le64 volatile *regs)
+ {
+-#if BITS_PER_LONG == 64
+-	return readq(regs);
+-#else
+ 	__u32 *ptr = (__u32 *)regs;
+ 	u64 val_lo = readl(ptr);
+ 	u64 val_hi = readl(ptr + 1);
+ 	return val_lo + (val_hi << 32);
+-#endif
+ }
+ 
+ static inline void xhci_writeq(__le64 volatile *regs, const u64 val)
+ {
+-#if BITS_PER_LONG == 64
+-	writeq(val, regs);
+-#else
+ 	__u32 *ptr = (__u32 *)regs;
+ 	u32 val_lo = lower_32_bits(val);
+ 	/* FIXME */
+ 	u32 val_hi = upper_32_bits(val);
+ 	writel(val_lo, ptr);
+ 	writel(val_hi, ptr + 1);
+-#endif
+ }
+ 
+ int xhci_hcd_init(int index, struct xhci_hccr **ret_hccr,
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0004-pci-Move-some-PCIe-register-offset-definitions-to-a-.patch
+++ b/buildroot-external/patches/uboot/2020.07/0004-pci-Move-some-PCIe-register-offset-definitions-to-a-.patch
@@ -1,0 +1,85 @@
+From 82024c95e4d00b555f93d93b9f706c4d995ab302 Mon Sep 17 00:00:00 2001
+Message-Id: <82024c95e4d00b555f93d93b9f706c4d995ab302.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Date: Mon, 25 May 2020 13:39:53 +0200
+Subject: [PATCH 04/20] pci: Move some PCIe register offset definitions to a
+ common header
+
+Some PCI Express register offsets are currently defined in multiple
+drivers, move them to a common header to avoid re-definitions and
+as a pre-requisite for adding new PCIe driver.
+While at it replace some spaces with tabs.
+
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Bin Meng <bmeng.cn@gmail.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ drivers/pci/pci-rcar-gen3.c   |  8 --------
+ drivers/pci/pcie_intel_fpga.c |  3 ---
+ include/pci.h                 | 13 +++++++++++--
+ 3 files changed, 11 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/pci/pci-rcar-gen3.c b/drivers/pci/pci-rcar-gen3.c
+index df7b37a592..1f51854ccc 100644
+--- a/drivers/pci/pci-rcar-gen3.c
++++ b/drivers/pci/pci-rcar-gen3.c
+@@ -118,14 +118,6 @@
+ #define RCAR_PCI_MAX_RESOURCES	4
+ #define MAX_NR_INBOUND_MAPS	6
+ 
+-#define PCI_EXP_FLAGS		2		/* Capabilities register */
+-#define PCI_EXP_FLAGS_TYPE	0x00f0		/* Device/Port type */
+-#define PCI_EXP_TYPE_ROOT_PORT	0x4		/* Root Port */
+-#define PCI_EXP_LNKCAP		12		/* Link Capabilities */
+-#define PCI_EXP_LNKCAP_DLLLARC	0x00100000	/* Data Link Layer Link Active Reporting Capable */
+-#define PCI_EXP_SLTCAP		20		/* Slot Capabilities */
+-#define PCI_EXP_SLTCAP_PSN	0xfff80000	/* Physical Slot Number */
+-
+ enum {
+ 	RCAR_PCI_ACCESS_READ,
+ 	RCAR_PCI_ACCESS_WRITE,
+diff --git a/drivers/pci/pcie_intel_fpga.c b/drivers/pci/pcie_intel_fpga.c
+index aa1903e547..9f102c64c6 100644
+--- a/drivers/pci/pcie_intel_fpga.c
++++ b/drivers/pci/pcie_intel_fpga.c
+@@ -67,9 +67,6 @@
+ #define IS_ROOT_PORT(pcie, bdf)				\
+ 		((PCI_BUS(bdf) == pcie->first_busno) ? true : false)
+ 
+-#define PCI_EXP_LNKSTA		18	/* Link Status */
+-#define PCI_EXP_LNKSTA_DLLLA	0x2000	/* Data Link Layer Link Active */
+-
+ /**
+  * struct intel_fpga_pcie - Intel FPGA PCIe controller state
+  * @bus: Pointer to the PCI bus
+diff --git a/include/pci.h b/include/pci.h
+index 19c9244b94..9cd8564436 100644
+--- a/include/pci.h
++++ b/include/pci.h
+@@ -471,10 +471,19 @@
+ #define  PCI_EA_FIELD_MASK	0xfffffffc	/* For Base & Max Offset */
+ 
+ /* PCI Express capabilities */
++#define PCI_EXP_FLAGS		2	/* Capabilities register */
++#define  PCI_EXP_FLAGS_TYPE	0x00f0	/* Device/Port type */
++#define  PCI_EXP_TYPE_ROOT_PORT 0x4	/* Root Port */
+ #define PCI_EXP_DEVCAP		4	/* Device capabilities */
+-#define  PCI_EXP_DEVCAP_FLR     0x10000000 /* Function Level Reset */
++#define  PCI_EXP_DEVCAP_FLR	0x10000000 /* Function Level Reset */
+ #define PCI_EXP_DEVCTL		8	/* Device Control */
+-#define  PCI_EXP_DEVCTL_BCR_FLR 0x8000  /* Bridge Configuration Retry / FLR */
++#define  PCI_EXP_DEVCTL_BCR_FLR	0x8000  /* Bridge Configuration Retry / FLR */
++#define PCI_EXP_LNKCAP		12	/* Link Capabilities */
++#define  PCI_EXP_LNKCAP_DLLLARC	0x00100000 /* Data Link Layer Link Active Reporting Capable */
++#define PCI_EXP_LNKSTA		18	/* Link Status */
++#define  PCI_EXP_LNKSTA_DLLLA	0x2000	/* Data Link Layer Link Active */
++#define PCI_EXP_SLTCAP		20	/* Slot Capabilities */
++#define  PCI_EXP_SLTCAP_PSN	0xfff80000 /* Physical Slot Number */
+ 
+ /* Include the ID list */
+ 
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0005-rpi4-shorten-a-mapping-for-the-DRAM.patch
+++ b/buildroot-external/patches/uboot/2020.07/0005-rpi4-shorten-a-mapping-for-the-DRAM.patch
@@ -1,0 +1,33 @@
+From 5dddca0c2ca5de72b74a5fca0d3ea67251add760 Mon Sep 17 00:00:00 2001
+Message-Id: <5dddca0c2ca5de72b74a5fca0d3ea67251add760.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Mon, 25 May 2020 13:39:54 +0200
+Subject: [PATCH 05/20] rpi4: shorten a mapping for the DRAM
+
+Remove the overlap between DRAM and device's IO area.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ arch/arm/mach-bcm283x/init.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-bcm283x/init.c b/arch/arm/mach-bcm283x/init.c
+index f4d00d892d..f9a5209480 100644
+--- a/arch/arm/mach-bcm283x/init.c
++++ b/arch/arm/mach-bcm283x/init.c
+@@ -39,7 +39,7 @@ static struct mm_region bcm2711_mem_map[] = {
+ 	{
+ 		.virt = 0x00000000UL,
+ 		.phys = 0x00000000UL,
+-		.size = 0xfe000000UL,
++		.size = 0xfc000000UL,
+ 		.attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+ 			 PTE_BLOCK_INNER_SHARE
+ 	}, {
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0006-rpi4-add-a-mapping-for-the-PCIe-XHCI-controller-MMIO.patch
+++ b/buildroot-external/patches/uboot/2020.07/0006-rpi4-add-a-mapping-for-the-PCIe-XHCI-controller-MMIO.patch
@@ -1,0 +1,76 @@
+From a326f58940f16b2dc3740fd9e87eb485da939ae5 Mon Sep 17 00:00:00 2001
+Message-Id: <a326f58940f16b2dc3740fd9e87eb485da939ae5.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Mon, 25 May 2020 13:39:55 +0200
+Subject: [PATCH 06/20] rpi4: add a mapping for the PCIe XHCI controller MMIO
+ registers (ARM 64bit)
+
+Create a non-cacheable mapping for the 0x600000000 physical memory region,
+where MMIO registers for the PCIe XHCI controller are instantiated by the
+PCIe bridge.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ arch/arm/mach-bcm283x/init.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-bcm283x/init.c b/arch/arm/mach-bcm283x/init.c
+index f9a5209480..cf4c5b245d 100644
+--- a/arch/arm/mach-bcm283x/init.c
++++ b/arch/arm/mach-bcm283x/init.c
+@@ -12,10 +12,15 @@
+ #include <dm/device.h>
+ #include <fdt_support.h>
+ 
++#define BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS	0x600000000UL
++#define BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE	0x800000UL
++
+ #ifdef CONFIG_ARM64
+ #include <asm/armv8/mmu.h>
+ 
+-static struct mm_region bcm283x_mem_map[] = {
++#define MEM_MAP_MAX_ENTRIES (4)
++
++static struct mm_region bcm283x_mem_map[MEM_MAP_MAX_ENTRIES] = {
+ 	{
+ 		.virt = 0x00000000UL,
+ 		.phys = 0x00000000UL,
+@@ -35,7 +40,7 @@ static struct mm_region bcm283x_mem_map[] = {
+ 	}
+ };
+ 
+-static struct mm_region bcm2711_mem_map[] = {
++static struct mm_region bcm2711_mem_map[MEM_MAP_MAX_ENTRIES] = {
+ 	{
+ 		.virt = 0x00000000UL,
+ 		.phys = 0x00000000UL,
+@@ -49,6 +54,13 @@ static struct mm_region bcm2711_mem_map[] = {
+ 		.attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
+ 			 PTE_BLOCK_NON_SHARE |
+ 			 PTE_BLOCK_PXN | PTE_BLOCK_UXN
++	}, {
++		.virt = BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS,
++		.phys = BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS,
++		.size = BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE,
++		.attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
++			 PTE_BLOCK_NON_SHARE |
++			 PTE_BLOCK_PXN | PTE_BLOCK_UXN
+ 	}, {
+ 		/* List terminator */
+ 		0,
+@@ -72,7 +84,7 @@ static void _rpi_update_mem_map(struct mm_region *pd)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < 2; i++) {
++	for (i = 0; i < MEM_MAP_MAX_ENTRIES; i++) {
+ 		mem_map[i].virt = pd[i].virt;
+ 		mem_map[i].phys = pd[i].phys;
+ 		mem_map[i].size = pd[i].size;
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0007-linux-bitfield.h-Add-primitives-for-manipulating-bit.patch
+++ b/buildroot-external/patches/uboot/2020.07/0007-linux-bitfield.h-Add-primitives-for-manipulating-bit.patch
@@ -1,0 +1,85 @@
+From 9c761488487ce27517e2a9e425f4ed0777708c53 Mon Sep 17 00:00:00 2001
+Message-Id: <9c761488487ce27517e2a9e425f4ed0777708c53.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 25 May 2020 13:39:56 +0200
+Subject: [PATCH 07/20] linux/bitfield.h: Add primitives for manipulating
+ bitfields both in host- and fixed-endian
+
+Imports Al Viro's original Linux commit 00b0c9b82663a, which contains
+an in depth explanation and two fixes from Johannes Berg:
+ e7d4a95da86e0 "bitfield: fix *_encode_bits()",
+ 37a3862e12382 "bitfield: add u8 helpers".
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+[s.nawrocki: added empty lines between functions and macros]
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+---
+ include/linux/bitfield.h | 52 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 52 insertions(+)
+
+diff --git a/include/linux/bitfield.h b/include/linux/bitfield.h
+index 8b9d6fff00..7ad8b088ed 100644
+--- a/include/linux/bitfield.h
++++ b/include/linux/bitfield.h
+@@ -103,4 +103,56 @@
+ 		(typeof(_mask))(((_reg) & (_mask)) >> __bf_shf(_mask));	\
+ 	})
+ 
++extern void __compiletime_error("value doesn't fit into mask")
++__field_overflow(void);
++extern void __compiletime_error("bad bitfield mask")
++__bad_mask(void);
++
++static __always_inline u64 field_multiplier(u64 field)
++{
++	if ((field | (field - 1)) & ((field | (field - 1)) + 1))
++		__bad_mask();
++	return field & -field;
++}
++
++static __always_inline u64 field_mask(u64 field)
++{
++	return field / field_multiplier(field);
++}
++
++#define ____MAKE_OP(type, base, to, from)				\
++static __always_inline __##type type##_encode_bits(base v, base field)	\
++{									\
++	if (__builtin_constant_p(v) && (v & ~field_mask(field)))	\
++		__field_overflow();					\
++	return to((v & field_mask(field)) * field_multiplier(field));	\
++}									\
++static __always_inline __##type type##_replace_bits(__##type old,	\
++					base val, base field)		\
++{									\
++	return (old & ~to(field)) | type##_encode_bits(val, field);	\
++}									\
++static __always_inline void type##p_replace_bits(__##type * p,		\
++					base val, base field)		\
++{									\
++	*p = (*p & ~to(field)) | type##_encode_bits(val, field);	\
++}									\
++static __always_inline base type##_get_bits(__##type v, base field)	\
++{									\
++	return (from(v) & field) / field_multiplier(field);		\
++}
++
++#define __MAKE_OP(size)							\
++	____MAKE_OP(le##size, u##size, cpu_to_le##size, le##size##_to_cpu) \
++	____MAKE_OP(be##size, u##size, cpu_to_be##size, be##size##_to_cpu) \
++	____MAKE_OP(u##size, u##size, ,)
++
++____MAKE_OP(u8, u8, ,)
++__MAKE_OP(16)
++__MAKE_OP(32)
++__MAKE_OP(64)
++
++#undef __MAKE_OP
++#undef ____MAKE_OP
++
+ #endif
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0008-pci-Add-some-PCI-Express-capability-register-offset-.patch
+++ b/buildroot-external/patches/uboot/2020.07/0008-pci-Add-some-PCI-Express-capability-register-offset-.patch
@@ -1,0 +1,47 @@
+From 376bd33efa69abfc6102eb5a56b700c0f1981cf4 Mon Sep 17 00:00:00 2001
+Message-Id: <376bd33efa69abfc6102eb5a56b700c0f1981cf4.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Date: Mon, 25 May 2020 13:39:57 +0200
+Subject: [PATCH 08/20] pci: Add some PCI Express capability register offset
+ definitions
+
+Add PCI Express capability definitions required by the Broadcom
+STB PCIe controller driver.
+
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Reviewed-by: Bin Meng <bmeng.cn@gmail.com>
+Reviewed-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ include/pci.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/include/pci.h b/include/pci.h
+index 9cd8564436..281f353916 100644
+--- a/include/pci.h
++++ b/include/pci.h
+@@ -479,11 +479,20 @@
+ #define PCI_EXP_DEVCTL		8	/* Device Control */
+ #define  PCI_EXP_DEVCTL_BCR_FLR	0x8000  /* Bridge Configuration Retry / FLR */
+ #define PCI_EXP_LNKCAP		12	/* Link Capabilities */
++#define  PCI_EXP_LNKCAP_SLS	0x0000000f /* Supported Link Speeds */
++#define  PCI_EXP_LNKCAP_MLW	0x000003f0 /* Maximum Link Width */
+ #define  PCI_EXP_LNKCAP_DLLLARC	0x00100000 /* Data Link Layer Link Active Reporting Capable */
+ #define PCI_EXP_LNKSTA		18	/* Link Status */
++#define  PCI_EXP_LNKSTA_CLS	0x000f	/* Current Link Speed */
++#define  PCI_EXP_LNKSTA_CLS_2_5GB 0x0001 /* Current Link Speed 2.5GT/s */
++#define  PCI_EXP_LNKSTA_CLS_5_0GB 0x0002 /* Current Link Speed 5.0GT/s */
++#define  PCI_EXP_LNKSTA_CLS_8_0GB 0x0003 /* Current Link Speed 8.0GT/s */
++#define  PCI_EXP_LNKSTA_NLW	0x03f0	/* Negotiated Link Width */
++#define  PCI_EXP_LNKSTA_NLW_SHIFT 4	/* start of NLW mask in link status */
+ #define  PCI_EXP_LNKSTA_DLLLA	0x2000	/* Data Link Layer Link Active */
+ #define PCI_EXP_SLTCAP		20	/* Slot Capabilities */
+ #define  PCI_EXP_SLTCAP_PSN	0xfff80000 /* Physical Slot Number */
++#define PCI_EXP_LNKCTL2		48	/* Link Control 2 */
+ 
+ /* Include the ID list */
+ 
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0009-pci-Add-driver-for-Broadcom-BCM2711-SoC-PCIe-control.patch
+++ b/buildroot-external/patches/uboot/2020.07/0009-pci-Add-driver-for-Broadcom-BCM2711-SoC-PCIe-control.patch
@@ -1,0 +1,686 @@
+From 21a9b72b4a28398c9511f3d9e3c1adc1439a8870 Mon Sep 17 00:00:00 2001
+Message-Id: <21a9b72b4a28398c9511f3d9e3c1adc1439a8870.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Sylwester Nawrocki <s.nawrocki@samsung.com>
+Date: Mon, 25 May 2020 13:39:58 +0200
+Subject: [PATCH 09/20] pci: Add driver for Broadcom BCM2711 SoC PCIe
+ controller
+
+This patch adds basic driver PCI Express controller found on Broadcom
+set-top-box SoCs, e.g. BCM2711.
+The code is based on Linux upstream driver (pcie-brcmstb.c) with MSI
+handling removed. The inbound access memory region is not currently
+parsed from dma-ranges DT property and a fixed 3GB region is used.
+
+The patch has been tested on RPI4 board, i.e. on BCM2711 SoC with VL805
+USB Host Controller.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+---
+ drivers/pci/Kconfig        |   9 +
+ drivers/pci/Makefile       |   1 +
+ drivers/pci/pcie_brcmstb.c | 623 +++++++++++++++++++++++++++++++++++++
+ 3 files changed, 633 insertions(+)
+ create mode 100644 drivers/pci/pcie_brcmstb.c
+
+diff --git a/drivers/pci/Kconfig b/drivers/pci/Kconfig
+index 6d8c22aacf..7e1e51d9ea 100644
+--- a/drivers/pci/Kconfig
++++ b/drivers/pci/Kconfig
+@@ -205,4 +205,13 @@ config PCIE_ROCKCHIP
+ 	  Say Y here if you want to enable PCIe controller support on
+ 	  Rockchip SoCs.
+ 
++config PCI_BRCMSTB
++	bool "Broadcom STB PCIe controller"
++	depends on DM_PCI
++	depends on ARCH_BCM283X
++	help
++	  Say Y here if you want to enable support for PCIe controller
++	  on Broadcom set-top-box (STB) SoCs.
++	  This driver currently supports only BCM2711 SoC and RC mode
++	  of the controller.
+ endif
+diff --git a/drivers/pci/Makefile b/drivers/pci/Makefile
+index 955351c5c2..29092916a6 100644
+--- a/drivers/pci/Makefile
++++ b/drivers/pci/Makefile
+@@ -44,3 +44,4 @@ obj-$(CONFIG_PCIE_INTEL_FPGA) += pcie_intel_fpga.o
+ obj-$(CONFIG_PCI_KEYSTONE) += pcie_dw_ti.o
+ obj-$(CONFIG_PCIE_MEDIATEK) += pcie_mediatek.o
+ obj-$(CONFIG_PCIE_ROCKCHIP) += pcie_rockchip.o pcie_rockchip_phy.o
++obj-$(CONFIG_PCI_BRCMSTB) += pcie_brcmstb.o
+diff --git a/drivers/pci/pcie_brcmstb.c b/drivers/pci/pcie_brcmstb.c
+new file mode 100644
+index 0000000000..dade79e9c8
+--- /dev/null
++++ b/drivers/pci/pcie_brcmstb.c
+@@ -0,0 +1,623 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Broadcom STB PCIe controller driver
++ *
++ * Copyright (C) 2020 Samsung Electronics Co., Ltd.
++ *
++ * Based on upstream Linux kernel driver:
++ * drivers/pci/controller/pcie-brcmstb.c
++ * Copyright (C) 2009 - 2017 Broadcom
++ *
++ * Based driver by Nicolas Saenz Julienne
++ * Copyright (C) 2020 Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
++ */
++
++#include <common.h>
++#include <errno.h>
++#include <dm.h>
++#include <dm/ofnode.h>
++#include <pci.h>
++#include <asm/io.h>
++#include <linux/bitfield.h>
++#include <linux/log2.h>
++#include <linux/iopoll.h>
++
++/* Offset of the mandatory PCIe capability config registers */
++#define BRCM_PCIE_CAP_REGS				0x00ac
++
++/* The PCIe controller register offsets */
++#define PCIE_RC_CFG_VENDOR_SPECIFIC_REG1		0x0188
++#define  VENDOR_SPECIFIC_REG1_ENDIAN_MODE_BAR2_MASK	0xc
++#define  VENDOR_SPECIFIC_REG1_LITTLE_ENDIAN		0x0
++
++#define PCIE_RC_CFG_PRIV1_ID_VAL3			0x043c
++#define  CFG_PRIV1_ID_VAL3_CLASS_CODE_MASK		0xffffff
++
++#define PCIE_RC_DL_MDIO_ADDR				0x1100
++#define PCIE_RC_DL_MDIO_WR_DATA				0x1104
++#define PCIE_RC_DL_MDIO_RD_DATA				0x1108
++
++#define PCIE_MISC_MISC_CTRL				0x4008
++#define  MISC_CTRL_SCB_ACCESS_EN_MASK			0x1000
++#define  MISC_CTRL_CFG_READ_UR_MODE_MASK		0x2000
++#define  MISC_CTRL_MAX_BURST_SIZE_MASK			0x300000
++#define  MISC_CTRL_MAX_BURST_SIZE_128			0x0
++#define  MISC_CTRL_SCB0_SIZE_MASK			0xf8000000
++
++#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO		0x400c
++#define PCIE_MEM_WIN0_LO(win)	\
++		PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO + ((win) * 4)
++
++#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI		0x4010
++#define PCIE_MEM_WIN0_HI(win)	\
++		PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI + ((win) * 4)
++
++#define PCIE_MISC_RC_BAR1_CONFIG_LO			0x402c
++#define  RC_BAR1_CONFIG_LO_SIZE_MASK			0x1f
++
++#define PCIE_MISC_RC_BAR2_CONFIG_LO			0x4034
++#define  RC_BAR2_CONFIG_LO_SIZE_MASK			0x1f
++#define PCIE_MISC_RC_BAR2_CONFIG_HI			0x4038
++
++#define PCIE_MISC_RC_BAR3_CONFIG_LO			0x403c
++#define  RC_BAR3_CONFIG_LO_SIZE_MASK			0x1f
++
++#define PCIE_MISC_PCIE_STATUS				0x4068
++#define  STATUS_PCIE_PORT_MASK				0x80
++#define  STATUS_PCIE_PORT_SHIFT				7
++#define  STATUS_PCIE_DL_ACTIVE_MASK			0x20
++#define  STATUS_PCIE_DL_ACTIVE_SHIFT			5
++#define  STATUS_PCIE_PHYLINKUP_MASK			0x10
++#define  STATUS_PCIE_PHYLINKUP_SHIFT			4
++
++#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT	0x4070
++#define  MEM_WIN0_BASE_LIMIT_LIMIT_MASK			0xfff00000
++#define  MEM_WIN0_BASE_LIMIT_BASE_MASK			0xfff0
++#define  MEM_WIN0_BASE_LIMIT_BASE_HI_SHIFT		12
++#define PCIE_MEM_WIN0_BASE_LIMIT(win)	\
++	 PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT + ((win) * 4)
++
++#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI		0x4080
++#define  MEM_WIN0_BASE_HI_BASE_MASK			0xff
++#define PCIE_MEM_WIN0_BASE_HI(win)	\
++	 PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI + ((win) * 8)
++
++#define PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI		0x4084
++#define  PCIE_MEM_WIN0_LIMIT_HI_LIMIT_MASK		0xff
++#define PCIE_MEM_WIN0_LIMIT_HI(win)	\
++	 PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI + ((win) * 8)
++
++#define PCIE_MISC_HARD_PCIE_HARD_DEBUG			0x4204
++#define  PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE_MASK	0x2
++#define  PCIE_HARD_DEBUG_SERDES_IDDQ_MASK		0x08000000
++
++#define PCIE_MSI_INTR2_CLR				0x4508
++#define PCIE_MSI_INTR2_MASK_SET				0x4510
++
++#define PCIE_EXT_CFG_DATA				0x8000
++
++#define PCIE_EXT_CFG_INDEX				0x9000
++#define  PCIE_EXT_BUSNUM_SHIFT				20
++#define  PCIE_EXT_SLOT_SHIFT				15
++#define  PCIE_EXT_FUNC_SHIFT				12
++
++#define PCIE_RGR1_SW_INIT_1				0x9210
++#define  RGR1_SW_INIT_1_PERST_MASK			0x1
++#define  RGR1_SW_INIT_1_INIT_MASK			0x2
++
++/* PCIe parameters */
++#define BRCM_NUM_PCIE_OUT_WINS				4
++
++/* MDIO registers */
++#define MDIO_PORT0					0x0
++#define MDIO_DATA_MASK					0x7fffffff
++#define MDIO_DATA_SHIFT					0
++#define MDIO_PORT_MASK					0xf0000
++#define MDIO_PORT_SHIFT					16
++#define MDIO_REGAD_MASK					0xffff
++#define MDIO_REGAD_SHIFT				0
++#define MDIO_CMD_MASK					0xfff00000
++#define MDIO_CMD_SHIFT					20
++#define MDIO_CMD_READ					0x1
++#define MDIO_CMD_WRITE					0x0
++#define MDIO_DATA_DONE_MASK				0x80000000
++#define SSC_REGS_ADDR					0x1100
++#define SET_ADDR_OFFSET					0x1f
++#define SSC_CNTL_OFFSET					0x2
++#define SSC_CNTL_OVRD_EN_MASK				0x8000
++#define SSC_CNTL_OVRD_VAL_MASK				0x4000
++#define SSC_STATUS_OFFSET				0x1
++#define SSC_STATUS_SSC_MASK				0x400
++#define SSC_STATUS_SSC_SHIFT				10
++#define SSC_STATUS_PLL_LOCK_MASK			0x800
++#define SSC_STATUS_PLL_LOCK_SHIFT			11
++
++/**
++ * struct brcm_pcie - the PCIe controller state
++ * @base: Base address of memory mapped IO registers of the controller
++ * @gen: Non-zero value indicates limitation of the PCIe controller operation
++ *       to a specific generation (1, 2 or 3)
++ * @ssc: true indicates active Spread Spectrum Clocking operation
++ */
++struct brcm_pcie {
++	void __iomem		*base;
++
++	int			gen;
++	bool			ssc;
++};
++
++/**
++ * brcm_pcie_encode_ibar_size() - Encode the inbound "BAR" region size
++ * @size: The inbound region size
++ *
++ * This function converts size of the inbound "BAR" region to the non-linear
++ * values of the PCIE_MISC_RC_BAR[123]_CONFIG_LO register SIZE field.
++ *
++ * Return: The encoded inbound region size
++ */
++static int brcm_pcie_encode_ibar_size(u64 size)
++{
++	int log2_in = ilog2(size);
++
++	if (log2_in >= 12 && log2_in <= 15)
++		/* Covers 4KB to 32KB (inclusive) */
++		return (log2_in - 12) + 0x1c;
++	else if (log2_in >= 16 && log2_in <= 37)
++		/* Covers 64KB to 32GB, (inclusive) */
++		return log2_in - 15;
++
++	/* Something is awry so disable */
++	return 0;
++}
++
++/**
++ * brcm_pcie_rc_mode() - Check if PCIe controller is in RC mode
++ * @pcie: Pointer to the PCIe controller state
++ *
++ * The controller is capable of serving in both RC and EP roles.
++ *
++ * Return: true for RC mode, false for EP mode.
++ */
++static bool brcm_pcie_rc_mode(struct brcm_pcie *pcie)
++{
++	u32 val;
++
++	val = readl(pcie->base + PCIE_MISC_PCIE_STATUS);
++
++	return (val & STATUS_PCIE_PORT_MASK) >> STATUS_PCIE_PORT_SHIFT;
++}
++
++/**
++ * brcm_pcie_link_up() - Check whether the PCIe link is up
++ * @pcie: Pointer to the PCIe controller state
++ *
++ * Return: true if the link is up, false otherwise.
++ */
++static bool brcm_pcie_link_up(struct brcm_pcie *pcie)
++{
++	u32 val, dla, plu;
++
++	val = readl(pcie->base + PCIE_MISC_PCIE_STATUS);
++	dla = (val & STATUS_PCIE_DL_ACTIVE_MASK) >> STATUS_PCIE_DL_ACTIVE_SHIFT;
++	plu = (val & STATUS_PCIE_PHYLINKUP_MASK) >> STATUS_PCIE_PHYLINKUP_SHIFT;
++
++	return dla && plu;
++}
++
++static int brcm_pcie_config_address(const struct udevice *dev, pci_dev_t bdf,
++				    uint offset, void **paddress)
++{
++	struct brcm_pcie *pcie = dev_get_priv(dev);
++	unsigned int pci_bus = PCI_BUS(bdf);
++	unsigned int pci_dev = PCI_DEV(bdf);
++	unsigned int pci_func = PCI_FUNC(bdf);
++	int idx;
++
++	/*
++	 * Busses 0 (host PCIe bridge) and 1 (its immediate child)
++	 * are limited to a single device each
++	 */
++	if (pci_bus < 2 && pci_dev > 0)
++		return -EINVAL;
++
++	/* Accesses to the RC go right to the RC registers */
++	if (pci_bus == 0) {
++		*paddress = pcie->base + offset;
++		return 0;
++	}
++
++	/* For devices, write to the config space index register */
++	idx = (pci_bus << PCIE_EXT_BUSNUM_SHIFT)
++		| (pci_dev << PCIE_EXT_SLOT_SHIFT)
++		| (pci_func << PCIE_EXT_FUNC_SHIFT);
++
++	writel(idx, pcie->base + PCIE_EXT_CFG_INDEX);
++	*paddress = pcie->base + PCIE_EXT_CFG_DATA + offset;
++
++	return 0;
++}
++
++static int brcm_pcie_read_config(const struct udevice *bus, pci_dev_t bdf,
++				 uint offset, ulong *valuep,
++				 enum pci_size_t size)
++{
++	return pci_generic_mmap_read_config(bus, brcm_pcie_config_address,
++					    bdf, offset, valuep, size);
++}
++
++static int brcm_pcie_write_config(struct udevice *bus, pci_dev_t bdf,
++				  uint offset, ulong value,
++				  enum pci_size_t size)
++{
++	return pci_generic_mmap_write_config(bus, brcm_pcie_config_address,
++					     bdf, offset, value, size);
++}
++
++static const char *link_speed_to_str(unsigned int cls)
++{
++	switch (cls) {
++	case PCI_EXP_LNKSTA_CLS_2_5GB: return "2.5";
++	case PCI_EXP_LNKSTA_CLS_5_0GB: return "5.0";
++	case PCI_EXP_LNKSTA_CLS_8_0GB: return "8.0";
++	default:
++		break;
++	}
++
++	return "??";
++}
++
++static u32 brcm_pcie_mdio_form_pkt(unsigned int port, unsigned int regad,
++				   unsigned int cmd)
++{
++	u32 pkt;
++
++	pkt = (port << MDIO_PORT_SHIFT) & MDIO_PORT_MASK;
++	pkt |= (regad << MDIO_REGAD_SHIFT) & MDIO_REGAD_MASK;
++	pkt |= (cmd << MDIO_CMD_SHIFT) & MDIO_CMD_MASK;
++
++	return pkt;
++}
++
++/**
++ * brcm_pcie_mdio_read() - Perform a register read on the internal MDIO bus
++ * @base: Pointer to the PCIe controller IO registers
++ * @port: The MDIO port number
++ * @regad: The register address
++ * @val: A pointer at which to store the read value
++ *
++ * Return: 0 on success and register value in @val, negative error value
++ *         on failure.
++ */
++static int brcm_pcie_mdio_read(void __iomem *base, unsigned int port,
++			       unsigned int regad, u32 *val)
++{
++	u32 data, addr;
++	int ret;
++
++	addr = brcm_pcie_mdio_form_pkt(port, regad, MDIO_CMD_READ);
++	writel(addr, base + PCIE_RC_DL_MDIO_ADDR);
++	readl(base + PCIE_RC_DL_MDIO_ADDR);
++
++	ret = readl_poll_timeout(base + PCIE_RC_DL_MDIO_RD_DATA, data,
++				 (data & MDIO_DATA_DONE_MASK), 100);
++
++	*val = data & MDIO_DATA_MASK;
++
++	return ret;
++}
++
++/**
++ * brcm_pcie_mdio_write() - Perform a register write on the internal MDIO bus
++ * @base: Pointer to the PCIe controller IO registers
++ * @port: The MDIO port number
++ * @regad: Address of the register
++ * @wrdata: The value to write
++ *
++ * Return: 0 on success, negative error value on failure.
++ */
++static int brcm_pcie_mdio_write(void __iomem *base, unsigned int port,
++				unsigned int regad, u16 wrdata)
++{
++	u32 data, addr;
++
++	addr = brcm_pcie_mdio_form_pkt(port, regad, MDIO_CMD_WRITE);
++	writel(addr, base + PCIE_RC_DL_MDIO_ADDR);
++	readl(base + PCIE_RC_DL_MDIO_ADDR);
++	writel(MDIO_DATA_DONE_MASK | wrdata, base + PCIE_RC_DL_MDIO_WR_DATA);
++
++	return readl_poll_timeout(base + PCIE_RC_DL_MDIO_WR_DATA, data,
++				  !(data & MDIO_DATA_DONE_MASK), 100);
++}
++
++/**
++ * brcm_pcie_set_ssc() - Configure the controller for Spread Spectrum Clocking
++ * @base: pointer to the PCIe controller IO registers
++ *
++ * Return: 0 on success, negative error value on failure.
++ */
++static int brcm_pcie_set_ssc(void __iomem *base)
++{
++	int pll, ssc;
++	int ret;
++	u32 tmp;
++
++	ret = brcm_pcie_mdio_write(base, MDIO_PORT0, SET_ADDR_OFFSET,
++				   SSC_REGS_ADDR);
++	if (ret < 0)
++		return ret;
++
++	ret = brcm_pcie_mdio_read(base, MDIO_PORT0, SSC_CNTL_OFFSET, &tmp);
++	if (ret < 0)
++		return ret;
++
++	tmp |= (SSC_CNTL_OVRD_EN_MASK | SSC_CNTL_OVRD_VAL_MASK);
++
++	ret = brcm_pcie_mdio_write(base, MDIO_PORT0, SSC_CNTL_OFFSET, tmp);
++	if (ret < 0)
++		return ret;
++
++	udelay(1000);
++	ret = brcm_pcie_mdio_read(base, MDIO_PORT0, SSC_STATUS_OFFSET, &tmp);
++	if (ret < 0)
++		return ret;
++
++	ssc = (tmp & SSC_STATUS_SSC_MASK) >> SSC_STATUS_SSC_SHIFT;
++	pll = (tmp & SSC_STATUS_PLL_LOCK_MASK) >> SSC_STATUS_PLL_LOCK_SHIFT;
++
++	return ssc && pll ? 0 : -EIO;
++}
++
++/**
++ * brcm_pcie_set_gen() - Limits operation to a specific generation (1, 2 or 3)
++ * @pcie: pointer to the PCIe controller state
++ * @gen: PCIe generation to limit the controller's operation to
++ */
++static void brcm_pcie_set_gen(struct brcm_pcie *pcie, unsigned int gen)
++{
++	void __iomem *cap_base = pcie->base + BRCM_PCIE_CAP_REGS;
++
++	u16 lnkctl2 = readw(cap_base + PCI_EXP_LNKCTL2);
++	u32 lnkcap = readl(cap_base + PCI_EXP_LNKCAP);
++
++	lnkcap = (lnkcap & ~PCI_EXP_LNKCAP_SLS) | gen;
++	writel(lnkcap, cap_base + PCI_EXP_LNKCAP);
++
++	lnkctl2 = (lnkctl2 & ~0xf) | gen;
++	writew(lnkctl2, cap_base + PCI_EXP_LNKCTL2);
++}
++
++static void brcm_pcie_set_outbound_win(struct brcm_pcie *pcie,
++				       unsigned int win, u64 phys_addr,
++				       u64 pcie_addr, u64 size)
++{
++	void __iomem *base = pcie->base;
++	u32 phys_addr_mb_high, limit_addr_mb_high;
++	phys_addr_t phys_addr_mb, limit_addr_mb;
++	int high_addr_shift;
++	u32 tmp;
++
++	/* Set the base of the pcie_addr window */
++	writel(lower_32_bits(pcie_addr), base + PCIE_MEM_WIN0_LO(win));
++	writel(upper_32_bits(pcie_addr), base + PCIE_MEM_WIN0_HI(win));
++
++	/* Write the addr base & limit lower bits (in MBs) */
++	phys_addr_mb = phys_addr / SZ_1M;
++	limit_addr_mb = (phys_addr + size - 1) / SZ_1M;
++
++	tmp = readl(base + PCIE_MEM_WIN0_BASE_LIMIT(win));
++	u32p_replace_bits(&tmp, phys_addr_mb,
++			  MEM_WIN0_BASE_LIMIT_BASE_MASK);
++	u32p_replace_bits(&tmp, limit_addr_mb,
++			  MEM_WIN0_BASE_LIMIT_LIMIT_MASK);
++	writel(tmp, base + PCIE_MEM_WIN0_BASE_LIMIT(win));
++
++	/* Write the cpu & limit addr upper bits */
++	high_addr_shift = MEM_WIN0_BASE_LIMIT_BASE_HI_SHIFT;
++	phys_addr_mb_high = phys_addr_mb >> high_addr_shift;
++	tmp = readl(base + PCIE_MEM_WIN0_BASE_HI(win));
++	u32p_replace_bits(&tmp, phys_addr_mb_high,
++			  MEM_WIN0_BASE_HI_BASE_MASK);
++	writel(tmp, base + PCIE_MEM_WIN0_BASE_HI(win));
++
++	limit_addr_mb_high = limit_addr_mb >> high_addr_shift;
++	tmp = readl(base + PCIE_MEM_WIN0_LIMIT_HI(win));
++	u32p_replace_bits(&tmp, limit_addr_mb_high,
++			  PCIE_MEM_WIN0_LIMIT_HI_LIMIT_MASK);
++	writel(tmp, base + PCIE_MEM_WIN0_LIMIT_HI(win));
++}
++
++static int brcm_pcie_probe(struct udevice *dev)
++{
++	struct udevice *ctlr = pci_get_controller(dev);
++	struct pci_controller *hose = dev_get_uclass_priv(ctlr);
++	struct brcm_pcie *pcie = dev_get_priv(dev);
++	void __iomem *base = pcie->base;
++	bool ssc_good = false;
++	int num_out_wins = 0;
++	u64 rc_bar2_offset, rc_bar2_size;
++	unsigned int scb_size_val;
++	int i, ret;
++	u16 nlw, cls, lnksta;
++	u32 tmp;
++
++	/*
++	 * Reset the bridge, assert the fundamental reset. Note for some SoCs,
++	 * e.g. BCM7278, the fundamental reset should not be asserted here.
++	 * This will need to be changed when support for other SoCs is added.
++	 */
++	setbits_le32(base + PCIE_RGR1_SW_INIT_1,
++		     RGR1_SW_INIT_1_INIT_MASK | RGR1_SW_INIT_1_PERST_MASK);
++	/*
++	 * The delay is a safety precaution to preclude the reset signal
++	 * from looking like a glitch.
++	 */
++	udelay(100);
++
++	/* Take the bridge out of reset */
++	clrbits_le32(base + PCIE_RGR1_SW_INIT_1, RGR1_SW_INIT_1_INIT_MASK);
++
++	clrbits_le32(base + PCIE_MISC_HARD_PCIE_HARD_DEBUG,
++		     PCIE_HARD_DEBUG_SERDES_IDDQ_MASK);
++
++	/* Wait for SerDes to be stable */
++	udelay(100);
++
++	/* Set SCB_MAX_BURST_SIZE, CFG_READ_UR_MODE, SCB_ACCESS_EN */
++	clrsetbits_le32(base + PCIE_MISC_MISC_CTRL,
++			MISC_CTRL_MAX_BURST_SIZE_MASK,
++			MISC_CTRL_SCB_ACCESS_EN_MASK |
++			MISC_CTRL_CFG_READ_UR_MODE_MASK |
++			MISC_CTRL_MAX_BURST_SIZE_128);
++	/*
++	 * TODO: When support for other SoCs than BCM2711 is added we may
++	 * need to use the base address and size(s) provided in the dma-ranges
++	 * property.
++	 */
++	rc_bar2_offset = 0;
++	rc_bar2_size = 0xc0000000;
++
++	tmp = lower_32_bits(rc_bar2_offset);
++	u32p_replace_bits(&tmp, brcm_pcie_encode_ibar_size(rc_bar2_size),
++			  RC_BAR2_CONFIG_LO_SIZE_MASK);
++	writel(tmp, base + PCIE_MISC_RC_BAR2_CONFIG_LO);
++	writel(upper_32_bits(rc_bar2_offset),
++	       base + PCIE_MISC_RC_BAR2_CONFIG_HI);
++
++	scb_size_val = rc_bar2_size ?
++		       ilog2(rc_bar2_size) - 15 : 0xf; /* 0xf is 1GB */
++
++	tmp = readl(base + PCIE_MISC_MISC_CTRL);
++	u32p_replace_bits(&tmp, scb_size_val,
++			  MISC_CTRL_SCB0_SIZE_MASK);
++	writel(tmp, base + PCIE_MISC_MISC_CTRL);
++
++	/* Disable the PCIe->GISB memory window (RC_BAR1) */
++	clrbits_le32(base + PCIE_MISC_RC_BAR1_CONFIG_LO,
++		     RC_BAR1_CONFIG_LO_SIZE_MASK);
++
++	/* Disable the PCIe->SCB memory window (RC_BAR3) */
++	clrbits_le32(base + PCIE_MISC_RC_BAR3_CONFIG_LO,
++		     RC_BAR3_CONFIG_LO_SIZE_MASK);
++
++	/* Mask all interrupts since we are not handling any yet */
++	writel(0xffffffff, base + PCIE_MSI_INTR2_MASK_SET);
++
++	/* Clear any interrupts we find on boot */
++	writel(0xffffffff, base + PCIE_MSI_INTR2_CLR);
++
++	if (pcie->gen)
++		brcm_pcie_set_gen(pcie, pcie->gen);
++
++	/* Unassert the fundamental reset */
++	clrbits_le32(pcie->base + PCIE_RGR1_SW_INIT_1,
++		     RGR1_SW_INIT_1_PERST_MASK);
++
++	/* Give the RC/EP time to wake up, before trying to configure RC.
++	 * Intermittently check status for link-up, up to a total of 100ms.
++	 */
++	for (i = 0; i < 100 && !brcm_pcie_link_up(pcie); i += 5)
++		mdelay(5);
++
++	if (!brcm_pcie_link_up(pcie)) {
++		printf("PCIe BRCM: link down\n");
++		return -EINVAL;
++	}
++
++	if (!brcm_pcie_rc_mode(pcie)) {
++		printf("PCIe misconfigured; is in EP mode\n");
++		return -EINVAL;
++	}
++
++	for (i = 0; i < hose->region_count; i++) {
++		struct pci_region *reg = &hose->regions[i];
++
++		if (reg->flags != PCI_REGION_MEM)
++			continue;
++
++		if (num_out_wins >= BRCM_NUM_PCIE_OUT_WINS)
++			return -EINVAL;
++
++		brcm_pcie_set_outbound_win(pcie, num_out_wins, reg->phys_start,
++					   reg->bus_start, reg->size);
++
++		num_out_wins++;
++	}
++
++	/*
++	 * For config space accesses on the RC, show the right class for
++	 * a PCIe-PCIe bridge (the default setting is to be EP mode).
++	 */
++	clrsetbits_le32(base + PCIE_RC_CFG_PRIV1_ID_VAL3,
++			CFG_PRIV1_ID_VAL3_CLASS_CODE_MASK, 0x060400);
++
++	if (pcie->ssc) {
++		ret = brcm_pcie_set_ssc(pcie->base);
++		if (!ret)
++			ssc_good = true;
++		else
++			printf("PCIe BRCM: failed attempt to enter SSC mode\n");
++	}
++
++	lnksta = readw(base + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA);
++	cls = lnksta & PCI_EXP_LNKSTA_CLS;
++	nlw = (lnksta & PCI_EXP_LNKSTA_NLW) >> PCI_EXP_LNKSTA_NLW_SHIFT;
++
++	printf("PCIe BRCM: link up, %s Gbps x%u %s\n", link_speed_to_str(cls),
++	       nlw, ssc_good ? "(SSC)" : "(!SSC)");
++
++	/* PCIe->SCB endian mode for BAR */
++	clrsetbits_le32(base + PCIE_RC_CFG_VENDOR_SPECIFIC_REG1,
++			VENDOR_SPECIFIC_REG1_ENDIAN_MODE_BAR2_MASK,
++			VENDOR_SPECIFIC_REG1_LITTLE_ENDIAN);
++	/*
++	 * Refclk from RC should be gated with CLKREQ# input when ASPM L0s,L1
++	 * is enabled => setting the CLKREQ_DEBUG_ENABLE field to 1.
++	 */
++	setbits_le32(base + PCIE_MISC_HARD_PCIE_HARD_DEBUG,
++		     PCIE_HARD_DEBUG_CLKREQ_DEBUG_ENABLE_MASK);
++
++	return 0;
++}
++
++static int brcm_pcie_ofdata_to_platdata(struct udevice *dev)
++{
++	struct brcm_pcie *pcie = dev_get_priv(dev);
++	ofnode dn = dev_ofnode(dev);
++	u32 max_link_speed;
++	int ret;
++
++	/* Get the controller base address */
++	pcie->base = dev_read_addr_ptr(dev);
++	if (!pcie->base)
++		return -EINVAL;
++
++	pcie->ssc = ofnode_read_bool(dn, "brcm,enable-ssc");
++
++	ret = ofnode_read_u32(dn, "max-link-speed", &max_link_speed);
++	if (ret < 0 || max_link_speed > 4)
++		pcie->gen = 0;
++	else
++		pcie->gen = max_link_speed;
++
++	return 0;
++}
++
++static const struct dm_pci_ops brcm_pcie_ops = {
++	.read_config	= brcm_pcie_read_config,
++	.write_config	= brcm_pcie_write_config,
++};
++
++static const struct udevice_id brcm_pcie_ids[] = {
++	{ .compatible = "brcm,bcm2711-pcie" },
++	{ }
++};
++
++U_BOOT_DRIVER(pcie_brcm_base) = {
++	.name			= "pcie_brcm",
++	.id			= UCLASS_PCI,
++	.ops			= &brcm_pcie_ops,
++	.of_match		= brcm_pcie_ids,
++	.probe			= brcm_pcie_probe,
++	.ofdata_to_platdata	= brcm_pcie_ofdata_to_platdata,
++	.priv_auto_alloc_size	= sizeof(struct brcm_pcie),
++};
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0010-configs-Enable-support-for-the-XHCI-controller-on-RP.patch
+++ b/buildroot-external/patches/uboot/2020.07/0010-configs-Enable-support-for-the-XHCI-controller-on-RP.patch
@@ -1,0 +1,102 @@
+From 66537b5984af81b5add420df9eb64c508268f581 Mon Sep 17 00:00:00 2001
+Message-Id: <66537b5984af81b5add420df9eb64c508268f581.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Mon, 25 May 2020 13:39:59 +0200
+Subject: [PATCH 10/20] configs: Enable support for the XHCI controller on RPI4
+ board (ARM 64-bit)
+
+This requires enabling BRCMSTB PCIe and XHCI_PCI drivers as well as PCI
+and USB commands. To get it working one has to call the following commands:
+"pci enum; usb start;", thus such commands have been added to the default
+"preboot" environment variable. One has to update their environment if it
+is already configured to get this feature working out of the box.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Signed-off-by: Sylwester Nawrocki <s.nawrocki@samsung.com>
+---
+ configs/rpi_4_defconfig     | 9 +++++++++
+ configs/rpi_arm64_defconfig | 8 +++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index f0301dc8bc..b42efe6072 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -6,6 +6,8 @@ CONFIG_SYS_MALLOC_F_LEN=0x2000
+ CONFIG_ENV_SIZE=0x4000
+ CONFIG_DISTRO_DEFAULTS=y
+ CONFIG_OF_BOARD_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="pci enum; usb start;"
+ CONFIG_MISC_INIT_R=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ # CONFIG_DISPLAY_BOARDINFO is not set
+@@ -13,6 +15,8 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_DFU=y
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+@@ -26,12 +30,17 @@ CONFIG_MMC_SDHCI_SDMA=y
+ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_BCMGENET=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
+ # CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_DM_USB_GADGET=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_PCI=y
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_GADGET_MANUFACTURER="FSL"
+ CONFIG_USB_GADGET_VENDOR_NUM=0x0525
+diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
+index d16c2388af..0feea7f0be 100644
+--- a/configs/rpi_arm64_defconfig
++++ b/configs/rpi_arm64_defconfig
+@@ -7,13 +7,14 @@ CONFIG_ENV_SIZE=0x4000
+ CONFIG_DISTRO_DEFAULTS=y
+ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="usb start"
++CONFIG_PREBOOT="pci enum; usb start;"
+ CONFIG_MISC_INIT_R=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ # CONFIG_DISPLAY_BOARDINFO is not set
+ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_BOARD=y
+@@ -26,11 +27,16 @@ CONFIG_MMC_SDHCI_SDMA=y
+ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_BCMGENET=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
+ # CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_PCI=y
+ CONFIG_USB_DWC2=y
+ CONFIG_USB_KEYBOARD=y
+ CONFIG_USB_HOST_ETHER=y
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0011-arm-rpi-Add-function-to-trigger-VL805-s-firmware-loa.patch
+++ b/buildroot-external/patches/uboot/2020.07/0011-arm-rpi-Add-function-to-trigger-VL805-s-firmware-loa.patch
@@ -1,0 +1,131 @@
+From 2899e2cbe5412ee6f6a01855467fa37534ffc2be Mon Sep 17 00:00:00 2001
+Message-Id: <2899e2cbe5412ee6f6a01855467fa37534ffc2be.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:37:22 +0200
+Subject: [PATCH 11/20] arm: rpi: Add function to trigger VL805's firmware load
+
+On the Raspberry Pi 4, after a PCI reset, VL805's (a xHCI chip) firmware
+may either be loaded directly from an EEPROM or, if not present, by the
+SoC's VideCore (the SoC's co-processor). Introduce the function that
+informs VideCore that VL805 may need its firmware loaded.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ arch/arm/mach-bcm283x/include/mach/mbox.h | 13 +++++++
+ arch/arm/mach-bcm283x/include/mach/msg.h  |  7 ++++
+ arch/arm/mach-bcm283x/msg.c               | 46 +++++++++++++++++++++++
+ 3 files changed, 66 insertions(+)
+
+diff --git a/arch/arm/mach-bcm283x/include/mach/mbox.h b/arch/arm/mach-bcm283x/include/mach/mbox.h
+index 60e226ce1d..2ae2d3d97c 100644
+--- a/arch/arm/mach-bcm283x/include/mach/mbox.h
++++ b/arch/arm/mach-bcm283x/include/mach/mbox.h
+@@ -491,6 +491,19 @@ struct bcm2835_mbox_tag_set_palette {
+ 	} body;
+ };
+ 
++#define BCM2835_MBOX_TAG_NOTIFY_XHCI_RESET          0x00030058
++
++struct bcm2835_mbox_tag_pci_dev_addr {
++	struct bcm2835_mbox_tag_hdr tag_hdr;
++	union {
++		struct {
++			u32 dev_addr;
++		} req;
++		struct {
++		} resp;
++	} body;
++};
++
+ /*
+  * Pass a raw u32 message to the VC, and receive a raw u32 back.
+  *
+diff --git a/arch/arm/mach-bcm283x/include/mach/msg.h b/arch/arm/mach-bcm283x/include/mach/msg.h
+index 4afb08631b..e45c1bf010 100644
+--- a/arch/arm/mach-bcm283x/include/mach/msg.h
++++ b/arch/arm/mach-bcm283x/include/mach/msg.h
+@@ -48,4 +48,11 @@ int bcm2835_set_video_params(int *widthp, int *heightp, int depth_bpp,
+ 			     int pixel_order, int alpha_mode, ulong *fb_basep,
+ 			     ulong *fb_sizep, int *pitchp);
+ 
++/**
++ * bcm2711_load_vl805_firmware() - get vl805's firmware loaded
++ *
++ * @return 0 if OK, -EIO on error
++ */
++int bcm2711_notify_vl805_reset(void);
++
+ #endif
+diff --git a/arch/arm/mach-bcm283x/msg.c b/arch/arm/mach-bcm283x/msg.c
+index 94b75283f8..347aece3cd 100644
+--- a/arch/arm/mach-bcm283x/msg.c
++++ b/arch/arm/mach-bcm283x/msg.c
+@@ -7,6 +7,7 @@
+ #include <memalign.h>
+ #include <phys2bus.h>
+ #include <asm/arch/mbox.h>
++#include <linux/delay.h>
+ 
+ struct msg_set_power_state {
+ 	struct bcm2835_mbox_hdr hdr;
+@@ -40,6 +41,12 @@ struct msg_setup {
+ 	u32 end_tag;
+ };
+ 
++struct msg_notify_vl805_reset {
++	struct bcm2835_mbox_hdr hdr;
++	struct bcm2835_mbox_tag_pci_dev_addr dev_addr;
++	u32 end_tag;
++};
++
+ int bcm2835_power_on_module(u32 module)
+ {
+ 	ALLOC_CACHE_ALIGN_BUFFER(struct msg_set_power_state, msg_pwr, 1);
+@@ -151,3 +158,42 @@ int bcm2835_set_video_params(int *widthp, int *heightp, int depth_bpp,
+ 
+ 	return 0;
+ }
++
++/*
++ * On the Raspberry Pi 4, after a PCI reset, VL805's (the xHCI chip) firmware
++ * may either be loaded directly from an EEPROM or, if not present, by the
++ * SoC's VideoCore. This informs VideoCore that VL805 needs its firmware
++ * loaded.
++ */
++int bcm2711_notify_vl805_reset(void)
++{
++	ALLOC_CACHE_ALIGN_BUFFER(struct msg_notify_vl805_reset,
++				 msg_notify_vl805_reset, 1);
++	int ret;
++
++	BCM2835_MBOX_INIT_HDR(msg_notify_vl805_reset);
++	BCM2835_MBOX_INIT_TAG(&msg_notify_vl805_reset->dev_addr,
++			      NOTIFY_XHCI_RESET);
++
++	/*
++	 * The pci device address is expected like this:
++	 *
++	 *   PCI_BUS << 20 | PCI_SLOT << 15 | PCI_FUNC << 12
++	 *
++	 * But since RPi4's PCIe setup is hardwired, we know the address in
++	 * advance.
++	 */
++	msg_notify_vl805_reset->dev_addr.body.req.dev_addr = 0x100000;
++
++	ret = bcm2835_mbox_call_prop(BCM2835_MBOX_PROP_CHAN,
++				     &msg_notify_vl805_reset->hdr);
++	if (ret) {
++		printf("bcm2711: Faild to load vl805's firmware, %d\n", ret);
++		return -EIO;
++	}
++
++	udelay(200);
++
++	return 0;
++}
++
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0012-reset-Add-Raspberry-Pi-4-firmware-reset-controller.patch
+++ b/buildroot-external/patches/uboot/2020.07/0012-reset-Add-Raspberry-Pi-4-firmware-reset-controller.patch
@@ -1,0 +1,140 @@
+From e9925f97c2c31253e1ff62de4049d90e19884f55 Mon Sep 17 00:00:00 2001
+Message-Id: <e9925f97c2c31253e1ff62de4049d90e19884f55.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:37:23 +0200
+Subject: [PATCH 12/20] reset: Add Raspberry Pi 4 firmware reset controller
+
+Raspberry Pi 4's co-processor controls some of the board's HW
+initialization process, but it's up to Linux to trigger it when
+relevant. Introduce a reset controller capable of interfacing with
+RPi4's co-processor that models these firmware initialization routines as
+reset lines.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ drivers/reset/Kconfig                         | 10 ++++
+ drivers/reset/Makefile                        |  1 +
+ drivers/reset/reset-raspberrypi.c             | 60 +++++++++++++++++++
+ .../reset/raspberrypi,firmware-reset.h        | 13 ++++
+ 4 files changed, 84 insertions(+)
+ create mode 100644 drivers/reset/reset-raspberrypi.c
+ create mode 100644 include/dt-bindings/reset/raspberrypi,firmware-reset.h
+
+diff --git a/drivers/reset/Kconfig b/drivers/reset/Kconfig
+index 88d3be1593..d02c1522e5 100644
+--- a/drivers/reset/Kconfig
++++ b/drivers/reset/Kconfig
+@@ -148,4 +148,14 @@ config RESET_IMX7
+ 	help
+ 	  Support for reset controller on i.MX7/8 SoCs.
+ 
++config RESET_RASPBERRYPI
++	bool "Raspberry Pi 4 Firmware Reset Controller Driver"
++	depends on DM_RESET && ARCH_BCM283X
++	default USB_XHCI_PCI
++	help
++	  Raspberry Pi 4's co-processor controls some of the board's HW
++	  initialization process, but it's up to Linux to trigger it when
++	  relevant. This driver provides a reset controller capable of
++	  interfacing with RPi4's co-processor and model these firmware
++	  initialization routines as reset lines.
+ endmenu
+diff --git a/drivers/reset/Makefile b/drivers/reset/Makefile
+index 0a044d5d8c..be54dae725 100644
+--- a/drivers/reset/Makefile
++++ b/drivers/reset/Makefile
+@@ -23,3 +23,4 @@ obj-$(CONFIG_RESET_MTMIPS) += reset-mtmips.o
+ obj-$(CONFIG_RESET_SUNXI) += reset-sunxi.o
+ obj-$(CONFIG_RESET_HISILICON) += reset-hisilicon.o
+ obj-$(CONFIG_RESET_IMX7) += reset-imx7.o
++obj-$(CONFIG_RESET_RASPBERRYPI) += reset-raspberrypi.o
+diff --git a/drivers/reset/reset-raspberrypi.c b/drivers/reset/reset-raspberrypi.c
+new file mode 100644
+index 0000000000..e2d284e5ac
+--- /dev/null
++++ b/drivers/reset/reset-raspberrypi.c
+@@ -0,0 +1,60 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Raspberry Pi 4 firmware reset driver
++ *
++ * Copyright (C) 2020 Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
++ */
++#include <common.h>
++#include <dm.h>
++#include <reset-uclass.h>
++#include <asm/arch/msg.h>
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
++
++static int raspberrypi_reset_request(struct reset_ctl *reset_ctl)
++{
++	if (reset_ctl->id >= RASPBERRYPI_FIRMWARE_RESET_NUM_IDS)
++		return -EINVAL;
++
++	return 0;
++}
++
++static int raspberrypi_reset_free(struct reset_ctl *reset_ctl)
++{
++	return 0;
++}
++
++static int raspberrypi_reset_assert(struct reset_ctl *reset_ctl)
++{
++	switch (reset_ctl->id) {
++	case RASPBERRYPI_FIRMWARE_RESET_ID_USB:
++		bcm2711_notify_vl805_reset();
++		return 0;
++	default:
++		return -EINVAL;
++	}
++}
++
++static int raspberrypi_reset_deassert(struct reset_ctl *reset_ctl)
++{
++	return 0;
++}
++
++struct reset_ops raspberrypi_reset_ops = {
++	.request = raspberrypi_reset_request,
++	.rfree = raspberrypi_reset_free,
++	.rst_assert = raspberrypi_reset_assert,
++	.rst_deassert = raspberrypi_reset_deassert,
++};
++
++static const struct udevice_id raspberrypi_reset_ids[] = {
++	{ .compatible = "raspberrypi,firmware-reset" },
++	{ }
++};
++
++U_BOOT_DRIVER(raspberrypi_reset) = {
++	.name = "raspberrypi-reset",
++	.id = UCLASS_RESET,
++	.of_match = raspberrypi_reset_ids,
++	.ops = &raspberrypi_reset_ops,
++};
++
+diff --git a/include/dt-bindings/reset/raspberrypi,firmware-reset.h b/include/dt-bindings/reset/raspberrypi,firmware-reset.h
+new file mode 100644
+index 0000000000..1a4f4c7927
+--- /dev/null
++++ b/include/dt-bindings/reset/raspberrypi,firmware-reset.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (c) 2020 Nicolas Saenz Julienne
++ * Author: Nicolas Saenz Julienne <nsaenzjulienne@suse.com>
++ */
++
++#ifndef _DT_BINDINGS_RASPBERRYPI_FIRMWARE_RESET_H
++#define _DT_BINDINGS_RASPBERRYPI_FIRMWARE_RESET_H
++
++#define RASPBERRYPI_FIRMWARE_RESET_ID_USB	0
++#define RASPBERRYPI_FIRMWARE_RESET_NUM_IDS	1
++
++#endif
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0013-configs-Enable-support-for-reset-controllers-on-RPi4.patch
+++ b/buildroot-external/patches/uboot/2020.07/0013-configs-Enable-support-for-reset-controllers-on-RPi4.patch
@@ -1,0 +1,57 @@
+From d32b13ba58aa59a5ec0b71cfc2005bf1efd84ddf Mon Sep 17 00:00:00 2001
+Message-Id: <d32b13ba58aa59a5ec0b71cfc2005bf1efd84ddf.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:37:24 +0200
+Subject: [PATCH 13/20] configs: Enable support for reset controllers on RPi4
+
+This is required in order to access the reset controller used to
+initialize the board's xHCI chip.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ configs/rpi_4_32b_defconfig | 1 +
+ configs/rpi_4_defconfig     | 1 +
+ configs/rpi_arm64_defconfig | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
+index a36a249540..0df5c17d6e 100644
+--- a/configs/rpi_4_32b_defconfig
++++ b/configs/rpi_4_32b_defconfig
+@@ -28,6 +28,7 @@ CONFIG_DM_ETH=y
+ CONFIG_BCMGENET=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
++CONFIG_DM_RESET=y
+ # CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
+index b42efe6072..f641ad3dfa 100644
+--- a/configs/rpi_4_defconfig
++++ b/configs/rpi_4_defconfig
+@@ -35,6 +35,7 @@ CONFIG_DM_PCI=y
+ CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
++CONFIG_DM_RESET=y
+ # CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
+index 0feea7f0be..4ce8469f43 100644
+--- a/configs/rpi_arm64_defconfig
++++ b/configs/rpi_arm64_defconfig
+@@ -32,6 +32,7 @@ CONFIG_DM_PCI=y
+ CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
++CONFIG_DM_RESET=y
+ # CONFIG_REQUIRE_SERIAL_CONSOLE is not set
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0014-usb-xhci-Add-reset-controller-support.patch
+++ b/buildroot-external/patches/uboot/2020.07/0014-usb-xhci-Add-reset-controller-support.patch
@@ -1,0 +1,106 @@
+From a39dcf665d8867875b104661bd6a6325f502c5f2 Mon Sep 17 00:00:00 2001
+Message-Id: <a39dcf665d8867875b104661bd6a6325f502c5f2.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Date: Mon, 29 Jun 2020 18:37:25 +0200
+Subject: [PATCH 14/20] usb: xhci: Add reset controller support
+
+Some atypical users of xhci might need to manually reset their xHCI
+controller before starting the HCD setup. Check if a reset controller
+device is available to the PCI bus and trigger a reset.
+
+Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+---
+ drivers/usb/host/xhci-mem.c |  2 ++
+ drivers/usb/host/xhci.c     | 33 +++++++++++++++++++++++++++++++++
+ include/usb/xhci.h          |  2 ++
+ 3 files changed, 37 insertions(+)
+
+diff --git a/drivers/usb/host/xhci-mem.c b/drivers/usb/host/xhci-mem.c
+index f446520528..108f4bd8cf 100644
+--- a/drivers/usb/host/xhci-mem.c
++++ b/drivers/usb/host/xhci-mem.c
+@@ -180,6 +180,8 @@ void xhci_cleanup(struct xhci_ctrl *ctrl)
+ 	xhci_free_virt_devices(ctrl);
+ 	free(ctrl->erst.entries);
+ 	free(ctrl->dcbaa);
++	if (reset_valid(&ctrl->reset))
++		reset_free(&ctrl->reset);
+ 	memset(ctrl, '\0', sizeof(struct xhci_ctrl));
+ }
+ 
+diff --git a/drivers/usb/host/xhci.c b/drivers/usb/host/xhci.c
+index ebd2954571..e252964d0d 100644
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -190,6 +190,35 @@ static int xhci_start(struct xhci_hcor *hcor)
+ 	return ret;
+ }
+ 
++/**
++ * Resets XHCI Hardware
++ *
++ * @param ctrl	pointer to host controller
++ * @return 0 if OK, or a negative error code.
++ */
++static int xhci_reset_hw(struct xhci_ctrl *ctrl)
++{
++	int ret;
++
++	ret = reset_get_by_index(ctrl->dev, 0, &ctrl->reset);
++	if (ret && ret != -ENOENT && ret != -ENOTSUPP) {
++		dev_err(ctrl->dev, "failed to get reset\n");
++		return ret;
++	}
++
++	if (reset_valid(&ctrl->reset)) {
++		ret = reset_assert(&ctrl->reset);
++		if (ret)
++			return ret;
++
++		ret = reset_deassert(&ctrl->reset);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++
+ /**
+  * Resets the XHCI Controller
+  *
+@@ -1508,6 +1537,10 @@ int xhci_register(struct udevice *dev, struct xhci_hccr *hccr,
+ 
+ 	ctrl->dev = dev;
+ 
++	ret = xhci_reset_hw(ctrl);
++	if (ret)
++		goto err;
++
+ 	/*
+ 	 * XHCI needs to issue a Address device command to setup
+ 	 * proper device context structures, before it can interact
+diff --git a/include/usb/xhci.h b/include/usb/xhci.h
+index 1170c0ac69..7d34103fd5 100644
+--- a/include/usb/xhci.h
++++ b/include/usb/xhci.h
+@@ -16,6 +16,7 @@
+ #ifndef HOST_XHCI_H_
+ #define HOST_XHCI_H_
+ 
++#include <reset.h>
+ #include <asm/types.h>
+ #include <asm/cache.h>
+ #include <asm/io.h>
+@@ -1209,6 +1210,7 @@ struct xhci_ctrl {
+ #if CONFIG_IS_ENABLED(DM_USB)
+ 	struct udevice *dev;
+ #endif
++	struct reset_ctl reset;
+ 	struct xhci_hccr *hccr;	/* R/O registers, not need for volatile */
+ 	struct xhci_hcor *hcor;
+ 	struct xhci_doorbell_array *dba;
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0015-powerpc-move-ADDR_MAP-to-Kconfig.patch
+++ b/buildroot-external/patches/uboot/2020.07/0015-powerpc-move-ADDR_MAP-to-Kconfig.patch
@@ -1,0 +1,1813 @@
+From 42992bdb8c358f10fe8cc8da16d4ec5f3cb97efb Mon Sep 17 00:00:00 2001
+Message-Id: <42992bdb8c358f10fe8cc8da16d4ec5f3cb97efb.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:40 +0200
+Subject: [PATCH 15/20] powerpc: move ADDR_MAP to Kconfig
+
+Move ADDR_MAP related config options from include/configs/*.h to the
+proper place in lib/Kconfig. This has been done using
+./tools/moveconfig.py and manual inspection of the generated changes.
+This is a preparation to use ADDR_MAP helper on ARM 32bit Raspberry Pi4
+board for mapping the PCIe XHCI MMIO, which is above the 4GiB identity
+mapping limit.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ configs/Cyrus_P5020_defconfig                       |  2 ++
+ configs/Cyrus_P5040_defconfig                       |  2 ++
+ configs/MPC8548CDS_36BIT_defconfig                  |  1 +
+ configs/MPC8572DS_36BIT_defconfig                   |  1 +
+ configs/MPC8641HPCN_36BIT_defconfig                 |  2 ++
+ configs/MPC8641HPCN_defconfig                       |  2 ++
+ configs/P1010RDB-PA_36BIT_NAND_SECBOOT_defconfig    |  1 +
+ configs/P1010RDB-PA_36BIT_NAND_defconfig            |  1 +
+ configs/P1010RDB-PA_36BIT_NOR_SECBOOT_defconfig     |  1 +
+ configs/P1010RDB-PA_36BIT_NOR_defconfig             |  1 +
+ configs/P1010RDB-PA_36BIT_SDCARD_defconfig          |  1 +
+ .../P1010RDB-PA_36BIT_SPIFLASH_SECBOOT_defconfig    |  1 +
+ configs/P1010RDB-PA_36BIT_SPIFLASH_defconfig        |  1 +
+ configs/P1010RDB-PB_36BIT_NAND_SECBOOT_defconfig    |  1 +
+ configs/P1010RDB-PB_36BIT_NAND_defconfig            |  1 +
+ configs/P1010RDB-PB_36BIT_NOR_SECBOOT_defconfig     |  1 +
+ configs/P1010RDB-PB_36BIT_NOR_defconfig             |  1 +
+ configs/P1010RDB-PB_36BIT_SDCARD_defconfig          |  1 +
+ .../P1010RDB-PB_36BIT_SPIFLASH_SECBOOT_defconfig    |  1 +
+ configs/P1010RDB-PB_36BIT_SPIFLASH_defconfig        |  1 +
+ configs/P1020MBG-PC_36BIT_SDCARD_defconfig          |  1 +
+ configs/P1020MBG-PC_36BIT_defconfig                 |  1 +
+ configs/P1020RDB-PC_36BIT_NAND_defconfig            |  1 +
+ configs/P1020RDB-PC_36BIT_SDCARD_defconfig          |  1 +
+ configs/P1020RDB-PC_36BIT_SPIFLASH_defconfig        |  1 +
+ configs/P1020RDB-PC_36BIT_defconfig                 |  1 +
+ configs/P1020UTM-PC_36BIT_SDCARD_defconfig          |  1 +
+ configs/P1020UTM-PC_36BIT_defconfig                 |  1 +
+ configs/P1021RDB-PC_36BIT_NAND_defconfig            |  1 +
+ configs/P1021RDB-PC_36BIT_SDCARD_defconfig          |  1 +
+ configs/P1021RDB-PC_36BIT_SPIFLASH_defconfig        |  1 +
+ configs/P1021RDB-PC_36BIT_defconfig                 |  1 +
+ configs/P1024RDB_36BIT_defconfig                    |  1 +
+ configs/P1025RDB_36BIT_defconfig                    |  1 +
+ configs/P2020RDB-PC_36BIT_NAND_defconfig            |  1 +
+ configs/P2020RDB-PC_36BIT_SDCARD_defconfig          |  1 +
+ configs/P2020RDB-PC_36BIT_SPIFLASH_defconfig        |  1 +
+ configs/P2020RDB-PC_36BIT_defconfig                 |  1 +
+ configs/P2041RDB_NAND_defconfig                     |  2 ++
+ configs/P2041RDB_SDCARD_defconfig                   |  2 ++
+ configs/P2041RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/P2041RDB_SPIFLASH_defconfig                 |  2 ++
+ configs/P2041RDB_SRIO_PCIE_BOOT_defconfig           |  2 ++
+ configs/P2041RDB_defconfig                          |  2 ++
+ configs/P3041DS_NAND_SECURE_BOOT_defconfig          |  2 ++
+ configs/P3041DS_NAND_defconfig                      |  2 ++
+ configs/P3041DS_SDCARD_defconfig                    |  2 ++
+ configs/P3041DS_SECURE_BOOT_defconfig               |  2 ++
+ configs/P3041DS_SPIFLASH_defconfig                  |  2 ++
+ configs/P3041DS_SRIO_PCIE_BOOT_defconfig            |  2 ++
+ configs/P3041DS_defconfig                           |  2 ++
+ configs/P4080DS_SDCARD_defconfig                    |  2 ++
+ configs/P4080DS_SECURE_BOOT_defconfig               |  2 ++
+ configs/P4080DS_SPIFLASH_defconfig                  |  2 ++
+ configs/P4080DS_SRIO_PCIE_BOOT_defconfig            |  2 ++
+ configs/P4080DS_defconfig                           |  2 ++
+ configs/P5020DS_NAND_SECURE_BOOT_defconfig          |  2 ++
+ configs/P5020DS_NAND_defconfig                      |  2 ++
+ configs/P5020DS_SDCARD_defconfig                    |  2 ++
+ configs/P5020DS_SECURE_BOOT_defconfig               |  2 ++
+ configs/P5020DS_SPIFLASH_defconfig                  |  2 ++
+ configs/P5020DS_SRIO_PCIE_BOOT_defconfig            |  2 ++
+ configs/P5020DS_defconfig                           |  2 ++
+ configs/P5040DS_NAND_SECURE_BOOT_defconfig          |  2 ++
+ configs/P5040DS_NAND_defconfig                      |  2 ++
+ configs/P5040DS_SDCARD_defconfig                    |  2 ++
+ configs/P5040DS_SECURE_BOOT_defconfig               |  2 ++
+ configs/P5040DS_SPIFLASH_defconfig                  |  2 ++
+ configs/P5040DS_defconfig                           |  2 ++
+ configs/T1023RDB_NAND_defconfig                     |  2 ++
+ configs/T1023RDB_SDCARD_defconfig                   |  2 ++
+ configs/T1023RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/T1023RDB_SPIFLASH_defconfig                 |  2 ++
+ configs/T1023RDB_defconfig                          |  2 ++
+ configs/T1024RDB_NAND_defconfig                     |  2 ++
+ configs/T1024RDB_SDCARD_defconfig                   |  2 ++
+ configs/T1024RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/T1024RDB_SPIFLASH_defconfig                 |  2 ++
+ configs/T1024RDB_defconfig                          |  2 ++
+ configs/T1040D4RDB_NAND_defconfig                   |  2 ++
+ configs/T1040D4RDB_SDCARD_defconfig                 |  2 ++
+ configs/T1040D4RDB_SECURE_BOOT_defconfig            |  2 ++
+ configs/T1040D4RDB_SPIFLASH_defconfig               |  2 ++
+ configs/T1040D4RDB_defconfig                        |  2 ++
+ configs/T1040RDB_NAND_defconfig                     |  2 ++
+ configs/T1040RDB_SDCARD_defconfig                   |  2 ++
+ configs/T1040RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/T1040RDB_SPIFLASH_defconfig                 |  2 ++
+ configs/T1040RDB_defconfig                          |  2 ++
+ configs/T1042D4RDB_NAND_defconfig                   |  2 ++
+ configs/T1042D4RDB_SDCARD_defconfig                 |  2 ++
+ configs/T1042D4RDB_SECURE_BOOT_defconfig            |  2 ++
+ configs/T1042D4RDB_SPIFLASH_defconfig               |  2 ++
+ configs/T1042D4RDB_defconfig                        |  2 ++
+ configs/T1042RDB_PI_NAND_SECURE_BOOT_defconfig      |  2 ++
+ configs/T1042RDB_PI_NAND_defconfig                  |  2 ++
+ configs/T1042RDB_PI_SDCARD_defconfig                |  2 ++
+ configs/T1042RDB_PI_SPIFLASH_defconfig              |  2 ++
+ configs/T1042RDB_PI_defconfig                       |  2 ++
+ configs/T1042RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/T1042RDB_defconfig                          |  2 ++
+ configs/T2080QDS_NAND_defconfig                     |  2 ++
+ configs/T2080QDS_SDCARD_defconfig                   |  2 ++
+ configs/T2080QDS_SECURE_BOOT_defconfig              |  2 ++
+ configs/T2080QDS_SPIFLASH_defconfig                 |  2 ++
+ configs/T2080QDS_SRIO_PCIE_BOOT_defconfig           |  2 ++
+ configs/T2080QDS_defconfig                          |  2 ++
+ configs/T2080RDB_NAND_defconfig                     |  2 ++
+ configs/T2080RDB_SDCARD_defconfig                   |  2 ++
+ configs/T2080RDB_SECURE_BOOT_defconfig              |  2 ++
+ configs/T2080RDB_SPIFLASH_defconfig                 |  2 ++
+ configs/T2080RDB_SRIO_PCIE_BOOT_defconfig           |  2 ++
+ configs/T2080RDB_defconfig                          |  2 ++
+ configs/T2081QDS_NAND_defconfig                     |  2 ++
+ configs/T2081QDS_SDCARD_defconfig                   |  2 ++
+ configs/T2081QDS_SPIFLASH_defconfig                 |  2 ++
+ configs/T2081QDS_SRIO_PCIE_BOOT_defconfig           |  2 ++
+ configs/T2081QDS_defconfig                          |  2 ++
+ configs/T4160RDB_defconfig                          |  2 ++
+ configs/T4240RDB_SDCARD_defconfig                   |  2 ++
+ configs/T4240RDB_defconfig                          |  2 ++
+ .../controlcenterd_36BIT_SDCARD_DEVELOP_defconfig   |  1 +
+ configs/controlcenterd_36BIT_SDCARD_defconfig       |  1 +
+ configs/kmcoge4_defconfig                           |  2 ++
+ configs/qemu-ppce500_defconfig                      |  1 +
+ include/configs/MPC8548CDS.h                        |  5 -----
+ include/configs/MPC8572DS.h                         |  5 -----
+ include/configs/MPC8641HPCN.h                       |  2 --
+ include/configs/P1010RDB.h                          |  5 -----
+ include/configs/P2041RDB.h                          |  5 -----
+ include/configs/T102xRDB.h                          |  5 -----
+ include/configs/T104xRDB.h                          |  3 ---
+ include/configs/T208xQDS.h                          |  5 -----
+ include/configs/T208xRDB.h                          |  5 -----
+ include/configs/T4240RDB.h                          |  3 ---
+ include/configs/controlcenterd.h                    |  5 -----
+ include/configs/corenet_ds.h                        |  5 -----
+ include/configs/cyrus.h                             |  5 -----
+ include/configs/kmp204x.h                           |  3 ---
+ include/configs/p1_p2_rdb_pc.h                      |  5 -----
+ include/configs/qemu-ppce500.h                      |  3 ---
+ include/configs/t4qds.h                             |  3 ---
+ lib/Kconfig                                         | 13 +++++++++++++
+ scripts/config_whitelist.txt                        |  2 --
+ 144 files changed, 226 insertions(+), 74 deletions(-)
+
+diff --git a/configs/Cyrus_P5020_defconfig b/configs/Cyrus_P5020_defconfig
+index 19fc741eb7..d7798ef3aa 100644
+--- a/configs/Cyrus_P5020_defconfig
++++ b/configs/Cyrus_P5020_defconfig
+@@ -42,4 +42,6 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_KEYBOARD=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/Cyrus_P5040_defconfig b/configs/Cyrus_P5040_defconfig
+index 9c6919f387..39191debdf 100644
+--- a/configs/Cyrus_P5040_defconfig
++++ b/configs/Cyrus_P5040_defconfig
+@@ -42,4 +42,6 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_KEYBOARD=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/MPC8548CDS_36BIT_defconfig b/configs/MPC8548CDS_36BIT_defconfig
+index 010e375740..6884754cac 100644
+--- a/configs/MPC8548CDS_36BIT_defconfig
++++ b/configs/MPC8548CDS_36BIT_defconfig
+@@ -46,3 +46,4 @@ CONFIG_DM_PCI_COMPAT=y
+ CONFIG_PCIE_FSL=y
+ CONFIG_CONS_INDEX=2
+ CONFIG_SYS_NS16550=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/MPC8572DS_36BIT_defconfig b/configs/MPC8572DS_36BIT_defconfig
+index 50912bf245..4053cb70f8 100644
+--- a/configs/MPC8572DS_36BIT_defconfig
++++ b/configs/MPC8572DS_36BIT_defconfig
+@@ -51,4 +51,5 @@ CONFIG_USB=y
+ CONFIG_USB_EHCI_PCI=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/MPC8641HPCN_36BIT_defconfig b/configs/MPC8641HPCN_36BIT_defconfig
+index 1e643673ec..c75e665ad9 100644
+--- a/configs/MPC8641HPCN_36BIT_defconfig
++++ b/configs/MPC8641HPCN_36BIT_defconfig
+@@ -42,4 +42,6 @@ CONFIG_SYS_NS16550=y
+ CONFIG_USB=y
+ CONFIG_USB_KEYBOARD=y
+ CONFIG_VIDEO=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=8
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/MPC8641HPCN_defconfig b/configs/MPC8641HPCN_defconfig
+index 7ce7891d14..b60813d048 100644
+--- a/configs/MPC8641HPCN_defconfig
++++ b/configs/MPC8641HPCN_defconfig
+@@ -42,4 +42,6 @@ CONFIG_SYS_NS16550=y
+ CONFIG_USB=y
+ CONFIG_USB_KEYBOARD=y
+ CONFIG_VIDEO=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=8
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1010RDB-PA_36BIT_NAND_SECBOOT_defconfig b/configs/P1010RDB-PA_36BIT_NAND_SECBOOT_defconfig
+index c1044520d7..c4066672d5 100644
+--- a/configs/P1010RDB-PA_36BIT_NAND_SECBOOT_defconfig
++++ b/configs/P1010RDB-PA_36BIT_NAND_SECBOOT_defconfig
+@@ -57,6 +57,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PA_36BIT_NAND_defconfig b/configs/P1010RDB-PA_36BIT_NAND_defconfig
+index 86c90dac27..a5ffbda7e4 100644
+--- a/configs/P1010RDB-PA_36BIT_NAND_defconfig
++++ b/configs/P1010RDB-PA_36BIT_NAND_defconfig
+@@ -83,3 +83,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PA_36BIT_NOR_SECBOOT_defconfig b/configs/P1010RDB-PA_36BIT_NOR_SECBOOT_defconfig
+index 723f6ca2bb..c3cfaf1a73 100644
+--- a/configs/P1010RDB-PA_36BIT_NOR_SECBOOT_defconfig
++++ b/configs/P1010RDB-PA_36BIT_NOR_SECBOOT_defconfig
+@@ -56,6 +56,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PA_36BIT_NOR_defconfig b/configs/P1010RDB-PA_36BIT_NOR_defconfig
+index e6edd395e7..5a2dcaeea2 100644
+--- a/configs/P1010RDB-PA_36BIT_NOR_defconfig
++++ b/configs/P1010RDB-PA_36BIT_NOR_defconfig
+@@ -65,3 +65,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PA_36BIT_SDCARD_defconfig b/configs/P1010RDB-PA_36BIT_SDCARD_defconfig
+index 2850e305f0..c8c7bedf5a 100644
+--- a/configs/P1010RDB-PA_36BIT_SDCARD_defconfig
++++ b/configs/P1010RDB-PA_36BIT_SDCARD_defconfig
+@@ -77,3 +77,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PA_36BIT_SPIFLASH_SECBOOT_defconfig b/configs/P1010RDB-PA_36BIT_SPIFLASH_SECBOOT_defconfig
+index 9987cde995..8a13e3a622 100644
+--- a/configs/P1010RDB-PA_36BIT_SPIFLASH_SECBOOT_defconfig
++++ b/configs/P1010RDB-PA_36BIT_SPIFLASH_SECBOOT_defconfig
+@@ -58,6 +58,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PA_36BIT_SPIFLASH_defconfig b/configs/P1010RDB-PA_36BIT_SPIFLASH_defconfig
+index 98ad4b6109..2aa476ca69 100644
+--- a/configs/P1010RDB-PA_36BIT_SPIFLASH_defconfig
++++ b/configs/P1010RDB-PA_36BIT_SPIFLASH_defconfig
+@@ -79,3 +79,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PB_36BIT_NAND_SECBOOT_defconfig b/configs/P1010RDB-PB_36BIT_NAND_SECBOOT_defconfig
+index 66bdebbf99..1f2e969cce 100644
+--- a/configs/P1010RDB-PB_36BIT_NAND_SECBOOT_defconfig
++++ b/configs/P1010RDB-PB_36BIT_NAND_SECBOOT_defconfig
+@@ -57,6 +57,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PB_36BIT_NAND_defconfig b/configs/P1010RDB-PB_36BIT_NAND_defconfig
+index bd779aacf6..25fb606ef4 100644
+--- a/configs/P1010RDB-PB_36BIT_NAND_defconfig
++++ b/configs/P1010RDB-PB_36BIT_NAND_defconfig
+@@ -83,3 +83,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PB_36BIT_NOR_SECBOOT_defconfig b/configs/P1010RDB-PB_36BIT_NOR_SECBOOT_defconfig
+index f2e40668ea..bbaec2beee 100644
+--- a/configs/P1010RDB-PB_36BIT_NOR_SECBOOT_defconfig
++++ b/configs/P1010RDB-PB_36BIT_NOR_SECBOOT_defconfig
+@@ -56,6 +56,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PB_36BIT_NOR_defconfig b/configs/P1010RDB-PB_36BIT_NOR_defconfig
+index e85af32e2c..58f4430e80 100644
+--- a/configs/P1010RDB-PB_36BIT_NOR_defconfig
++++ b/configs/P1010RDB-PB_36BIT_NOR_defconfig
+@@ -65,3 +65,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PB_36BIT_SDCARD_defconfig b/configs/P1010RDB-PB_36BIT_SDCARD_defconfig
+index 8559ffe3f3..137f613158 100644
+--- a/configs/P1010RDB-PB_36BIT_SDCARD_defconfig
++++ b/configs/P1010RDB-PB_36BIT_SDCARD_defconfig
+@@ -77,3 +77,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1010RDB-PB_36BIT_SPIFLASH_SECBOOT_defconfig b/configs/P1010RDB-PB_36BIT_SPIFLASH_SECBOOT_defconfig
+index 50b5c5f1c5..63ac2f2b17 100644
+--- a/configs/P1010RDB-PB_36BIT_SPIFLASH_SECBOOT_defconfig
++++ b/configs/P1010RDB-PB_36BIT_SPIFLASH_SECBOOT_defconfig
+@@ -58,6 +58,7 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P1010RDB-PB_36BIT_SPIFLASH_defconfig b/configs/P1010RDB-PB_36BIT_SPIFLASH_defconfig
+index fe503c1a6b..493597ee01 100644
+--- a/configs/P1010RDB-PB_36BIT_SPIFLASH_defconfig
++++ b/configs/P1010RDB-PB_36BIT_SPIFLASH_defconfig
+@@ -79,3 +79,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1020MBG-PC_36BIT_SDCARD_defconfig b/configs/P1020MBG-PC_36BIT_SDCARD_defconfig
+index a9befd2e3f..1178c27599 100644
+--- a/configs/P1020MBG-PC_36BIT_SDCARD_defconfig
++++ b/configs/P1020MBG-PC_36BIT_SDCARD_defconfig
+@@ -64,4 +64,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1020MBG-PC_36BIT_defconfig b/configs/P1020MBG-PC_36BIT_defconfig
+index 7930af3b73..2385da49f6 100644
+--- a/configs/P1020MBG-PC_36BIT_defconfig
++++ b/configs/P1020MBG-PC_36BIT_defconfig
+@@ -52,4 +52,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1020RDB-PC_36BIT_NAND_defconfig b/configs/P1020RDB-PC_36BIT_NAND_defconfig
+index c148f4d592..00f9fb58a0 100644
+--- a/configs/P1020RDB-PC_36BIT_NAND_defconfig
++++ b/configs/P1020RDB-PC_36BIT_NAND_defconfig
+@@ -83,3 +83,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1020RDB-PC_36BIT_SDCARD_defconfig b/configs/P1020RDB-PC_36BIT_SDCARD_defconfig
+index 7b40858de7..7ffac2e1f4 100644
+--- a/configs/P1020RDB-PC_36BIT_SDCARD_defconfig
++++ b/configs/P1020RDB-PC_36BIT_SDCARD_defconfig
+@@ -78,3 +78,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1020RDB-PC_36BIT_SPIFLASH_defconfig b/configs/P1020RDB-PC_36BIT_SPIFLASH_defconfig
+index 7a7ae29bd7..b8e5e333c6 100644
+--- a/configs/P1020RDB-PC_36BIT_SPIFLASH_defconfig
++++ b/configs/P1020RDB-PC_36BIT_SPIFLASH_defconfig
+@@ -80,3 +80,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1020RDB-PC_36BIT_defconfig b/configs/P1020RDB-PC_36BIT_defconfig
+index f9a4b735ca..850a1525f4 100644
+--- a/configs/P1020RDB-PC_36BIT_defconfig
++++ b/configs/P1020RDB-PC_36BIT_defconfig
+@@ -67,3 +67,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P1020UTM-PC_36BIT_SDCARD_defconfig b/configs/P1020UTM-PC_36BIT_SDCARD_defconfig
+index a24f14a97f..36bb136c1b 100644
+--- a/configs/P1020UTM-PC_36BIT_SDCARD_defconfig
++++ b/configs/P1020UTM-PC_36BIT_SDCARD_defconfig
+@@ -64,4 +64,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1020UTM-PC_36BIT_defconfig b/configs/P1020UTM-PC_36BIT_defconfig
+index 968d3edbcf..47232d95e1 100644
+--- a/configs/P1020UTM-PC_36BIT_defconfig
++++ b/configs/P1020UTM-PC_36BIT_defconfig
+@@ -52,4 +52,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1021RDB-PC_36BIT_NAND_defconfig b/configs/P1021RDB-PC_36BIT_NAND_defconfig
+index 353f4677f2..873243825e 100644
+--- a/configs/P1021RDB-PC_36BIT_NAND_defconfig
++++ b/configs/P1021RDB-PC_36BIT_NAND_defconfig
+@@ -81,4 +81,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1021RDB-PC_36BIT_SDCARD_defconfig b/configs/P1021RDB-PC_36BIT_SDCARD_defconfig
+index 62cbbc016a..66c37f9407 100644
+--- a/configs/P1021RDB-PC_36BIT_SDCARD_defconfig
++++ b/configs/P1021RDB-PC_36BIT_SDCARD_defconfig
+@@ -76,4 +76,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1021RDB-PC_36BIT_SPIFLASH_defconfig b/configs/P1021RDB-PC_36BIT_SPIFLASH_defconfig
+index 7f71b52477..eaf45a6f3e 100644
+--- a/configs/P1021RDB-PC_36BIT_SPIFLASH_defconfig
++++ b/configs/P1021RDB-PC_36BIT_SPIFLASH_defconfig
+@@ -78,4 +78,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1021RDB-PC_36BIT_defconfig b/configs/P1021RDB-PC_36BIT_defconfig
+index ca1be9c112..608a6d10b1 100644
+--- a/configs/P1021RDB-PC_36BIT_defconfig
++++ b/configs/P1021RDB-PC_36BIT_defconfig
+@@ -64,4 +64,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1024RDB_36BIT_defconfig b/configs/P1024RDB_36BIT_defconfig
+index 5116fac64a..bb016af45e 100644
+--- a/configs/P1024RDB_36BIT_defconfig
++++ b/configs/P1024RDB_36BIT_defconfig
+@@ -58,4 +58,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P1025RDB_36BIT_defconfig b/configs/P1025RDB_36BIT_defconfig
+index 8eaddb1290..c096593c18 100644
+--- a/configs/P1025RDB_36BIT_defconfig
++++ b/configs/P1025RDB_36BIT_defconfig
+@@ -60,4 +60,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P2020RDB-PC_36BIT_NAND_defconfig b/configs/P2020RDB-PC_36BIT_NAND_defconfig
+index dff2afa344..13f16ef246 100644
+--- a/configs/P2020RDB-PC_36BIT_NAND_defconfig
++++ b/configs/P2020RDB-PC_36BIT_NAND_defconfig
+@@ -88,3 +88,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P2020RDB-PC_36BIT_SDCARD_defconfig b/configs/P2020RDB-PC_36BIT_SDCARD_defconfig
+index 700fabeef1..c11c304d8d 100644
+--- a/configs/P2020RDB-PC_36BIT_SDCARD_defconfig
++++ b/configs/P2020RDB-PC_36BIT_SDCARD_defconfig
+@@ -83,3 +83,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P2020RDB-PC_36BIT_SPIFLASH_defconfig b/configs/P2020RDB-PC_36BIT_SPIFLASH_defconfig
+index 6b6ab7e57d..2ea28e734c 100644
+--- a/configs/P2020RDB-PC_36BIT_SPIFLASH_defconfig
++++ b/configs/P2020RDB-PC_36BIT_SPIFLASH_defconfig
+@@ -85,3 +85,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P2020RDB-PC_36BIT_defconfig b/configs/P2020RDB-PC_36BIT_defconfig
+index 88e24c30ba..1140177bdd 100644
+--- a/configs/P2020RDB-PC_36BIT_defconfig
++++ b/configs/P2020RDB-PC_36BIT_defconfig
+@@ -72,3 +72,4 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
+diff --git a/configs/P2041RDB_NAND_defconfig b/configs/P2041RDB_NAND_defconfig
+index 4670d823c2..af48fc5e98 100644
+--- a/configs/P2041RDB_NAND_defconfig
++++ b/configs/P2041RDB_NAND_defconfig
+@@ -65,3 +65,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P2041RDB_SDCARD_defconfig b/configs/P2041RDB_SDCARD_defconfig
+index dc23e107b8..0fa5caa54b 100644
+--- a/configs/P2041RDB_SDCARD_defconfig
++++ b/configs/P2041RDB_SDCARD_defconfig
+@@ -64,3 +64,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P2041RDB_SECURE_BOOT_defconfig b/configs/P2041RDB_SECURE_BOOT_defconfig
+index 35a9d00e4b..e1b2ee0652 100644
+--- a/configs/P2041RDB_SECURE_BOOT_defconfig
++++ b/configs/P2041RDB_SECURE_BOOT_defconfig
+@@ -54,6 +54,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P2041RDB_SPIFLASH_defconfig b/configs/P2041RDB_SPIFLASH_defconfig
+index bf8d9a2381..99611caf3b 100644
+--- a/configs/P2041RDB_SPIFLASH_defconfig
++++ b/configs/P2041RDB_SPIFLASH_defconfig
+@@ -65,3 +65,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P2041RDB_SRIO_PCIE_BOOT_defconfig b/configs/P2041RDB_SRIO_PCIE_BOOT_defconfig
+index dd5f2a4fc0..2832a86e54 100644
+--- a/configs/P2041RDB_SRIO_PCIE_BOOT_defconfig
++++ b/configs/P2041RDB_SRIO_PCIE_BOOT_defconfig
+@@ -47,4 +47,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P2041RDB_defconfig b/configs/P2041RDB_defconfig
+index bbf6ea61a3..cd05a7ae82 100644
+--- a/configs/P2041RDB_defconfig
++++ b/configs/P2041RDB_defconfig
+@@ -63,3 +63,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P3041DS_NAND_SECURE_BOOT_defconfig b/configs/P3041DS_NAND_SECURE_BOOT_defconfig
+index 8ab25373c9..c14a05b644 100644
+--- a/configs/P3041DS_NAND_SECURE_BOOT_defconfig
++++ b/configs/P3041DS_NAND_SECURE_BOOT_defconfig
+@@ -53,6 +53,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P3041DS_NAND_defconfig b/configs/P3041DS_NAND_defconfig
+index 55613ccacd..f774e1f635 100644
+--- a/configs/P3041DS_NAND_defconfig
++++ b/configs/P3041DS_NAND_defconfig
+@@ -62,3 +62,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P3041DS_SDCARD_defconfig b/configs/P3041DS_SDCARD_defconfig
+index b52068d050..89678ea1ef 100644
+--- a/configs/P3041DS_SDCARD_defconfig
++++ b/configs/P3041DS_SDCARD_defconfig
+@@ -61,3 +61,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P3041DS_SECURE_BOOT_defconfig b/configs/P3041DS_SECURE_BOOT_defconfig
+index d6cabebeb7..afb1aec5cc 100644
+--- a/configs/P3041DS_SECURE_BOOT_defconfig
++++ b/configs/P3041DS_SECURE_BOOT_defconfig
+@@ -51,6 +51,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P3041DS_SPIFLASH_defconfig b/configs/P3041DS_SPIFLASH_defconfig
+index 3af52b90e8..a5d881aa28 100644
+--- a/configs/P3041DS_SPIFLASH_defconfig
++++ b/configs/P3041DS_SPIFLASH_defconfig
+@@ -62,3 +62,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P3041DS_SRIO_PCIE_BOOT_defconfig b/configs/P3041DS_SRIO_PCIE_BOOT_defconfig
+index c34311b2f9..6c7b951654 100644
+--- a/configs/P3041DS_SRIO_PCIE_BOOT_defconfig
++++ b/configs/P3041DS_SRIO_PCIE_BOOT_defconfig
+@@ -47,4 +47,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P3041DS_defconfig b/configs/P3041DS_defconfig
+index cc3234c6b1..0a766c89f3 100644
+--- a/configs/P3041DS_defconfig
++++ b/configs/P3041DS_defconfig
+@@ -60,3 +60,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P4080DS_SDCARD_defconfig b/configs/P4080DS_SDCARD_defconfig
+index 18ad56ac8d..c0d184e58f 100644
+--- a/configs/P4080DS_SDCARD_defconfig
++++ b/configs/P4080DS_SDCARD_defconfig
+@@ -60,3 +60,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P4080DS_SECURE_BOOT_defconfig b/configs/P4080DS_SECURE_BOOT_defconfig
+index 22a6ebe89c..e4d494bdf9 100644
+--- a/configs/P4080DS_SECURE_BOOT_defconfig
++++ b/configs/P4080DS_SECURE_BOOT_defconfig
+@@ -50,6 +50,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P4080DS_SPIFLASH_defconfig b/configs/P4080DS_SPIFLASH_defconfig
+index 81a513bec9..f171d7cb21 100644
+--- a/configs/P4080DS_SPIFLASH_defconfig
++++ b/configs/P4080DS_SPIFLASH_defconfig
+@@ -61,3 +61,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P4080DS_SRIO_PCIE_BOOT_defconfig b/configs/P4080DS_SRIO_PCIE_BOOT_defconfig
+index a740bc4a7b..46aee4dee9 100644
+--- a/configs/P4080DS_SRIO_PCIE_BOOT_defconfig
++++ b/configs/P4080DS_SRIO_PCIE_BOOT_defconfig
+@@ -45,4 +45,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P4080DS_defconfig b/configs/P4080DS_defconfig
+index 52db2e06c7..2980020d3e 100644
+--- a/configs/P4080DS_defconfig
++++ b/configs/P4080DS_defconfig
+@@ -59,3 +59,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P5020DS_NAND_SECURE_BOOT_defconfig b/configs/P5020DS_NAND_SECURE_BOOT_defconfig
+index 52efa92009..5f0c597cef 100644
+--- a/configs/P5020DS_NAND_SECURE_BOOT_defconfig
++++ b/configs/P5020DS_NAND_SECURE_BOOT_defconfig
+@@ -54,6 +54,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P5020DS_NAND_defconfig b/configs/P5020DS_NAND_defconfig
+index baf7d835bc..b711f3bcc2 100644
+--- a/configs/P5020DS_NAND_defconfig
++++ b/configs/P5020DS_NAND_defconfig
+@@ -54,4 +54,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P5020DS_SDCARD_defconfig b/configs/P5020DS_SDCARD_defconfig
+index c5b424145c..b459047780 100644
+--- a/configs/P5020DS_SDCARD_defconfig
++++ b/configs/P5020DS_SDCARD_defconfig
+@@ -52,4 +52,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P5020DS_SECURE_BOOT_defconfig b/configs/P5020DS_SECURE_BOOT_defconfig
+index c08f9fffa6..79e8cc9bfa 100644
+--- a/configs/P5020DS_SECURE_BOOT_defconfig
++++ b/configs/P5020DS_SECURE_BOOT_defconfig
+@@ -51,6 +51,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P5020DS_SPIFLASH_defconfig b/configs/P5020DS_SPIFLASH_defconfig
+index 03d7a16a6d..3777c1d2d0 100644
+--- a/configs/P5020DS_SPIFLASH_defconfig
++++ b/configs/P5020DS_SPIFLASH_defconfig
+@@ -53,4 +53,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P5020DS_SRIO_PCIE_BOOT_defconfig b/configs/P5020DS_SRIO_PCIE_BOOT_defconfig
+index 7569364252..9b7cb68878 100644
+--- a/configs/P5020DS_SRIO_PCIE_BOOT_defconfig
++++ b/configs/P5020DS_SRIO_PCIE_BOOT_defconfig
+@@ -47,4 +47,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P5020DS_defconfig b/configs/P5020DS_defconfig
+index a1b410c7b6..77fcf26e55 100644
+--- a/configs/P5020DS_defconfig
++++ b/configs/P5020DS_defconfig
+@@ -51,4 +51,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/P5040DS_NAND_SECURE_BOOT_defconfig b/configs/P5040DS_NAND_SECURE_BOOT_defconfig
+index beab855eae..782b027ef3 100644
+--- a/configs/P5040DS_NAND_SECURE_BOOT_defconfig
++++ b/configs/P5040DS_NAND_SECURE_BOOT_defconfig
+@@ -54,6 +54,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P5040DS_NAND_defconfig b/configs/P5040DS_NAND_defconfig
+index efffb706fb..35584e251e 100644
+--- a/configs/P5040DS_NAND_defconfig
++++ b/configs/P5040DS_NAND_defconfig
+@@ -63,3 +63,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P5040DS_SDCARD_defconfig b/configs/P5040DS_SDCARD_defconfig
+index fdd39acbaf..91c02855fb 100644
+--- a/configs/P5040DS_SDCARD_defconfig
++++ b/configs/P5040DS_SDCARD_defconfig
+@@ -61,3 +61,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P5040DS_SECURE_BOOT_defconfig b/configs/P5040DS_SECURE_BOOT_defconfig
+index 5d48206dc8..34e024af13 100644
+--- a/configs/P5040DS_SECURE_BOOT_defconfig
++++ b/configs/P5040DS_SECURE_BOOT_defconfig
+@@ -51,6 +51,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/P5040DS_SPIFLASH_defconfig b/configs/P5040DS_SPIFLASH_defconfig
+index 3f4642f4e0..49a2b93066 100644
+--- a/configs/P5040DS_SPIFLASH_defconfig
++++ b/configs/P5040DS_SPIFLASH_defconfig
+@@ -62,3 +62,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/P5040DS_defconfig b/configs/P5040DS_defconfig
+index d2a2e02dcd..a797088d7c 100644
+--- a/configs/P5040DS_defconfig
++++ b/configs/P5040DS_defconfig
+@@ -60,3 +60,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1023RDB_NAND_defconfig b/configs/T1023RDB_NAND_defconfig
+index 385dcb3947..2a544d78cf 100644
+--- a/configs/T1023RDB_NAND_defconfig
++++ b/configs/T1023RDB_NAND_defconfig
+@@ -74,4 +74,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1023RDB_SDCARD_defconfig b/configs/T1023RDB_SDCARD_defconfig
+index 825ab47f93..641b3929a3 100644
+--- a/configs/T1023RDB_SDCARD_defconfig
++++ b/configs/T1023RDB_SDCARD_defconfig
+@@ -71,4 +71,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1023RDB_SECURE_BOOT_defconfig b/configs/T1023RDB_SECURE_BOOT_defconfig
+index 34fe6e5e52..a9c9794410 100644
+--- a/configs/T1023RDB_SECURE_BOOT_defconfig
++++ b/configs/T1023RDB_SECURE_BOOT_defconfig
+@@ -58,6 +58,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1023RDB_SPIFLASH_defconfig b/configs/T1023RDB_SPIFLASH_defconfig
+index d537047d60..e30695e027 100644
+--- a/configs/T1023RDB_SPIFLASH_defconfig
++++ b/configs/T1023RDB_SPIFLASH_defconfig
+@@ -74,4 +74,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1023RDB_defconfig b/configs/T1023RDB_defconfig
+index 62cc129a31..3366ff0201 100644
+--- a/configs/T1023RDB_defconfig
++++ b/configs/T1023RDB_defconfig
+@@ -58,4 +58,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1024RDB_NAND_defconfig b/configs/T1024RDB_NAND_defconfig
+index 0d38d6656f..2c5ae11e58 100644
+--- a/configs/T1024RDB_NAND_defconfig
++++ b/configs/T1024RDB_NAND_defconfig
+@@ -87,3 +87,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1024RDB_SDCARD_defconfig b/configs/T1024RDB_SDCARD_defconfig
+index d091d7c0ad..f9bf5acab1 100644
+--- a/configs/T1024RDB_SDCARD_defconfig
++++ b/configs/T1024RDB_SDCARD_defconfig
+@@ -84,3 +84,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1024RDB_SECURE_BOOT_defconfig b/configs/T1024RDB_SECURE_BOOT_defconfig
+index fe3d28b373..bbcf145a08 100644
+--- a/configs/T1024RDB_SECURE_BOOT_defconfig
++++ b/configs/T1024RDB_SECURE_BOOT_defconfig
+@@ -63,6 +63,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1024RDB_SPIFLASH_defconfig b/configs/T1024RDB_SPIFLASH_defconfig
+index cab645dfb2..d550959220 100644
+--- a/configs/T1024RDB_SPIFLASH_defconfig
++++ b/configs/T1024RDB_SPIFLASH_defconfig
+@@ -87,3 +87,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1024RDB_defconfig b/configs/T1024RDB_defconfig
+index 46c857d6c5..20e85c12d2 100644
+--- a/configs/T1024RDB_defconfig
++++ b/configs/T1024RDB_defconfig
+@@ -72,3 +72,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1040D4RDB_NAND_defconfig b/configs/T1040D4RDB_NAND_defconfig
+index 21875e6c15..17664daa1b 100644
+--- a/configs/T1040D4RDB_NAND_defconfig
++++ b/configs/T1040D4RDB_NAND_defconfig
+@@ -72,4 +72,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040D4RDB_SDCARD_defconfig b/configs/T1040D4RDB_SDCARD_defconfig
+index 07c4974c96..72440c61ef 100644
+--- a/configs/T1040D4RDB_SDCARD_defconfig
++++ b/configs/T1040D4RDB_SDCARD_defconfig
+@@ -69,4 +69,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040D4RDB_SECURE_BOOT_defconfig b/configs/T1040D4RDB_SECURE_BOOT_defconfig
+index 7adffb73ea..01fa29c1db 100644
+--- a/configs/T1040D4RDB_SECURE_BOOT_defconfig
++++ b/configs/T1040D4RDB_SECURE_BOOT_defconfig
+@@ -55,6 +55,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1040D4RDB_SPIFLASH_defconfig b/configs/T1040D4RDB_SPIFLASH_defconfig
+index 8979ebf4b4..8abc3f74b7 100644
+--- a/configs/T1040D4RDB_SPIFLASH_defconfig
++++ b/configs/T1040D4RDB_SPIFLASH_defconfig
+@@ -72,4 +72,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040D4RDB_defconfig b/configs/T1040D4RDB_defconfig
+index eb25930ff7..dcf3dce0ee 100644
+--- a/configs/T1040D4RDB_defconfig
++++ b/configs/T1040D4RDB_defconfig
+@@ -56,4 +56,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040RDB_NAND_defconfig b/configs/T1040RDB_NAND_defconfig
+index b2c07d5f67..f08e03f424 100644
+--- a/configs/T1040RDB_NAND_defconfig
++++ b/configs/T1040RDB_NAND_defconfig
+@@ -73,4 +73,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040RDB_SDCARD_defconfig b/configs/T1040RDB_SDCARD_defconfig
+index 2c64794650..047fca3d02 100644
+--- a/configs/T1040RDB_SDCARD_defconfig
++++ b/configs/T1040RDB_SDCARD_defconfig
+@@ -70,4 +70,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040RDB_SECURE_BOOT_defconfig b/configs/T1040RDB_SECURE_BOOT_defconfig
+index 910b984f47..aa22883e54 100644
+--- a/configs/T1040RDB_SECURE_BOOT_defconfig
++++ b/configs/T1040RDB_SECURE_BOOT_defconfig
+@@ -56,6 +56,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1040RDB_SPIFLASH_defconfig b/configs/T1040RDB_SPIFLASH_defconfig
+index a7f9f7db19..19a0a8f8db 100644
+--- a/configs/T1040RDB_SPIFLASH_defconfig
++++ b/configs/T1040RDB_SPIFLASH_defconfig
+@@ -73,4 +73,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1040RDB_defconfig b/configs/T1040RDB_defconfig
+index e8c5393b18..56d61ae93e 100644
+--- a/configs/T1040RDB_defconfig
++++ b/configs/T1040RDB_defconfig
+@@ -57,4 +57,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1042D4RDB_NAND_defconfig b/configs/T1042D4RDB_NAND_defconfig
+index f607973fcc..855f9a49d3 100644
+--- a/configs/T1042D4RDB_NAND_defconfig
++++ b/configs/T1042D4RDB_NAND_defconfig
+@@ -84,3 +84,5 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1042D4RDB_SDCARD_defconfig b/configs/T1042D4RDB_SDCARD_defconfig
+index e31d95aed9..81362a8ea9 100644
+--- a/configs/T1042D4RDB_SDCARD_defconfig
++++ b/configs/T1042D4RDB_SDCARD_defconfig
+@@ -81,3 +81,5 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1042D4RDB_SECURE_BOOT_defconfig b/configs/T1042D4RDB_SECURE_BOOT_defconfig
+index f460b17e4d..b9adcc0053 100644
+--- a/configs/T1042D4RDB_SECURE_BOOT_defconfig
++++ b/configs/T1042D4RDB_SECURE_BOOT_defconfig
+@@ -58,6 +58,8 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1042D4RDB_SPIFLASH_defconfig b/configs/T1042D4RDB_SPIFLASH_defconfig
+index 11bbdb4321..e5e4fea1c5 100644
+--- a/configs/T1042D4RDB_SPIFLASH_defconfig
++++ b/configs/T1042D4RDB_SPIFLASH_defconfig
+@@ -84,3 +84,5 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1042D4RDB_defconfig b/configs/T1042D4RDB_defconfig
+index 70ddffb3a7..2c6e8d00c1 100644
+--- a/configs/T1042D4RDB_defconfig
++++ b/configs/T1042D4RDB_defconfig
+@@ -69,3 +69,5 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T1042RDB_PI_NAND_SECURE_BOOT_defconfig b/configs/T1042RDB_PI_NAND_SECURE_BOOT_defconfig
+index a6878f5626..ffb65d2278 100644
+--- a/configs/T1042RDB_PI_NAND_SECURE_BOOT_defconfig
++++ b/configs/T1042RDB_PI_NAND_SECURE_BOOT_defconfig
+@@ -79,6 +79,8 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1042RDB_PI_NAND_defconfig b/configs/T1042RDB_PI_NAND_defconfig
+index 5585517757..a048862a8d 100644
+--- a/configs/T1042RDB_PI_NAND_defconfig
++++ b/configs/T1042RDB_PI_NAND_defconfig
+@@ -77,4 +77,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1042RDB_PI_SDCARD_defconfig b/configs/T1042RDB_PI_SDCARD_defconfig
+index 4aadd90c7a..12e96a09ec 100644
+--- a/configs/T1042RDB_PI_SDCARD_defconfig
++++ b/configs/T1042RDB_PI_SDCARD_defconfig
+@@ -74,4 +74,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1042RDB_PI_SPIFLASH_defconfig b/configs/T1042RDB_PI_SPIFLASH_defconfig
+index b8a96cc173..56173ebaf0 100644
+--- a/configs/T1042RDB_PI_SPIFLASH_defconfig
++++ b/configs/T1042RDB_PI_SPIFLASH_defconfig
+@@ -77,4 +77,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1042RDB_PI_defconfig b/configs/T1042RDB_PI_defconfig
+index 07ad865b6e..4a9e5348ee 100644
+--- a/configs/T1042RDB_PI_defconfig
++++ b/configs/T1042RDB_PI_defconfig
+@@ -61,4 +61,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T1042RDB_SECURE_BOOT_defconfig b/configs/T1042RDB_SECURE_BOOT_defconfig
+index c5f39e82f6..2633b830ef 100644
+--- a/configs/T1042RDB_SECURE_BOOT_defconfig
++++ b/configs/T1042RDB_SECURE_BOOT_defconfig
+@@ -55,6 +55,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T1042RDB_defconfig b/configs/T1042RDB_defconfig
+index c94730d79b..0755a95d10 100644
+--- a/configs/T1042RDB_defconfig
++++ b/configs/T1042RDB_defconfig
+@@ -56,4 +56,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2080QDS_NAND_defconfig b/configs/T2080QDS_NAND_defconfig
+index 1de486f64b..d088e1189a 100644
+--- a/configs/T2080QDS_NAND_defconfig
++++ b/configs/T2080QDS_NAND_defconfig
+@@ -81,3 +81,5 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080QDS_SDCARD_defconfig b/configs/T2080QDS_SDCARD_defconfig
+index 0e2dce224d..c12a651eab 100644
+--- a/configs/T2080QDS_SDCARD_defconfig
++++ b/configs/T2080QDS_SDCARD_defconfig
+@@ -78,3 +78,5 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080QDS_SECURE_BOOT_defconfig b/configs/T2080QDS_SECURE_BOOT_defconfig
+index 9b3f709c87..35891cc01a 100644
+--- a/configs/T2080QDS_SECURE_BOOT_defconfig
++++ b/configs/T2080QDS_SECURE_BOOT_defconfig
+@@ -65,6 +65,8 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T2080QDS_SPIFLASH_defconfig b/configs/T2080QDS_SPIFLASH_defconfig
+index 49db2fec7c..901ad2cad0 100644
+--- a/configs/T2080QDS_SPIFLASH_defconfig
++++ b/configs/T2080QDS_SPIFLASH_defconfig
+@@ -81,3 +81,5 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080QDS_SRIO_PCIE_BOOT_defconfig b/configs/T2080QDS_SRIO_PCIE_BOOT_defconfig
+index 4958435ef4..38d947c8c2 100644
+--- a/configs/T2080QDS_SRIO_PCIE_BOOT_defconfig
++++ b/configs/T2080QDS_SRIO_PCIE_BOOT_defconfig
+@@ -58,3 +58,5 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080QDS_defconfig b/configs/T2080QDS_defconfig
+index 602bf577e0..a5bd06c5ac 100644
+--- a/configs/T2080QDS_defconfig
++++ b/configs/T2080QDS_defconfig
+@@ -66,3 +66,5 @@ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080RDB_NAND_defconfig b/configs/T2080RDB_NAND_defconfig
+index 5ec264b9c3..da21b315a5 100644
+--- a/configs/T2080RDB_NAND_defconfig
++++ b/configs/T2080RDB_NAND_defconfig
+@@ -82,3 +82,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080RDB_SDCARD_defconfig b/configs/T2080RDB_SDCARD_defconfig
+index 05fa2d66c0..6e23c57d13 100644
+--- a/configs/T2080RDB_SDCARD_defconfig
++++ b/configs/T2080RDB_SDCARD_defconfig
+@@ -79,3 +79,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080RDB_SECURE_BOOT_defconfig b/configs/T2080RDB_SECURE_BOOT_defconfig
+index 7d04a94116..1a89cd8899 100644
+--- a/configs/T2080RDB_SECURE_BOOT_defconfig
++++ b/configs/T2080RDB_SECURE_BOOT_defconfig
+@@ -57,6 +57,8 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_RSA=y
+ CONFIG_SPL_RSA=y
+ CONFIG_RSA_SOFTWARE_EXP=y
+diff --git a/configs/T2080RDB_SPIFLASH_defconfig b/configs/T2080RDB_SPIFLASH_defconfig
+index da562d222d..8af05eefe8 100644
+--- a/configs/T2080RDB_SPIFLASH_defconfig
++++ b/configs/T2080RDB_SPIFLASH_defconfig
+@@ -82,3 +82,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2080RDB_SRIO_PCIE_BOOT_defconfig b/configs/T2080RDB_SRIO_PCIE_BOOT_defconfig
+index a8f0a965c1..729edaa41a 100644
+--- a/configs/T2080RDB_SRIO_PCIE_BOOT_defconfig
++++ b/configs/T2080RDB_SRIO_PCIE_BOOT_defconfig
+@@ -50,4 +50,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2080RDB_defconfig b/configs/T2080RDB_defconfig
+index 85e3b64ad3..d957e40cb3 100644
+--- a/configs/T2080RDB_defconfig
++++ b/configs/T2080RDB_defconfig
+@@ -66,3 +66,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T2081QDS_NAND_defconfig b/configs/T2081QDS_NAND_defconfig
+index bf2f36f1a4..d40fd6e561 100644
+--- a/configs/T2081QDS_NAND_defconfig
++++ b/configs/T2081QDS_NAND_defconfig
+@@ -72,4 +72,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2081QDS_SDCARD_defconfig b/configs/T2081QDS_SDCARD_defconfig
+index f6ebc4814e..bc229284d0 100644
+--- a/configs/T2081QDS_SDCARD_defconfig
++++ b/configs/T2081QDS_SDCARD_defconfig
+@@ -69,4 +69,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2081QDS_SPIFLASH_defconfig b/configs/T2081QDS_SPIFLASH_defconfig
+index cd8fa25b74..82bacdbf6d 100644
+--- a/configs/T2081QDS_SPIFLASH_defconfig
++++ b/configs/T2081QDS_SPIFLASH_defconfig
+@@ -72,4 +72,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2081QDS_SRIO_PCIE_BOOT_defconfig b/configs/T2081QDS_SRIO_PCIE_BOOT_defconfig
+index a10f39b336..87cfb5f100 100644
+--- a/configs/T2081QDS_SRIO_PCIE_BOOT_defconfig
++++ b/configs/T2081QDS_SRIO_PCIE_BOOT_defconfig
+@@ -48,4 +48,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T2081QDS_defconfig b/configs/T2081QDS_defconfig
+index 22ca08363c..c7ff58a958 100644
+--- a/configs/T2081QDS_defconfig
++++ b/configs/T2081QDS_defconfig
+@@ -56,4 +56,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T4160RDB_defconfig b/configs/T4160RDB_defconfig
+index f3c7e1ec57..70e6d92bcd 100644
+--- a/configs/T4160RDB_defconfig
++++ b/configs/T4160RDB_defconfig
+@@ -51,4 +51,6 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/T4240RDB_SDCARD_defconfig b/configs/T4240RDB_SDCARD_defconfig
+index 85825da8f3..e916fbfcc6 100644
+--- a/configs/T4240RDB_SDCARD_defconfig
++++ b/configs/T4240RDB_SDCARD_defconfig
+@@ -72,3 +72,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/T4240RDB_defconfig b/configs/T4240RDB_defconfig
+index dfe8953af7..2d8ab6f50a 100644
+--- a/configs/T4240RDB_defconfig
++++ b/configs/T4240RDB_defconfig
+@@ -60,3 +60,5 @@ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+diff --git a/configs/controlcenterd_36BIT_SDCARD_DEVELOP_defconfig b/configs/controlcenterd_36BIT_SDCARD_DEVELOP_defconfig
+index 90fe803ac8..41785d09d0 100644
+--- a/configs/controlcenterd_36BIT_SDCARD_DEVELOP_defconfig
++++ b/configs/controlcenterd_36BIT_SDCARD_DEVELOP_defconfig
+@@ -64,5 +64,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ # CONFIG_VIDEO_SW_CURSOR is not set
++CONFIG_ADDR_MAP=y
+ CONFIG_TPM=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/controlcenterd_36BIT_SDCARD_defconfig b/configs/controlcenterd_36BIT_SDCARD_defconfig
+index 55a46c3c29..777f5aee41 100644
+--- a/configs/controlcenterd_36BIT_SDCARD_defconfig
++++ b/configs/controlcenterd_36BIT_SDCARD_defconfig
+@@ -64,5 +64,6 @@ CONFIG_USB=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_VIDEO=y
+ # CONFIG_VIDEO_SW_CURSOR is not set
++CONFIG_ADDR_MAP=y
+ CONFIG_TPM=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/kmcoge4_defconfig b/configs/kmcoge4_defconfig
+index a0d2c1a726..cf54e9fd30 100644
+--- a/configs/kmcoge4_defconfig
++++ b/configs/kmcoge4_defconfig
+@@ -64,5 +64,7 @@ CONFIG_SYS_QE_FMAN_FW_IN_SPIFLASH=y
+ CONFIG_SYS_NS16550=y
+ CONFIG_SPI=y
+ CONFIG_FSL_ESPI=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=64
+ CONFIG_BCH=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/configs/qemu-ppce500_defconfig b/configs/qemu-ppce500_defconfig
+index ab4bc5d327..ba2ee27658 100644
+--- a/configs/qemu-ppce500_defconfig
++++ b/configs/qemu-ppce500_defconfig
+@@ -27,5 +27,6 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ # CONFIG_MMC is not set
+ CONFIG_E1000=y
+ CONFIG_SYS_NS16550=y
++CONFIG_ADDR_MAP=y
+ CONFIG_PANIC_HANG=y
+ CONFIG_OF_LIBFDT=y
+diff --git a/include/configs/MPC8548CDS.h b/include/configs/MPC8548CDS.h
+index de2bfd8f2f..7ef8eab79b 100644
+--- a/include/configs/MPC8548CDS.h
++++ b/include/configs/MPC8548CDS.h
+@@ -43,11 +43,6 @@ extern unsigned long get_clock_freq(void);
+  */
+ #define CONFIG_ENABLE_36BIT_PHYS	1
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_SYS_CCSRBAR		0xe0000000
+ #define CONFIG_SYS_CCSRBAR_PHYS_LOW	CONFIG_SYS_CCSRBAR
+ 
+diff --git a/include/configs/MPC8572DS.h b/include/configs/MPC8572DS.h
+index 3243f39df4..f6a1939118 100644
+--- a/include/configs/MPC8572DS.h
++++ b/include/configs/MPC8572DS.h
+@@ -45,11 +45,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS	1
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP			1
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-#endif
+-
+ /*
+  * Config the L2 Cache as L2 SRAM
+  */
+diff --git a/include/configs/MPC8641HPCN.h b/include/configs/MPC8641HPCN.h
+index edbeeefdd4..206f68456b 100644
+--- a/include/configs/MPC8641HPCN.h
++++ b/include/configs/MPC8641HPCN.h
+@@ -19,7 +19,6 @@
+ 
+ /* High Level Configuration Options */
+ #define CONFIG_LINUX_RESET_VEC	0x100	/* Reset vector used by Linux */
+-#define CONFIG_ADDR_MAP		1	/* Use addr map */
+ 
+ /*
+  * default CCSRBAR is at 0xff700000
+@@ -47,7 +46,6 @@
+ #define CONFIG_ENV_OVERWRITE
+ 
+ #define CONFIG_BAT_RW		1	/* Use common BAT rw code */
+-#define CONFIG_SYS_NUM_ADDR_MAP 8	/* Number of addr map slots = 8 dbats */
+ 
+ #define CONFIG_ALTIVEC		1
+ 
+diff --git a/include/configs/P1010RDB.h b/include/configs/P1010RDB.h
+index 8f709a6cac..fc74d57497 100644
+--- a/include/configs/P1010RDB.h
++++ b/include/configs/P1010RDB.h
+@@ -196,11 +196,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP			1
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-#endif
+-
+ /* DDR Setup */
+ #define CONFIG_SYS_DDR_RAW_TIMING
+ #define CONFIG_DDR_SPD
+diff --git a/include/configs/P2041RDB.h b/include/configs/P2041RDB.h
+index 94cbe10dd3..c6a64ee479 100644
+--- a/include/configs/P2041RDB.h
++++ b/include/configs/P2041RDB.h
+@@ -70,11 +70,6 @@ unsigned long get_board_sys_clk(unsigned long dummy);
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_POST CONFIG_SYS_POST_MEMORY	/* test POST memory test */
+ 
+ /*
+diff --git a/include/configs/T102xRDB.h b/include/configs/T102xRDB.h
+index f5d9657444..efd9b6b5e1 100644
+--- a/include/configs/T102xRDB.h
++++ b/include/configs/T102xRDB.h
+@@ -17,11 +17,6 @@
+ #define CONFIG_SYS_BOOK3E_HV		/* Category E.HV supported */
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP		1
+-#define CONFIG_SYS_NUM_ADDR_MAP	64	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_SYS_FSL_CPC		/* Corenet Platform Cache */
+ #define CONFIG_SYS_NUM_CPC		CONFIG_SYS_NUM_DDR_CTLRS
+ 
+diff --git a/include/configs/T104xRDB.h b/include/configs/T104xRDB.h
+index 4237dfcd6c..8f9de56f07 100644
+--- a/include/configs/T104xRDB.h
++++ b/include/configs/T104xRDB.h
+@@ -186,9 +186,6 @@ $(SRCTREE)/board/freescale/t104xrdb/t1042d4_sd_rcw.cfg
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-
+ /*
+  *  Config the L3 Cache as L3 SRAM
+  */
+diff --git a/include/configs/T208xQDS.h b/include/configs/T208xQDS.h
+index c54f7f53e5..f32e6680b3 100644
+--- a/include/configs/T208xQDS.h
++++ b/include/configs/T208xQDS.h
+@@ -26,11 +26,6 @@
+ #define CONFIG_SYS_BOOK3E_HV	/* Category E.HV supported */
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP 1
+-#define CONFIG_SYS_NUM_ADDR_MAP 64 /* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_SYS_FSL_CPC	/* Corenet Platform Cache */
+ #define CONFIG_SYS_NUM_CPC	CONFIG_SYS_NUM_DDR_CTLRS
+ #define CONFIG_ENV_OVERWRITE
+diff --git a/include/configs/T208xRDB.h b/include/configs/T208xRDB.h
+index 70eafc3e28..e666e4f4a4 100644
+--- a/include/configs/T208xRDB.h
++++ b/include/configs/T208xRDB.h
+@@ -20,11 +20,6 @@
+ #define CONFIG_SYS_BOOK3E_HV	/* Category E.HV supported */
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP 1
+-#define CONFIG_SYS_NUM_ADDR_MAP 64 /* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_SYS_FSL_CPC	/* Corenet Platform Cache */
+ #define CONFIG_SYS_NUM_CPC	CONFIG_SYS_NUM_DDR_CTLRS
+ #define CONFIG_ENV_OVERWRITE
+diff --git a/include/configs/T4240RDB.h b/include/configs/T4240RDB.h
+index 9832f85405..ebe7a9cf92 100644
+--- a/include/configs/T4240RDB.h
++++ b/include/configs/T4240RDB.h
+@@ -80,9 +80,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-
+ /*
+  *  Config the L3 Cache as L3 SRAM
+  */
+diff --git a/include/configs/controlcenterd.h b/include/configs/controlcenterd.h
+index 823586cc09..512d8e16ee 100644
+--- a/include/configs/controlcenterd.h
++++ b/include/configs/controlcenterd.h
+@@ -41,11 +41,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_L2_CACHE
+ #define CONFIG_BTB
+ 
+diff --git a/include/configs/corenet_ds.h b/include/configs/corenet_ds.h
+index a49f9056c5..d7812bd886 100644
+--- a/include/configs/corenet_ds.h
++++ b/include/configs/corenet_ds.h
+@@ -84,11 +84,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_POST CONFIG_SYS_POST_MEMORY	/* test POST memory test */
+ 
+ /*
+diff --git a/include/configs/cyrus.h b/include/configs/cyrus.h
+index 052e6018a3..b587cb8d77 100644
+--- a/include/configs/cyrus.h
++++ b/include/configs/cyrus.h
+@@ -70,11 +70,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-#endif
+-
+ /* test POST memory test */
+ #undef CONFIG_POST
+ 
+diff --git a/include/configs/kmp204x.h b/include/configs/kmp204x.h
+index e43b2f7513..6cd77edf70 100644
+--- a/include/configs/kmp204x.h
++++ b/include/configs/kmp204x.h
+@@ -64,9 +64,6 @@ unsigned long get_board_sys_clk(unsigned long dummy);
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-
+ #define CONFIG_POST CONFIG_SYS_POST_MEM_REGIONS	/* POST memory regions test */
+ 
+ /*
+diff --git a/include/configs/p1_p2_rdb_pc.h b/include/configs/p1_p2_rdb_pc.h
+index 219e5d216b..1e6c8ae308 100644
+--- a/include/configs/p1_p2_rdb_pc.h
++++ b/include/configs/p1_p2_rdb_pc.h
+@@ -233,11 +233,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#ifdef CONFIG_PHYS_64BIT
+-#define CONFIG_ADDR_MAP			1
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-#endif
+-
+ #define CONFIG_SYS_CCSRBAR		0xffe00000
+ #define CONFIG_SYS_CCSRBAR_PHYS_LOW	CONFIG_SYS_CCSRBAR
+ 
+diff --git a/include/configs/qemu-ppce500.h b/include/configs/qemu-ppce500.h
+index 03b08968f6..b3ec43073c 100644
+--- a/include/configs/qemu-ppce500.h
++++ b/include/configs/qemu-ppce500.h
+@@ -21,9 +21,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		16	/* number of TLB1 entries */
+-
+ /* Needed to fill the ccsrbar pointer */
+ 
+ /* Virtual address to CCSRBAR */
+diff --git a/include/configs/t4qds.h b/include/configs/t4qds.h
+index 3da7ee7b3a..1f6ae462ae 100644
+--- a/include/configs/t4qds.h
++++ b/include/configs/t4qds.h
+@@ -42,9 +42,6 @@
+ 
+ #define CONFIG_ENABLE_36BIT_PHYS
+ 
+-#define CONFIG_ADDR_MAP
+-#define CONFIG_SYS_NUM_ADDR_MAP		64	/* number of TLB1 entries */
+-
+ /*
+  *  Config the L3 Cache as L3 SRAM
+  */
+diff --git a/lib/Kconfig b/lib/Kconfig
+index af5c38afd9..af5e8914b4 100644
+--- a/lib/Kconfig
++++ b/lib/Kconfig
+@@ -1,5 +1,18 @@
+ menu "Library routines"
+ 
++config ADDR_MAP
++	bool "Enable support for non-identity virtual-physical mappings"
++	help
++	  Enables helper code for implementing non-identity virtual-physical
++	  memory mappings for 32bit CPUs.
++
++config SYS_NUM_ADDR_MAP
++	int "Size of the address-map table"
++	depends on ADDR_MAP
++	default 16
++	help
++	  Sets the number of entries in the virtual-physical mapping table.
++
+ config BCH
+ 	bool "Enable Software based BCH ECC"
+ 	help
+diff --git a/scripts/config_whitelist.txt b/scripts/config_whitelist.txt
+index 916768f361..0fb69f4630 100644
+--- a/scripts/config_whitelist.txt
++++ b/scripts/config_whitelist.txt
+@@ -15,7 +15,6 @@ CONFIG_ACX517AKN
+ CONFIG_ACX544AKN
+ CONFIG_ADDRESS
+ CONFIG_ADDR_AUTO_INCR_BIT
+-CONFIG_ADDR_MAP
+ CONFIG_ADNPESC1
+ CONFIG_AEABI
+ CONFIG_AEMIF_CNTRL_BASE
+@@ -3271,7 +3270,6 @@ CONFIG_SYS_NS16550_MEM32
+ CONFIG_SYS_NS16550_PORT_MAPPED
+ CONFIG_SYS_NS16550_REG_SIZE
+ CONFIG_SYS_NS16550_SERIAL
+-CONFIG_SYS_NUM_ADDR_MAP
+ CONFIG_SYS_NUM_CPC
+ CONFIG_SYS_NUM_FM1_10GEC
+ CONFIG_SYS_NUM_FM1_DTSEC
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0016-arm-update-comments-to-the-common-style.patch
+++ b/buildroot-external/patches/uboot/2020.07/0016-arm-update-comments-to-the-common-style.patch
@@ -1,0 +1,88 @@
+From 32d72ef4331597864189b73b309490ac48f4ac05 Mon Sep 17 00:00:00 2001
+Message-Id: <32d72ef4331597864189b73b309490ac48f4ac05.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:41 +0200
+Subject: [PATCH 16/20] arm: update comments to the common style
+
+Update the comments in include/asm/system.h to the common style.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ arch/arm/include/asm/system.h | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm/include/asm/system.h b/arch/arm/include/asm/system.h
+index 7a40b56acd..0243f76e76 100644
+--- a/arch/arm/include/asm/system.h
++++ b/arch/arm/include/asm/system.h
+@@ -205,7 +205,7 @@ int __asm_invalidate_l3_icache(void);
+ void __asm_switch_ttbr(u64 new_ttbr);
+ 
+ /*
+- * Switch from EL3 to EL2 for ARMv8
++ * armv8_switch_to_el2() - switch from EL3 to EL2 for ARMv8
+  *
+  * @args:        For loading 64-bit OS, fdt address.
+  *               For loading 32-bit OS, zero.
+@@ -220,7 +220,7 @@ void __asm_switch_ttbr(u64 new_ttbr);
+ void __noreturn armv8_switch_to_el2(u64 args, u64 mach_nr, u64 fdt_addr,
+ 				    u64 arg4, u64 entry_point, u64 es_flag);
+ /*
+- * Switch from EL2 to EL1 for ARMv8
++ * armv8_switch_to_el1() - switch from EL2 to EL1 for ARMv8
+  *
+  * @args:        For loading 64-bit OS, fdt address.
+  *               For loading 32-bit OS, zero.
+@@ -246,11 +246,12 @@ void flush_l3_cache(void);
+ void mmu_change_region_attr(phys_addr_t start, size_t size, u64 attrs);
+ 
+ /*
+- *Issue a secure monitor call in accordance with ARM "SMC Calling convention",
++ * smc_call() - issue a secure monitor call
++ *
++ * Issue a secure monitor call in accordance with ARM "SMC Calling convention",
+  * DEN0028A
+  *
+  * @args: input and output arguments
+- *
+  */
+ void smc_call(struct pt_regs *args);
+ 
+@@ -519,10 +520,12 @@ enum {
+ #endif
+ 
+ /**
++ * mmu_page_table_flush() - register an update to page tables
++ *
+  * Register an update to the page tables, and flush the TLB
+  *
+- * \param start		start address of update in page table
+- * \param stop		stop address of update in page table
++ * @start:	start address of update in page table
++ * @stop:	stop address of update in page table
+  */
+ void mmu_page_table_flush(unsigned long start, unsigned long stop);
+ 
+@@ -583,11 +586,13 @@ s32 psci_features(u32 function_id, u32 psci_fid);
+ void save_boot_params_ret(void);
+ 
+ /**
++ * mmu_set_region_dcache_behaviour() - set cache settings
++ *
+  * Change the cache settings for a region.
+  *
+- * \param start		start address of memory region to change
+- * \param size		size of memory region to change
+- * \param option	dcache option to select
++ * @start:	start address of memory region to change
++ * @size:	size of memory region to change
++ * @option:	dcache option to select
+  */
+ void mmu_set_region_dcache_behaviour(phys_addr_t start, size_t size,
+ 				     enum dcache_option option);
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0017-arm-provide-a-function-for-boards-init-code-to-modif.patch
+++ b/buildroot-external/patches/uboot/2020.07/0017-arm-provide-a-function-for-boards-init-code-to-modif.patch
@@ -1,0 +1,130 @@
+From 82a944e4d1356e9ab3c87e6dc57b1b7213cbb233 Mon Sep 17 00:00:00 2001
+Message-Id: <82a944e4d1356e9ab3c87e6dc57b1b7213cbb233.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:42 +0200
+Subject: [PATCH 17/20] arm: provide a function for boards init code to modify
+ MMU virtual-physical map
+
+Provide function for setting arbitrary virtual-physical MMU mapping
+and cache settings for the given region.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Reviewed-by: Tom Rini <trini@konsulko.com>
+---
+ arch/arm/include/asm/mmu.h    |  8 ++++++++
+ arch/arm/include/asm/system.h | 13 +++++++++++++
+ arch/arm/lib/cache-cp15.c     | 24 ++++++++++++++++++------
+ 3 files changed, 39 insertions(+), 6 deletions(-)
+ create mode 100644 arch/arm/include/asm/mmu.h
+
+diff --git a/arch/arm/include/asm/mmu.h b/arch/arm/include/asm/mmu.h
+new file mode 100644
+index 0000000000..9ac16f599e
+--- /dev/null
++++ b/arch/arm/include/asm/mmu.h
+@@ -0,0 +1,8 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++
++#ifndef __ASM_ARM_MMU_H
++#define __ASM_ARM_MMU_H
++
++void init_addr_map(void);
++
++#endif
+diff --git a/arch/arm/include/asm/system.h b/arch/arm/include/asm/system.h
+index 0243f76e76..f9290fa9b6 100644
+--- a/arch/arm/include/asm/system.h
++++ b/arch/arm/include/asm/system.h
+@@ -585,6 +585,19 @@ s32 psci_features(u32 function_id, u32 psci_fid);
+  */
+ void save_boot_params_ret(void);
+ 
++/**
++ * mmu_set_region_dcache_behaviour_phys() - set virt/phys mapping
++ *
++ * Change the virt/phys mapping and cache settings for a region.
++ *
++ * @virt:	virtual start address of memory region to change
++ * @phys:	physical address for the memory region to set
++ * @size:	size of memory region to change
++ * @option:	dcache option to select
++ */
++void mmu_set_region_dcache_behaviour_phys(phys_addr_t virt, phys_addr_t phys,
++					size_t size, enum dcache_option option);
++
+ /**
+  * mmu_set_region_dcache_behaviour() - set cache settings
+  *
+diff --git a/arch/arm/lib/cache-cp15.c b/arch/arm/lib/cache-cp15.c
+index 1da2e92fe2..39717610d4 100644
+--- a/arch/arm/lib/cache-cp15.c
++++ b/arch/arm/lib/cache-cp15.c
+@@ -25,7 +25,8 @@ __weak void arm_init_domains(void)
+ {
+ }
+ 
+-void set_section_dcache(int section, enum dcache_option option)
++static void set_section_phys(int section, phys_addr_t phys,
++			     enum dcache_option option)
+ {
+ #ifdef CONFIG_ARMV7_LPAE
+ 	u64 *page_table = (u64 *)gd->arch.tlb_addr;
+@@ -37,7 +38,7 @@ void set_section_dcache(int section, enum dcache_option option)
+ #endif
+ 
+ 	/* Add the page offset */
+-	value |= ((u32)section << MMU_SECTION_SHIFT);
++	value |= phys;
+ 
+ 	/* Add caching bits */
+ 	value |= option;
+@@ -46,13 +47,18 @@ void set_section_dcache(int section, enum dcache_option option)
+ 	page_table[section] = value;
+ }
+ 
++void set_section_dcache(int section, enum dcache_option option)
++{
++	set_section_phys(section, (u32)section << MMU_SECTION_SHIFT, option);
++}
++
+ __weak void mmu_page_table_flush(unsigned long start, unsigned long stop)
+ {
+ 	debug("%s: Warning: not implemented\n", __func__);
+ }
+ 
+-void mmu_set_region_dcache_behaviour(phys_addr_t start, size_t size,
+-				     enum dcache_option option)
++void mmu_set_region_dcache_behaviour_phys(phys_addr_t start, phys_addr_t phys,
++					size_t size, enum dcache_option option)
+ {
+ #ifdef CONFIG_ARMV7_LPAE
+ 	u64 *page_table = (u64 *)gd->arch.tlb_addr;
+@@ -74,8 +80,8 @@ void mmu_set_region_dcache_behaviour(phys_addr_t start, size_t size,
+ 	debug("%s: start=%pa, size=%zu, option=0x%x\n", __func__, &start, size,
+ 	      option);
+ #endif
+-	for (upto = start; upto < end; upto++)
+-		set_section_dcache(upto, option);
++	for (upto = start; upto < end; upto++, phys += MMU_SECTION_SIZE)
++		set_section_phys(upto, phys, option);
+ 
+ 	/*
+ 	 * Make sure range is cache line aligned
+@@ -90,6 +96,12 @@ void mmu_set_region_dcache_behaviour(phys_addr_t start, size_t size,
+ 	mmu_page_table_flush(startpt, stoppt);
+ }
+ 
++void mmu_set_region_dcache_behaviour(phys_addr_t start, size_t size,
++				     enum dcache_option option)
++{
++	mmu_set_region_dcache_behaviour_phys(start, start, size, option);
++}
++
+ __weak void dram_bank_mmu_setup(int bank)
+ {
+ 	bd_t *bd = gd->bd;
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0018-mmc-bcm283x-fix-int-to-pointer-cast.patch
+++ b/buildroot-external/patches/uboot/2020.07/0018-mmc-bcm283x-fix-int-to-pointer-cast.patch
@@ -1,0 +1,33 @@
+From 2904bea082a1524b13af6afed08a7f5ee9faf0ae Mon Sep 17 00:00:00 2001
+Message-Id: <2904bea082a1524b13af6afed08a7f5ee9faf0ae.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Seung-Woo Kim <sw0312.kim@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:43 +0200
+Subject: [PATCH 18/20] mmc: bcm283x: fix int to pointer cast
+
+On build with 32 bit, there is a warning for int-to-pointer-cast.
+Fix the int to pointer cast by using uintptr_t.
+
+Signed-off-by: Seung-Woo Kim <sw0312.kim@samsung.com>
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+---
+ drivers/mmc/bcm2835_sdhci.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/bcm2835_sdhci.c b/drivers/mmc/bcm2835_sdhci.c
+index dc3dffb657..5cdf3c506f 100644
+--- a/drivers/mmc/bcm2835_sdhci.c
++++ b/drivers/mmc/bcm2835_sdhci.c
+@@ -210,7 +210,7 @@ static int bcm2835_sdhci_probe(struct udevice *dev)
+ 	priv->last_write = 0;
+ 
+ 	host->name = dev->name;
+-	host->ioaddr = (void *)base;
++	host->ioaddr = (void *)(uintptr_t)base;
+ 	host->quirks = SDHCI_QUIRK_BROKEN_VOLTAGE | SDHCI_QUIRK_BROKEN_R1B |
+ 		SDHCI_QUIRK_WAIT_SEND_CMD | SDHCI_QUIRK_NO_HISPD_BIT;
+ 	host->max_clk = emmc_freq;
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0019-rpi4-add-a-mapping-for-the-PCIe-XHCI-controller-MMIO.patch
+++ b/buildroot-external/patches/uboot/2020.07/0019-rpi4-add-a-mapping-for-the-PCIe-XHCI-controller-MMIO.patch
@@ -1,0 +1,85 @@
+From a8c492ef2a3a73d435765ce28944efebce5cfa17 Mon Sep 17 00:00:00 2001
+Message-Id: <a8c492ef2a3a73d435765ce28944efebce5cfa17.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:44 +0200
+Subject: [PATCH 19/20] rpi4: add a mapping for the PCIe XHCI controller MMIO
+ registers (ARM 32bit)
+
+Create a non-cacheable mapping for the 0x600000000 physical memory region,
+where MMIO registers for the PCIe XHCI controller are instantiated by the
+PCIe bridge. Due to 32bit limit in the CPU virtual address space in ARM
+32bit mode, this region is mapped at 0xff800000 CPU virtual address.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+---
+ arch/arm/mach-bcm283x/Kconfig             |  1 +
+ arch/arm/mach-bcm283x/include/mach/base.h |  8 ++++++++
+ arch/arm/mach-bcm283x/init.c              | 21 +++++++++++++++++++++
+ 3 files changed, 30 insertions(+)
+
+diff --git a/arch/arm/mach-bcm283x/Kconfig b/arch/arm/mach-bcm283x/Kconfig
+index e6eb904e7f..b3287ce8bc 100644
+--- a/arch/arm/mach-bcm283x/Kconfig
++++ b/arch/arm/mach-bcm283x/Kconfig
+@@ -36,6 +36,7 @@ config BCM2711_32B
+ 	select BCM2711
+ 	select ARMV7_LPAE
+ 	select CPU_V7A
++	select PHYS_64BIT
+ 
+ config BCM2711_64B
+ 	bool "Broadcom BCM2711 SoC 64-bit support"
+diff --git a/arch/arm/mach-bcm283x/include/mach/base.h b/arch/arm/mach-bcm283x/include/mach/base.h
+index c4ae39852f..4ccaf69693 100644
+--- a/arch/arm/mach-bcm283x/include/mach/base.h
++++ b/arch/arm/mach-bcm283x/include/mach/base.h
+@@ -8,4 +8,12 @@
+ 
+ extern unsigned long rpi_bcm283x_base;
+ 
++#ifdef CONFIG_ARMV7_LPAE
++#ifdef CONFIG_TARGET_RPI_4_32B
++#include <addr_map.h>
++#define phys_to_virt addrmap_phys_to_virt
++#define virt_to_phys addrmap_virt_to_phys
++#endif
++#endif
++
+ #endif
+diff --git a/arch/arm/mach-bcm283x/init.c b/arch/arm/mach-bcm283x/init.c
+index cf4c5b245d..f2a5411623 100644
+--- a/arch/arm/mach-bcm283x/init.c
++++ b/arch/arm/mach-bcm283x/init.c
+@@ -146,6 +146,27 @@ int mach_cpu_init(void)
+ }
+ 
+ #ifdef CONFIG_ARMV7_LPAE
++#ifdef CONFIG_TARGET_RPI_4_32B
++#define BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT	0xff800000UL
++#include <addr_map.h>
++#include <asm/system.h>
++
++void init_addr_map(void)
++{
++	mmu_set_region_dcache_behaviour_phys(BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT,
++					     BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS,
++					     BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE,
++					     DCACHE_OFF);
++
++	/* identity mapping for 0..BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT */
++	addrmap_set_entry(0, 0, BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT, 0);
++	/* XHCI MMIO on PCIe at BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT */
++	addrmap_set_entry(BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT,
++			  BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS,
++			  BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE, 1);
++}
++#endif
++
+ void enable_caches(void)
+ {
+ 	dcache_enable();
+-- 
+2.27.0
+

--- a/buildroot-external/patches/uboot/2020.07/0020-config-Enable-support-for-the-XHCI-controller-on-RPI.patch
+++ b/buildroot-external/patches/uboot/2020.07/0020-config-Enable-support-for-the-XHCI-controller-on-RPI.patch
@@ -1,0 +1,71 @@
+From 52d942897bcf2c775c3c5dff9f811e1a28f3fd7d Mon Sep 17 00:00:00 2001
+Message-Id: <52d942897bcf2c775c3c5dff9f811e1a28f3fd7d.1595101389.git.stefan@agner.ch>
+In-Reply-To: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+References: <040a141f84f2f84bf8be18f85b4cdb34bf066df0.1595101389.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Wed, 3 Jun 2020 14:43:45 +0200
+Subject: [PATCH 20/20] config: Enable support for the XHCI controller on RPI4
+ board
+
+This requires enabling BRCMSTB PCIe and XHCI_PCI drivers as well as PCI
+and USB commands. To get it working one has to call the following commands:
+"pci enum; usb start;", thus such commands have been added to the default
+"preboot" environment variable. One has to update their environment if it
+is already configured to get this feature working out of the box.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+---
+ configs/rpi_4_32b_defconfig | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
+index 0df5c17d6e..db7b781976 100644
+--- a/configs/rpi_4_32b_defconfig
++++ b/configs/rpi_4_32b_defconfig
+@@ -6,6 +6,8 @@ CONFIG_SYS_MALLOC_F_LEN=0x2000
+ CONFIG_ENV_SIZE=0x4000
+ CONFIG_DISTRO_DEFAULTS=y
+ CONFIG_OF_BOARD_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="pci enum; usb start;"
+ CONFIG_MISC_INIT_R=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ # CONFIG_DISPLAY_BOARDINFO is not set
+@@ -13,6 +15,8 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_DFU=y
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+@@ -26,6 +30,9 @@ CONFIG_MMC_SDHCI_SDMA=y
+ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_BCMGENET=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_PCI_BRCMSTB=y
+ CONFIG_PINCTRL=y
+ # CONFIG_PINCTRL_GENERIC is not set
+ CONFIG_DM_RESET=y
+@@ -33,6 +40,8 @@ CONFIG_DM_RESET=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_DM_USB_GADGET=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_PCI=y
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_GADGET_MANUFACTURER="FSL"
+ CONFIG_USB_GADGET_VENDOR_NUM=0x0525
+@@ -45,4 +54,6 @@ CONFIG_DM_VIDEO=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
++CONFIG_ADDR_MAP=y
++CONFIG_SYS_NUM_ADDR_MAP=2
+ CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.27.0
+


### PR DESCRIPTION
This adds support to boot Home Assistant Operating System on RPi4 from a USB MSD (mass storage device, e.g. USB SSD).

**Note:** This requires a newer bootloader flashed to EEPROM. Use RPi tooling to update your EEPROM. See also the "USB mass storage boot" chapter in the [bcm2711_bootloader_config.md](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md). The latest stable `pieeprom-2020-06-15.bin` should be working. 

The GPU Firmware (7caead9416f64b2d33361c703fb243b8e157eba4) currently shipped with Home Assistant OS seems to be new enough.

To avoid `mmc0: timeout waiting for hardware interrupt` without SD card add `sd_poll_once=on` to `dtparam` in `config.txt`.