### PR TITLE
RaspberryPI: Fix issue with correct SYMLINK with ttyAMA

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-com.rules
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-com.rules
@@ -1,6 +1,20 @@
-KERNEL=="ttyAMA[01]", ATTR{iomem_base}=="0xFE201000", PROGRAM="/bin/sh -c '\
+
+KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+		echo 0;\
+	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+		echo 1; \
+	else \
+		exit 1; \
+	fi\
+'", SYMLINK+="serial%c"
+
+KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
+	ALIASES=/proc/device-tree/aliases; \
+	if [ -e /dev/ttyAMA0 ]; then \
+		exit 1; \
+	elif cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
 		echo 0;\
 	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
 		echo 1; \


### PR DESCRIPTION
Fix: #910 

Partial different approach as https://github.com/home-assistant/operating-system/pull/862 - however, we use this only for the Bluetooth scripts.