### PR TITLE
Resize serial terminal on login (#860)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -3,6 +3,12 @@
 # Run logging cli
 # ==============================================================================
 
+# Setup terminal size on serial console
+if [ "${TERM}" = "vt220" ] || [ "${TERM}" = "vt102" ] || \
+   [ "${TERM}" = "vt100" ]; then
+	resize
+fi
+
 # Run CLI container
 if [ "$(docker ps -q -f name=hassio_cli)" ]; then
     docker container exec \


### PR DESCRIPTION
The new readline utilty used by the CLI add-on requires the size of the
terminal to be set. Use the resize command to initialize terminal size
on login if we are running on a serial terminal.