### PR TITLE
Make sure udev rule only applies to first PL011 UART (#778)

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-rpi.rules
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-rpi.rules
@@ -1,4 +1,4 @@
-KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
+KERNEL=="ttyAMA[01]", ATTR{iomem_base}=="0xFE201000", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
 		echo 0;\


### PR DESCRIPTION
The to symlink serial0/1 currently might apply to the first or second
ttyAMAX instance. In downstream, a patch makes sure that the first
PL011 is always ttyAMA0. However, upstream the numbering depends on the
UART alias, which leads to the first PL011 being ttyAMA1.

Check the actual iobase too to make sure we are dealing with the first
PL011 instance.

See also:
https://github.com/RPi-Distro/raspberrypi-sys-mods/commit/05cfe136f76677a891a0c77dc91d796913607c07#diff-2678c183f503319c8d8c09c818af789a