### PR TITLE
Don't use page table mapping for compressed pages (#1129)

### DIFF
--- a/buildroot-external/board/raspberrypi/kernel.config
+++ b/buildroot-external/board/raspberrypi/kernel.config
@@ -1,2 +1,3 @@
 # CONFIG_AUTOFS4_FS is not set
 # CONFIG_AUTOFS_FS is not set
+# CONFIG_PGTABLE_MAPPING is not set


### PR DESCRIPTION
It seems that page table mappings for compressed tables cause issues in
certain situation leading to "zram: Decompression failed!" errors.
Upstream Linux seems to have recognized the problem and a patch to drop
the functionality entirly has been proposed:
https://lore.kernel.org/linux-mm/20201117135632.GA27763@infradead.org/