### PR TITLE
Load loop module before starting the container

### DIFF
--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -9,6 +9,9 @@ sudo mkdir -p "${CACHE_DIR}"
 sudo chown -R "${BUILDER_UID}:${BUILDER_GID}" "${CACHE_DIR}"
 sudo docker build -t hassos:local .
 
+# Make sure loop devices are present before starting the container
+sudo losetup -f > /dev/null
+
 # shellcheck disable=SC2086
 sudo docker run -it --rm --privileged \
   -v "$(pwd):/build" -v "${CACHE_DIR}:/cache" \


### PR DESCRIPTION
This makes sure that the kernel module loop is loaded, the loop devices
under /dev have been created before the container starts. Docker uses
the current /dev as template for the container /dev. If the loop entries
are missing, loop devices can't be used inside the container. Use
losetup which does not make assumption weather loop support is built-in.

This fixes issues seen on my machine when entering the build environment
the first time after build:
  mount: /mnt/data: failed to setup loop device for /export/data.ext4.
  make[2]: *** [package/pkg-generic.mk:364: /build/buildroot/output_rpi4/build/hassio-1.0.0/.stamp_target_installed] Error 32