### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/buildroot-external/board/intel/ova/hassos-hook.sh
+++ b/buildroot-external/board/intel/ova/hassos-hook.sh
@@ -31,9 +31,9 @@ function hassos_post_image() {
     mkdir -p "${OVA_DATA}"
     rm -f "${HDD_OVA}"
 
-    cp -a ${BOARD_DIR}/home-assistant.ovf "${OVA_DATA}/home-assistant.ovf"
+    cp -a "${BOARD_DIR}/home-assistant.ovf" "${OVA_DATA}/home-assistant.ovf"
     qemu-img convert -O vmdk -o subformat=streamOptimized "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
-    (cd "${OVA_DATA}"; sha256sum --tag home-assistant.* >home-assistant.mf)
+    (cd "${OVA_DATA}" || exit 1; sha256sum --tag home-assistant.* >home-assistant.mf)
     tar -C "${OVA_DATA}" --owner=root --group=root -cf "${HDD_OVA}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
 
     # Cleanup

--- a/buildroot-external/package/bluetooth-rtl8723/bluetooth-rtl8723
+++ b/buildroot-external/package/bluetooth-rtl8723/bluetooth-rtl8723
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Setup the Bluetooth chip"
 echo 146 > /sys/class/gpio/export


### PR DESCRIPTION
* Use double quote to prevent globbing and exit with error in case
  directory doesn't exit in hassos-hook.sh

* echo flags are undefined in POSIX, use bash instead in
  bluetooth-rtl8723