### PR TITLE
Mention potential need for quirks on usb boot

### DIFF
--- a/Documentation/boards/raspberrypi/README.md
+++ b/Documentation/boards/raspberrypi/README.md
@@ -37,9 +37,11 @@ USB mass storage boot is available on Raspberry Pi 4 (64-bit only), 3B, 3B+, 3A+
 
 For Raspberry 3B, 3A+ and 2B v1.2, to enable USB boot, add `program_usb_boot_mode=1` into `config.txt`. Note that this **permanently** alters the one-time programmable memory of the device.
 
-For Raspberry 4, make sure to update the bootloader to a stable release
-supporting USB mass storage boot (see
-[bcm2711_bootloader_config.md](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md#usbmassstorageboot). If no SD card is used add `sd_poll_once=on` to `dtparam` in `config.txt` (comma separated). This gets rid of `mmc0: timeout waiting for hardware interrupt` kernel errors.
+For Raspberry 4
+
+* Make sure to update the bootloader to a stable release supporting USB mass storage boot (see [bcm2711_bootloader_config.md](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711_bootloader_config.md#usbmassstorageboot)). 
+* If no SD card is used add `sd_poll_once=on` to `dtparam` in `config.txt` (comma separated). This gets rid of `mmc0: timeout waiting for hardware interrupt` kernel errors.
+* If install still fails, then your SSD likely needs quirks enabled to work correctly (see [Finding the VID and PID of your USB SSD](https://www.raspberrypi.org/forums/viewtopic.php?t=245931)). Once you find your adapter's ID, add the quirks parameter in `cmdline.txt`. 
 
 For more information see [RaspberryPi](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md).
 


### PR DESCRIPTION
We are directing people from Discord over to this page but there wasn't any mention they will likely be needing quirks enabled for USB boot on RPi 4. Tried to add some extra information to minimise people having simple issues from not realising everything they have to try to set up their SSD properly. Also some minor layout adjustments on that section.