### PR TITLE
Avoid trying to boot non-existing kernel image in failover case

### DIFF
--- a/buildroot-external/board/asus/tinker/uboot-boot.ush
+++ b/buildroot-external/board/asus/tinker/uboot-boot.ush
@@ -40,16 +40,17 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:2 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:2 ${kernel_addr_r} zImage; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:4 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:4 ${kernel_addr_r} zImage"; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
     fi
   fi
 done
@@ -64,10 +65,8 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
+echo "Starting kernel"
 bootz ${kernel_addr_r} - ${fdt_addr_r}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -46,16 +46,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:5 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:7 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      fi
     fi
   fi
 done
@@ -70,12 +72,9 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
-printenv load_kernel
 printenv bootargs
+echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_addr_r}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -46,16 +46,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:5 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:7 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      fi
     fi
   fi
 done
@@ -70,12 +72,9 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
-printenv load_kernel
 printenv bootargs
+echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_addr_r}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -50,16 +50,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:5 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:7 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      fi
     fi
   fi
 done
@@ -74,12 +76,9 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
-printenv load_kernel
 printenv bootargs
+echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_addr_r}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -50,16 +50,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:5 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load mmc ${devnum}:7 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
+      fi
     fi
   fi
 done
@@ -74,13 +76,9 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
-printenv load_kernel
 printenv bootargs
-dmc ${ddr_freq}
-bootz ${kernel_addr_r} - ${fdt_addr_r}
+echo "Starting kernel"
+booti ${kernel_addr_r} - ${fdt_addr_r}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -51,7 +51,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
-      if ext4load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+      if ext4load mmc ${devnum}:5 ${kernel_addr_r} zImage; then
           setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
       fi
     fi

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -59,7 +59,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
-      if ext4load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+      if ext4load mmc ${devnum}:7 ${kernel_addr_r} zImage; then
           setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
       fi
     fi

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -37,16 +37,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load ${devtype} ${devnum}:2 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load ${devtype} ${devnum}:2 ${kernel_addr_r} zImage; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} zImage"
-      setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} zImage"; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+      fi
     fi
   fi
 done
@@ -62,10 +64,8 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
+echo "Starting kernel"
 bootz ${kernel_addr_r} - ${fdt_org}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -37,16 +37,18 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setenv load_kernel "ext4load ${devtype} ${devnum}:2 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+      echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load ${devtype} ${devnum}:2 ${kernel_addr_r} Image; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+      fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setenv load_kernel "ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} Image"
-      setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+      echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
+      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} Image"; then
+          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+      fi
     fi
   fi
 done
@@ -62,10 +64,8 @@ else
   reset
 fi
 
-echo "Loading kernel"
-run load_kernel
-echo " Starting kernel"
+echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_org}
 
-echo "Fails on boot"
+echo "Boot failed, resetting..."
 reset


### PR DESCRIPTION
The A/B update system automatically switches to the other boot slot when
booting fails. However, in a fresh installation, only boot slot A
exists. If booting fails three times (e.g. if somebody plugs out power
before the slot can be marked as good), then the system switches to boot
slot B which does not contain a kernel image yet. Avoid trying to boot
the non-existing kernel image.

With this change, if slot B is empty U-Boot will restore both slots to 3
attempts and retry booting from slot A on next reboot:

```
Trying to boot slot B, 2 attempts remaining. Loading kernel ...
** Unrecognized filesystem type **
No valid slot found, resetting tries to 3
storing env...
```