### PR TITLE
Fix ethernet link not comming up on ODROID-C2

### DIFF
--- a/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-convert-ODROID-N2-to-dtsi.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-convert-ODROID-N2-to-dtsi.patch
@@ -1,8 +1,8 @@
 From 9d2a2b44e67b0ef49e534c097e8b5e3e1173b033 Mon Sep 17 00:00:00 2001
-Message-Id: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+Message-Id: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Tue, 15 Sep 2020 17:24:30 +0200
-Subject: [PATCH 1/6] arm64: dts: meson: convert ODROID-N2 to dtsi
+Subject: [PATCH 1/7] arm64: dts: meson: convert ODROID-N2 to dtsi
 
 Convert the current ODROID-N2 dts into a common dtsi in preparation
 for adding ODROID-N2+ support.

--- a/buildroot-external/board/hardkernel/patches/linux/0002-dt-bindings-arm-amlogic-add-support-for-the-ODROID-N.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0002-dt-bindings-arm-amlogic-add-support-for-the-ODROID-N.patch
@@ -1,10 +1,10 @@
 From 258f03fa4fd897a61b5861df1f809e234711dd49 Mon Sep 17 00:00:00 2001
-Message-Id: <258f03fa4fd897a61b5861df1f809e234711dd49.1606779815.git.stefan@agner.ch>
-In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
-References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+Message-Id: <258f03fa4fd897a61b5861df1f809e234711dd49.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Tue, 15 Sep 2020 17:24:31 +0200
-Subject: [PATCH 2/6] dt-bindings: arm: amlogic: add support for the ODROID-N2+
+Subject: [PATCH 2/7] dt-bindings: arm: amlogic: add support for the ODROID-N2+
 
 HardKernel ODROID-N2+ uses a revised Amlogic S922X v2 chip that supports
 higher cpu clock speeds than the original ODROID-N2.

--- a/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-add-support-for-the-ODROID-N2.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-add-support-for-the-ODROID-N2.patch
@@ -1,10 +1,10 @@
 From 6cfaddae585e5a87c5253c932b8d58e153159f6b Mon Sep 17 00:00:00 2001
-Message-Id: <6cfaddae585e5a87c5253c932b8d58e153159f6b.1606779815.git.stefan@agner.ch>
-In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
-References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+Message-Id: <6cfaddae585e5a87c5253c932b8d58e153159f6b.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Tue, 15 Sep 2020 17:24:32 +0200
-Subject: [PATCH 3/6] arm64: dts: meson: add support for the ODROID-N2+
+Subject: [PATCH 3/7] arm64: dts: meson: add support for the ODROID-N2+
 
 HardKernel ODROID-N2+ uses an Amlogic S922X rev. C chip capable of higher
 clock speeds than the original ODROID-N2.

--- a/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-odroid-n2-plus-fix-vddcpu_a-pwm.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-odroid-n2-plus-fix-vddcpu_a-pwm.patch
@@ -1,10 +1,10 @@
 From 47f804dc970e2b1f71f1f032a0da2ef3b8315be0 Mon Sep 17 00:00:00 2001
-Message-Id: <47f804dc970e2b1f71f1f032a0da2ef3b8315be0.1606779815.git.stefan@agner.ch>
-In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
-References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+Message-Id: <47f804dc970e2b1f71f1f032a0da2ef3b8315be0.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Jerome Brunet <jbrunet@baylibre.com>
 Date: Fri, 23 Oct 2020 11:41:39 +0200
-Subject: [PATCH 4/6] arm64: dts: meson: odroid-n2 plus: fix vddcpu_a pwm
+Subject: [PATCH 4/7] arm64: dts: meson: odroid-n2 plus: fix vddcpu_a pwm
 
 On the odroid N2 plus, cpufreq is not available due to an error on the cpu
 regulators. vddcpu a and b get the same PWM. The one provided to vddcpu A

--- a/buildroot-external/board/hardkernel/patches/linux/0005-arm64-dts-meson-add-RTC-to-ODROID-N2-boards.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0005-arm64-dts-meson-add-RTC-to-ODROID-N2-boards.patch
@@ -1,10 +1,10 @@
 From 2c15ad491233a80d61c811a944b86067e2e74686 Mon Sep 17 00:00:00 2001
