### PR TITLE
Lower console log level after boot-up

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/10-printk.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/10-printk.conf
@@ -1,0 +1,2 @@
+# Only show kernel errors
+kernel.printk = 4 4 1 7


### PR DESCRIPTION
Some console logs are really not helpful in practise and are more
confusing then helpful. Show warnings and higher on console after
boot-up.