### PR TITLE
Enter console if data partition is missing

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -10,6 +10,11 @@ if [ "${TERM}" = "vt220" ] || [ "${TERM}" = "vt102" ] || \
 fi
 
 # Run CLI container
+if [ ! "$(findmnt /mnt/data)" ]; then
+    echo "[WARN] Data partition not mounted! Jump into emergency console..."
+    exec /bin/ash -l
+fi
+
 if [ "$(docker ps -q -f name=hassio_cli)" ]; then
     docker container exec \
         -ti hassio_cli \
@@ -21,7 +26,7 @@ if [ "$(docker ps -q -f name=hassio_cli)" ]; then
     fi
 else
     echo "[WARN] Home Assistant CLI is not running! Jump into emergency console..."
-    /bin/ash -l
+    exec /bin/ash -l
 fi
 
 exit


### PR DESCRIPTION
In case the data partition is missing avoid using the Docker command.
The Docker command triggers a socket activation, which in turn makes
systemd wait for the data partition. This blocks entry into the shell
forever.

Just enter the shell in case data partition is not mounted.