### PR TITLE
Mount boot partition sync (#1092)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
@@ -10,6 +10,7 @@ Wants=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2dboot.service
 What=/dev/disk/by-label/hassos-boot
 Where=/mnt/boot
 Type=auto
+Options=sync
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
When we write the update to the boot partiton, there is nothing which
makes sure that data is written to disk. This leaves a rather large
window (probably around 30s) where a machine reset/poweroff can lead
to a corrupted boot partition. Use the sync mount option to minimize the
corruption window.

Note that sync is not ideal for flash drives normally. But since we
write very little and typically only on OS update to the boot partition,
this shouldn't be a problem.