### PR TITLE
Do not attempt to resize on every boot (#843)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
@@ -11,7 +11,7 @@ PART_NUM="${DEVICE_CHILD: -1}"
 
 # Need resize
 UNUSED=$(sfdisk -Fq "${DEVICE_ROOT}" | cut -d " " -f 3 | tail -1)
-if [ -z "${UNUSED}" ] || [ "${UNUSED}" -le "2048" ]; then
+if [ -z "${UNUSED}" ] || [ "${UNUSED}" -le "16384" ]; then
     echo "[INFO] No resize of data partition needed"
     exit 0
 fi


### PR DESCRIPTION
The hassos-expand script calls sfdisk to find free disk space. It seems
that today it considers the space before the first partition as free:
$ sudo sfdisk -Fq /dev/sdi
Start   End Sectors Size
 2048 16383   14336   7M

This causes the script to always resize. It seems not to cause harm to
the partition table (it does not resize really). However, the call to
partx seems to confuse systemd and kill the mnt-data.mount process
(presumably because udev causes remove/add events for the by-label
device units).

Consider everything below 8MiB to not be worthy of a size change. This
avoids missdetection and resize attempts where there is no need.