### PR TITLE
Align all partitions to 1MiB boundary

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -201,27 +201,27 @@ function _create_disk_mbr() {
     local hdd_img="$(hassos_image_name img)"
     local hdd_count=${DISK_SIZE:-2}
     local disk_layout="${BINARIES_DIR}/disk.layout"
-    local boot_start=16384
+    local boot_start=$(size2sectors "8M")
 
-    local boot_size=$(($(size2sectors "$(get_boot_size)")+2))
-    local kernel0_size=$(($(size2sectors "$KERNEL_SIZE")+2))
-    local system0_size=$(($(size2sectors "$SYSTEM_SIZE")+2))
-    local kernel1_size=$(($(size2sectors "$KERNEL_SIZE")+2))
-    local system1_size=$(($(size2sectors "$SYSTEM_SIZE")+2))
-    local bootstate_size=$(($(size2sectors "$BOOTSTATE_SIZE")+2))
-    local overlay_size=$(($(size2sectors "$OVERLAY_SIZE")+2))
-    local data_size=$(($(size2sectors "$DATA_SIZE")+2))
-    local extended_size=$((kernel0_size+system0_size+kernel1_size+system1_size+bootstate_size+2))
+    local boot_size=$(size2sectors "$(get_boot_size)")
+    local kernel0_size=$(size2sectors "$KERNEL_SIZE")
+    local system0_size=$(size2sectors "$SYSTEM_SIZE")
+    local kernel1_size=$(size2sectors "$KERNEL_SIZE")
+    local system1_size=$(size2sectors "$SYSTEM_SIZE")
+    local bootstate_size=$(size2sectors "$BOOTSTATE_SIZE")
+    local overlay_size=$(size2sectors "$OVERLAY_SIZE")
+    local data_size=$(size2sectors "$DATA_SIZE")
+    local extended_size=$((kernel0_size+system0_size+kernel1_size+system1_size+bootstate_size+5*$(size2sectors "1M")))
 
     # we add one here for the extended header.
-    local extended_start=$((boot_start+boot_size+1))
-    local kernel0_start=$((extended_start+1))
-    local system0_start=$((kernel0_start+kernel0_size+1))
-    local kernel1_start=$((system0_start+system0_size+1))
-    local system1_start=$((kernel1_start+kernel1_size+1))
-    local bootstate_start=$((system1_start+system1_size+1))
-    local overlay_start=$((extended_start+extended_size+1))
-    local data_start=$((overlay_start+overlay_size+1))
+    local extended_start=$((boot_start+boot_size))
+    local kernel0_start=$((extended_start+$(size2sectors "1M")))
+    local system0_start=$((kernel0_start+kernel0_size+$(size2sectors "1M")))
+    local kernel1_start=$((system0_start+system0_size+$(size2sectors "1M")))
+    local system1_start=$((kernel1_start+kernel1_size+$(size2sectors "1M")))
+    local bootstate_start=$((system1_start+system1_size+$(size2sectors "1M")))
+    local overlay_start=$((extended_start+extended_size+$(size2sectors "1M")))
+    local data_start=$((overlay_start+overlay_size+$(size2sectors "1M")))
 
     local boot_offset=${boot_start}
     local kernel_offset=${kernel0_start}


### PR DESCRIPTION
Aligning partitions (and hence file system structures) to higher level
then 512 byte sectors is common practise and highly recommended for flash
backed block devices. It makes sure that the underlaying flash translation
layer (FTL) does not amplify writes due to missalignment of its erase
blcok size. Use a 1MiB boundary which is what a modern fdisk is doing.

Before this change:

```
# fdisk /dev/mmcblk0

Welcome to fdisk (util-linux 2.35.1).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Command (m for help): p
Disk /dev/mmcblk0: 14.57 GiB, 15634268160 bytes, 30535680 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x48617373

Device         Boot   Start      End  Sectors  Size Id Type
/dev/mmcblk0p1 *      16384    65537    49154   24M  c W95 FAT32 (LBA)
/dev/mmcblk0p2        65539  1228814  1163276  568M  5 Extended
/dev/mmcblk0p3      1228816  1425425   196610   96M 83 Linux
/dev/mmcblk0p4      1425427 30535679 29110253 13.9G 83 Linux
/dev/mmcblk0p5        65540   114693    49154   24M 83 Linux
/dev/mmcblk0p6       114695   638984   524290  256M 83 Linux
/dev/mmcblk0p7       638986   688139    49154   24M 83 Linux
/dev/mmcblk0p8       688141  1212430   524290  256M 83 Linux
/dev/mmcblk0p9      1212432  1228814    16383    8M 83 Linux
```

After this change:

```
# fdisk /dev/mmcblk0

Welcome to fdisk (util-linux 2.35.1).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Command (m for help): p
Disk /dev/mmcblk0: 14.57 GiB, 15634268160 bytes, 30535680 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x48617373

Device         Boot   Start      End  Sectors  Size Id Type
/dev/mmcblk0p1 *      16384    65535    49152   24M  c W95 FAT32 (LBA)
/dev/mmcblk0p2        65536  1239039  1173504  573M  5 Extended
/dev/mmcblk0p3      1241088  1437695   196608   96M 83 Linux
/dev/mmcblk0p4      1439744 30535679 29095936 13.9G 83 Linux
/dev/mmcblk0p5        67584   116735    49152   24M 83 Linux
/dev/mmcblk0p6       118784   643071   524288  256M 83 Linux
/dev/mmcblk0p7       645120   694271    49152   24M 83 Linux
/dev/mmcblk0p8       696320  1220607   524288  256M 83 Linux
/dev/mmcblk0p9      1222656  1239039    16384    8M 83 Linux
```

See also:
https://unix.stackexchange.com/questions/248939/how-to-achieve-optimal-alignment-for-emmc-partition
http://3gfp.com/wp/2014/07/formatting-sd-cards-for-speed-and-lifetime/