### PR TITLE
No random mac for wifi scan

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -13,3 +13,6 @@ backend=journal
 [connection]
 connection.mdns=2
 connection.llmnr=2
+
+[device]
+wifi.scan-rand-mac-address=no


### PR DESCRIPTION
Random MAC address makes sense for clients they move around. This will be used as a server which random mac are not wanted