### PR TITLE
Fix ODROID-N2(+) SoC version banner

### DIFF
--- a/buildroot-external/board/hardkernel/patches/uboot/0001-ARM-meson-isolate-loading-of-socinfo.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0001-ARM-meson-isolate-loading-of-socinfo.patch
@@ -1,5 +1,5 @@
-From 698972869afda7095e31892c48051350788aa0a1 Mon Sep 17 00:00:00 2001
-Message-Id: <698972869afda7095e31892c48051350788aa0a1.1603550330.git.stefan@agner.ch>
+From f9877c2895d6c05710a828d0cd46d9f25626b070 Mon Sep 17 00:00:00 2001
+Message-Id: <f9877c2895d6c05710a828d0cd46d9f25626b070.1606490648.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 31 Aug 2020 13:40:18 +0200
 Subject: [PATCH 1/2] ARM: meson: isolate loading of socinfo
@@ -9,14 +9,14 @@ reused later.
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
- arch/arm/mach-meson/board-info.c | 20 ++++++++++++++++++--
- 1 file changed, 18 insertions(+), 2 deletions(-)
+ arch/arm/mach-meson/board-info.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/mach-meson/board-info.c b/arch/arm/mach-meson/board-info.c
-index 3abb27e03b..cfcd5bbd3b 100644
+index 3abb27e03b..c585b12ca5 100644
 --- a/arch/arm/mach-meson/board-info.c
 +++ b/arch/arm/mach-meson/board-info.c
-@@ -126,12 +126,16 @@ static void print_board_model(void)
+@@ -126,7 +126,7 @@ static void print_board_model(void)
  	printf("Model: %s\n", model ? model : "Unknown");
  }
  
@@ -25,17 +25,7 @@ index 3abb27e03b..cfcd5bbd3b 100644
  {
  	struct regmap *regmap;
  	int nodeoffset, ret;
- 	ofnode node;
--	unsigned int socinfo;
-+	static unsigned int socinfo = 0;
-+
-+	/* Empty socinfo is invalid, so !socinfo is successfully initialized */
-+	if (socinfo)
-+		return socinfo;
- 
- 	/* find the offset of compatible node */
- 	nodeoffset = fdt_node_offset_by_compatible(gd->fdt_blob, -1,
-@@ -158,8 +162,20 @@ int show_board_info(void)
+@@ -158,8 +158,20 @@ int show_board_info(void)
  		return 0;
  	}
  
@@ -57,5 +47,5 @@ index 3abb27e03b..cfcd5bbd3b 100644
  	       socinfo_to_soc_id(socinfo),
  	       socinfo_to_package_id(socinfo),
 -- 
-2.29.1
+2.29.2
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
@@ -1,7 +1,7 @@
-From 439e2a240062c4be21ac7879b130ef590106cdd8 Mon Sep 17 00:00:00 2001
-Message-Id: <439e2a240062c4be21ac7879b130ef590106cdd8.1603550497.git.stefan@agner.ch>
-In-Reply-To: <698972869afda7095e31892c48051350788aa0a1.1603550497.git.stefan@agner.ch>
-References: <698972869afda7095e31892c48051350788aa0a1.1603550497.git.stefan@agner.ch>
+From 31e32295dc261032d7f5540a0b7f79a4f5a5b807 Mon Sep 17 00:00:00 2001
+Message-Id: <31e32295dc261032d7f5540a0b7f79a4f5a5b807.1606490648.git.stefan@agner.ch>
+In-Reply-To: <f9877c2895d6c05710a828d0cd46d9f25626b070.1606490648.git.stefan@agner.ch>
+References: <f9877c2895d6c05710a828d0cd46d9f25626b070.1606490648.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 4 Aug 2020 13:50:57 +0000
 Subject: [PATCH 2/2] meson: Add board_rev to env
@@ -35,10 +35,10 @@ index a90fe55081..c67d12d06c 100644
 +
  #endif /* __MESON_BOOT_H__ */
 diff --git a/arch/arm/mach-meson/board-info.c b/arch/arm/mach-meson/board-info.c
-index cfcd5bbd3b..3ea7eb7251 100644
+index c585b12ca5..9dbb997281 100644
 --- a/arch/arm/mach-meson/board-info.c
 +++ b/arch/arm/mach-meson/board-info.c
-@@ -186,3 +186,15 @@ int show_board_info(void)
+@@ -182,3 +182,15 @@ int show_board_info(void)
  
  	return 0;
  }
@@ -78,5 +78,5 @@ index caf7fd6810..c2a191ba6a 100644
  
  	if (!eth_env_get_enetaddr("ethaddr", mac_addr)) {
 -- 
-2.29.1
+2.29.2
 


### PR DESCRIPTION
The version banner was showing "Amlogic Meson G12A (Unknown) Revision
28:0 (0:0)" in all cases instead of the correct SoC name and revision.
Make sure the SoC revision is properly read also for the banner.