### PR TITLE
hardkernel: Fix build warning when building U-Boot

### DIFF
--- a/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
@@ -1,7 +1,10 @@
-From f888798dce14056eaea9783abc57f57b651a5491 Mon Sep 17 00:00:00 2001
+From 2efc005b8eb2738ac66f59d0a3af2b6540cbcc8f Mon Sep 17 00:00:00 2001
+Message-Id: <2efc005b8eb2738ac66f59d0a3af2b6540cbcc8f.1596577295.git.stefan@agner.ch>
+In-Reply-To: <34605fd3e035ce85265a8f308b8540b83c2ba67f.1596577295.git.stefan@agner.ch>
+References: <34605fd3e035ce85265a8f308b8540b83c2ba67f.1596577295.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 4 Aug 2020 13:50:57 +0000
-Subject: [PATCH 1/1] meson: Add board_rev to env
+Subject: [PATCH 2/2] meson: Add board_rev to env
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---
@@ -11,18 +14,18 @@ Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
  3 files changed, 45 insertions(+)
 
 diff --git a/arch/arm/include/asm/arch-meson/boot.h b/arch/arm/include/asm/arch-meson/boot.h
-index a90fe55081..056aedcd65 100644
+index a90fe55081..d344258ea1 100644
 --- a/arch/arm/include/asm/arch-meson/boot.h
 +++ b/arch/arm/include/asm/arch-meson/boot.h
 @@ -17,4 +17,6 @@
  
  int meson_get_boot_device(void);
  
-+int meson_get_soc_rev(const char *buff);
++int meson_get_soc_rev(char *buff);
 +
  #endif /* __MESON_BOOT_H__ */
 diff --git a/arch/arm/mach-meson/board-info.c b/arch/arm/mach-meson/board-info.c
-index 0d3b40a249..91fcc5eb33 100644
+index 0d3b40a249..dddcb85981 100644
 --- a/arch/arm/mach-meson/board-info.c
 +++ b/arch/arm/mach-meson/board-info.c
 @@ -167,3 +167,41 @@ int show_board_info(void)
@@ -30,7 +33,7 @@ index 0d3b40a249..91fcc5eb33 100644
  	return 0;
  }
 +
-+int meson_get_soc_rev(const char *buff)
++int meson_get_soc_rev(char *buff)
 +{
 +	struct regmap *regmap;
 +	int nodeoffset, ret;
@@ -68,7 +71,7 @@ index 0d3b40a249..91fcc5eb33 100644
 +	return 1;
 +}
 diff --git a/board/amlogic/w400/w400.c b/board/amlogic/w400/w400.c
-index d74aab899a..936a9d29e0 100644
+index d74aab899a..55fae6b67a 100644
 --- a/board/amlogic/w400/w400.c
 +++ b/board/amlogic/w400/w400.c
 @@ -10,6 +10,7 @@
@@ -90,5 +93,5 @@ index d74aab899a..936a9d29e0 100644
  	return 0;
  }
 -- 
-2.17.1
+2.27.0
 


### PR DESCRIPTION
Drop const since we actually modify the buffer in meson_get_soc_rev