### PR TITLE
Fix boot script issues (#1024)

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -78,7 +78,7 @@ fi
 
 printenv bootargs
 echo "Starting kernel"
-booti ${kernel_addr_r} - ${fdt_addr_r}
+bootz ${kernel_addr_r} - ${fdt_addr_r}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -46,7 +46,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
-      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} zImage"; then
+      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} zImage; then
           setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
       fi
     fi

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -46,7 +46,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
-      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} Image"; then
+      if ext4load ${devtype} ${devnum}:4 ${kernel_addr_r} Image; then
           setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
       fi
     fi


### PR DESCRIPTION
The change "Avoid trying to boot non-existing kernel image in failover
case" introduced a broken boot script on Raspberry Pi (when booting from
partition B) and ODROID-XU4.