-Message-Id: <2c15ad491233a80d61c811a944b86067e2e74686.1606779815.git.stefan@agner.ch>
-In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
-References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+Message-Id: <2c15ad491233a80d61c811a944b86067e2e74686.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 16 Nov 2020 23:11:02 +0100
-Subject: [PATCH 5/6] arm64: dts: meson: add RTC to ODROID-N2 boards
+Subject: [PATCH 5/7] arm64: dts: meson: add RTC to ODROID-N2 boards
 
 All ODROID-N2 boards come with a NXP PCF8563TS RTC connected to I2C bus
 3. This is the RTC which is connected to the on-board RTC backup battery.

--- a/buildroot-external/board/hardkernel/patches/linux/0006-arm64-dts-meson-g12b-odroid-n2-fix-PHY-deassert-timi.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0006-arm64-dts-meson-g12b-odroid-n2-fix-PHY-deassert-timi.patch
@@ -1,15 +1,16 @@
-From 01467c329a3aa70f92ac3cc6d1ab25252889cc34 Mon Sep 17 00:00:00 2001
-Message-Id: <01467c329a3aa70f92ac3cc6d1ab25252889cc34.1606779815.git.stefan@agner.ch>
-In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
-References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606779815.git.stefan@agner.ch>
+From 35d2de7b27bc3f4bc2d977fb6b7671d9ba889496 Mon Sep 17 00:00:00 2001
+Message-Id: <35d2de7b27bc3f4bc2d977fb6b7671d9ba889496.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 1 Dec 2020 00:32:23 +0100
-Subject: [PATCH 6/6] arm64: dts: meson: fix PHY deassert timing requirements
+Subject: [PATCH 6/7] arm64: dts: meson: g12b: odroid-n2: fix PHY deassert
+ timing requirements
 
-According to the datasheet (Rev. 1.4, page 30) the RTL8211F requires
-at least 50ms "for internal circuits settling time" before accessing
-the PHY registers. This fixes an issue where the Ethernet link doesn't
-come up when using ip link set down/up:
+According to the datasheet (Rev. 1.9) the RTL8211F requires at least
+72ms "for internal circuits settling time" before accessing the PHY
+egisters. This fixes an issue where the Ethernet link doesn't come up
+when using ip link set down/up:
   [   29.360965] meson8b-dwmac ff3f0000.ethernet eth0: Link is Down
   [   34.569012] meson8b-dwmac ff3f0000.ethernet eth0: PHY [0.0:00] driver [RTL8211F Gigabit Ethernet] (irq=31)
   [   34.676732] meson8b-dwmac ff3f0000.ethernet: Failed to reset the dma
