### PR TITLE
add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 /release
 *.pem


### PR DESCRIPTION
I sometimes do development on macOS and it litters .DS_Store files that cause git to think the directory is dirty.