### PR TITLE
Disable DNS over TLS by default (#1113)

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf
@@ -16,7 +16,7 @@
 #FallbackDNS=1.1.1.1 8.8.8.8 1.0.0.1 8.8.4.4 2606:4700:4700::1111 2001:4860:4860::8888 2606:4700:4700::1001 2001:4860:4860::8844
 #Domains=
 DNSSEC=no
-#DNSOverTLS=opportunistic
+DNSOverTLS=no
 #MulticastDNS=yes
 #LLMNR=yes
 #Cache=yes


### PR DESCRIPTION
It seems that on certain setups the default DNS over TLS mode
"opportunistic" causes delays of ~10s when trying to resolve names. This
is probably caused by providers and/or firewall setups not properly rejecting
connections on port 853.

It seems that also other distributions (such as Arch Linux) still
disable DNS over TLS currently. Side step issues with DNS over TLS by
disabling it for now.