### PR TITLE
Add sub-directory per development build

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,6 +25,7 @@ jobs:
     name: Release build for ${{ matrix.board.name }}
     needs: version
     strategy:
+      fail-fast: false
       matrix:
         board:
           - {"name": "ova", "output": "ova", "runner": "x86-64-runner"}
@@ -75,6 +76,6 @@ jobs:
           port: ${{ secrets.DEV_PORT }}
           key: ${{ secrets.DEV_SCP_KEY }}
           source: "release/*"
-          target: ${{ secrets.DEV_TARGET_PATH }}
+          target: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.version.outputs.version_dev }}/
           strip_components: 1
 


### PR DESCRIPTION
HAOS builds add a lot of files and things get quickly messy. Use a
directory per build.

Also don't abort the complete build if a single board failed, we still
might be interested in the rest.