### PR TITLE
Use correct label for ODROID boards in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,7 +10,7 @@ categories:
   - title: 'Intel NUC'
     label: 'board/intel-nuc'
   - title: 'Hardkernel ODROID'
-    label: 'board/hardkernel'
+    label: 'board/odroid'
   - title: 'ASUS Tinker'
     label: 'board/tinker'
 template: |


### PR DESCRIPTION
The correct label for Hardkernel's ODROID is board/odroid.