@@ -23,7 +24,7 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
-index 40390feba053..08c44fb0ccd0 100644
+index 40390feba053..445d90d25aa3 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
 @@ -415,7 +415,7 @@ external_phy: ethernet-phy@0 {
@@ -31,7 +32,7 @@ index 40390feba053..08c44fb0ccd0 100644
  
  		reset-assert-us = <10000>;
 -		reset-deassert-us = <30000>;
-+		reset-deassert-us = <50000>;
++		reset-deassert-us = <80000>;
  		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
  
  		interrupt-parent = <&gpio_intc>;

--- a/buildroot-external/board/hardkernel/patches/linux/0007-arm64-dts-meson-fix-PHY-deassert-timing-requirements.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0007-arm64-dts-meson-fix-PHY-deassert-timing-requirements.patch
@@ -1,0 +1,152 @@
+From 40e8e7e28c44993e352195b359c4d4540bfb2105 Mon Sep 17 00:00:00 2001
+Message-Id: <40e8e7e28c44993e352195b359c4d4540bfb2105.1606829302.git.stefan@agner.ch>
+In-Reply-To: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+References: <9d2a2b44e67b0ef49e534c097e8b5e3e1173b033.1606829302.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 1 Dec 2020 00:32:23 +0100
+Subject: [PATCH 7/7] arm64: dts: meson: fix PHY deassert timing requirements
+
+According to the datasheet (Rev. 1.9) the RTL8211F requires at least
+72ms "for internal circuits settling time" before accessing the PHY
+egisters. This fixes an issue seen on ODROID-C2 where the Ethernet
+link doesn't come up when using ip link set down/up:
+  [ 6630.714855] meson8b-dwmac c9410000.ethernet eth0: Link is Down
+  [ 6630.785775] meson8b-dwmac c9410000.ethernet eth0: PHY [stmmac-0:00] driver [RTL8211F Gigabit Ethernet] (irq=36)
+  [ 6630.893071] meson8b-dwmac c9410000.ethernet: Failed to reset the dma
+  [ 6630.893800] meson8b-dwmac c9410000.ethernet eth0: stmmac_hw_setup: DMA engine initialization failed
+  [ 6630.902835] meson8b-dwmac c9410000.ethernet eth0: stmmac_open: Hw setup failed
+
+Fixes: f29cabf240ed ("arm64: dts: meson: use the generic Ethernet PHY reset GPIO bindings")
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts  | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts   | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxbb-vega-s95.dtsi  | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi     | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts  | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts   | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxm-q200.dts        | 2 +-
+ arch/arm64/boot/dts/amlogic/meson-gxm-rbox-pro.dts    | 2 +-
+ 9 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+index 7be3e354093b..de27beafe9db 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+@@ -165,7 +165,7 @@ eth_phy0: ethernet-phy@0 {
+ 			reg = <0>;
+ 
+ 			reset-assert-us = <10000>;
+-			reset-deassert-us = <30000>;
++			reset-deassert-us = <80000>;
+ 			reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 			interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+index 70fcfb7b0683..50de1d01e565 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+@@ -200,7 +200,7 @@ eth_phy0: ethernet-phy@0 {
+ 			reg = <0>;
+ 
+ 			reset-assert-us = <10000>;
+-			reset-deassert-us = <30000>;
++			reset-deassert-us = <80000>;
+ 			reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 			interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-vega-s95.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb-vega-s95.dtsi
+index 222ee8069cfa..9b0b81f191f1 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-vega-s95.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-vega-s95.dtsi
+@@ -126,7 +126,7 @@ eth_phy0: ethernet-phy@0 {
+ 			reg = <0>;
+ 
+ 			reset-assert-us = <10000>;
+-			reset-deassert-us = <30000>;
++			reset-deassert-us = <80000>;
+ 			reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 			interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
+index ad812854a107..a350fee1264d 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
+@@ -147,7 +147,7 @@ eth_phy0: ethernet-phy@0 {
+ 			reg = <0>;
+ 
+ 			reset-assert-us = <10000>;
+-			reset-deassert-us = <30000>;
++			reset-deassert-us = <80000>;
+ 			reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 			interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
+index b08c4537f260..b2ab05c22090 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
+@@ -82,7 +82,7 @@ external_phy: ethernet-phy@0 {
+ 
+ 		/* External PHY reset is shared with internal PHY Led signal */
+ 		reset-assert-us = <10000>;
+-		reset-deassert-us = <30000>;
++		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index bff8ec2c1c70..e38d9e50caa7 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -194,7 +194,7 @@ external_phy: ethernet-phy@0 {
+ 		reg = <0>;
+ 
+ 		reset-assert-us = <10000>;
+-		reset-deassert-us = <30000>;
++		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
+index 83eca3af44ce..dfa7a37a1281 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
+@@ -112,7 +112,7 @@ external_phy: ethernet-phy@0 {
+ 		max-speed = <1000>;
+ 
+ 		reset-assert-us = <10000>;
+-		reset-deassert-us = <30000>;
++		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 	};
+ };
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-q200.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-q200.dts
+index ea45ae0c71b7..8edbfe040805 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-q200.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-q200.dts
+@@ -64,7 +64,7 @@ external_phy: ethernet-phy@0 {
+ 
+ 		/* External PHY reset is shared with internal PHY Led signal */
+ 		reset-assert-us = <10000>;
+-		reset-deassert-us = <30000>;
++		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-rbox-pro.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-rbox-pro.dts
+index c89c9f846fb1..dde7cfe12cff 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-rbox-pro.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-rbox-pro.dts
+@@ -114,7 +114,7 @@ external_phy: ethernet-phy@0 {
+ 		max-speed = <1000>;
+ 
+ 		reset-assert-us = <10000>;
+-		reset-deassert-us = <30000>;
++		reset-deassert-us = <80000>;
+ 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
+ 	};
+ };
+-- 
+2.29.2
+


### PR DESCRIPTION
Use the latest patches from the mailing list to fix Ethernet on
ODROID-C2/N2(+).