### PR TITLE
Compress images using xz instead of gzip

### DIFF
--- a/buildroot-external/board/asus/hassos-hook.sh
+++ b/buildroot-external/board/asus/hassos-hook.sh
@@ -21,5 +21,5 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }

--- a/buildroot-external/board/hardkernel/odroid-c2/hassos-hook.sh
+++ b/buildroot-external/board/hardkernel/odroid-c2/hassos-hook.sh
@@ -22,6 +22,6 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }
 

--- a/buildroot-external/board/hardkernel/odroid-c4/hassos-hook.sh
+++ b/buildroot-external/board/hardkernel/odroid-c4/hassos-hook.sh
@@ -19,5 +19,5 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }

--- a/buildroot-external/board/hardkernel/odroid-n2/hassos-hook.sh
+++ b/buildroot-external/board/hardkernel/odroid-n2/hassos-hook.sh
@@ -19,6 +19,6 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }
 

--- a/buildroot-external/board/hardkernel/odroid-xu4/hassos-hook.sh
+++ b/buildroot-external/board/hardkernel/odroid-xu4/hassos-hook.sh
@@ -26,5 +26,5 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }

--- a/buildroot-external/board/intel/nuc/hassos-hook.sh
+++ b/buildroot-external/board/intel/nuc/hassos-hook.sh
@@ -15,6 +15,6 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }
 

--- a/buildroot-external/board/intel/ova/hassos-hook.sh
+++ b/buildroot-external/board/intel/ova/hassos-hook.sh
@@ -22,10 +22,10 @@ function hassos_post_image() {
     # Virtual Disk images
     convert_disk_image_virtual
 
-    convert_disk_image_gz vmdk
-    convert_disk_image_gz vhdx
-    convert_disk_image_gz vdi
-    convert_disk_image_gz qcow2
+    convert_disk_image_xz vmdk
+    convert_disk_image_xz vhdx
+    convert_disk_image_xz vdi
+    convert_disk_image_xz qcow2
 
     # OVA
     mkdir -p "${OVA_DATA}"

--- a/buildroot-external/board/raspberrypi/hassos-hook.sh
+++ b/buildroot-external/board/raspberrypi/hassos-hook.sh
@@ -33,6 +33,6 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    convert_disk_image_gz
+    convert_disk_image_xz
 }
 

--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -312,10 +312,10 @@ function convert_disk_image_virtual() {
 }
 
 
-function convert_disk_image_gz() {
+function convert_disk_image_xz() {
     local hdd_ext=${1:-img}
     local hdd_img="$(hassos_image_name "${hdd_ext}")"
 
-    rm -f "${hdd_img}.gz"
-    gzip --best "${hdd_img}"
+    rm -f "${hdd_img}.xz"
+    xz -3 -T0 "${hdd_img}"
 }


### PR DESCRIPTION
The xz compression allows higher compression rates and higher speeds,
a quick measurement lead to this numbers:
gzip --best: compression 131.11s, decompression 9.797s (299M)
xz -3 (single thread): compression 95.13s, decompression 14.902s (228M)
xz -3 (multi thread): compression 12.146s, decompression 14.902s (228M)