### PR TITLE
Fix var-lib-NetworkManager.mount dependencies

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-lib-NetworkManager.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/var-lib-NetworkManager.mount
@@ -1,7 +1,7 @@
 [Unit]
 Description=NetworkManager persistent data
-Requires=mnt-data.mount
-After=mnt-data.mount
+Requires=mnt-overlay.mount
+After=mnt-overlay.mount hassos-overlay.service
 Before=NetworkManager.service
 
 [Mount]


### PR DESCRIPTION
Since `What=/mnt/overlay/...`, the `Requires/After` should refer to `mnt-overlay.mount`