### PR TITLE
Fix N2+ boot by disabling USB enumeration

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -25,8 +25,6 @@ setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=ap
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"
 setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=squashfs ro rootwait"
 
-usb start
-
 # Load extraargs
 fileenv mmc ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
 fatload mmc ${devnum}:1 ${fdt_addr_r} meson-gxbb-odroidc2.dtb

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -25,8 +25,6 @@ setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=ap
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"
 setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=squashfs ro rootwait"
 
-usb start
-
 # Load extraargs
 fileenv mmc ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
 fatload mmc ${devnum}:1 ${fdt_addr_r} meson-sm1-odroid-c4.dtb

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -25,8 +25,6 @@ setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=ap
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"
 setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=squashfs ro rootwait"
 
-usb start
-
 # Load extraargs
 fileenv mmc ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
 if test "${board_rev}" = "c"; then

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -27,8 +27,6 @@ setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=ap
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"
 setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=squashfs ro rootwait"
 
-#usb start
-
 # Load extraargs
 fileenv mmc ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
 fatload mmc ${devnum}:1 ${fdt_addr_r} exynos5422-odroidxu4.dtb


### PR DESCRIPTION
On some devices USB enumeration in U-Boot seems to freeze:
starting USB...
Bus usb@ff500000: Register 3000140 NbrPorts 3
Starting the controller
USB XHCI 1.10
scanning bus usb@ff500000 for devices... <freeze>

We don't use USB currenty in the U-Boot script, disable it for now.