### PR TITLE
Change VM naming handling

### DIFF
--- a/buildroot-external/board/intel/ova/home-assistant.ovf
+++ b/buildroot-external/board/intel/ova/home-assistant.ovf
@@ -13,8 +13,9 @@
       <Description>Logical network used by this appliance.</Description>
     </Network>
   </NetworkSection>
-  <VirtualSystem ovf:id="Home Assistant">
+  <VirtualSystem ovf:id="HomeAssistant">
     <Info>A virtual machine</Info>
+    <Name>Home Assistant</Name>
     <ProductSection>
       <Info>Meta-information about the installed software</Info>
       <Product>Operating-System</Product>


### PR DESCRIPTION
This should be compatible with most systems now.
Fix: #789 