### PR TITLE
Allow to execute commands using enter.sh directly

### DIFF
--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -2,6 +2,8 @@
 BUILDER_UID="$(id -u)"
 BUILDER_GID="$(id -g)"
 CACHE_DIR="${CACHE_DIR:-$HOME/hassos-cache}"
+ARGS="$*"
+COMMAND="${ARGS:-bash}"
 
 sudo mkdir -p "${CACHE_DIR}"
 sudo chown -R "${BUILDER_UID}:${BUILDER_GID}" "${CACHE_DIR}"
@@ -9,4 +11,4 @@ sudo docker build -t hassos:local .
 sudo docker run -it --rm --privileged \
   -v "$(pwd):/build" -v "${CACHE_DIR}:/cache" \
   -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
-  hassos:local bash
+  hassos:local ${COMMAND}


### PR DESCRIPTION
This is useful e.g. if one just wants to run a build.