### PR TITLE
Use Microsoft Basic Data instead of Microsoft Reserved Partition

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -268,7 +268,7 @@ function _create_disk_mbr() {
 function _fix_disk_hyprid() {
     local hdd_img="$(hassos_image_name img)"
 
-    sgdisk -t 1:"E3C9E316-0B5C-4DB8-817D-F92DF00215AE" "${hdd_img}"
+    sgdisk -t 1:"EBD0A0A2-B9E5-4433-87C0-68B6B72699C7" "${hdd_img}"
     dd if="${BR2_EXTERNAL_HASSOS_PATH}/bootloader/mbr.img" of="${hdd_img}" conv=notrunc bs=512 count=1
 }
 
@@ -277,7 +277,7 @@ function _fix_disk_spl_gpt() {
     local hdd_img="$(hassos_image_name img)"
     local spl_img="$(path_spl_img)"
 
-    sgdisk -t 1:"E3C9E316-0B5C-4DB8-817D-F92DF00215AE" "${hdd_img}"
+    sgdisk -t 1:"EBD0A0A2-B9E5-4433-87C0-68B6B72699C7" "${hdd_img}"
     dd if="${BR2_EXTERNAL_HASSOS_PATH}/bootloader/mbr-spl.img" of="${hdd_img}" conv=notrunc bs=512 count=1
     dd if="${spl_img}" of="${hdd_img}" conv=notrunc bs=512 seek=2 skip=2
 }


### PR DESCRIPTION
Currently the Microsoft Reserved Partition GUID is used for this FAT32
formatted partition. This GUID is a rather Microsoft Windows specific
GUID and not commonly used on Linux.

On Linux systems partitions of this type do not get automatically
mounted (see /usr/lib/udev/rules.d/80-udisks2.rules). However, since
this partition contains some files user commonly need to adjust
(config.txt, cmdline.txt) it would be good if the partition does get
mounted.

Use Microsoft Basic Data instead, which is used by default for FAT32
partition (even by Linux partitioning tools such as gparted). Tested
on ASUS Tinker Board and RPi4.