### PR TITLE
Fix systemd-udevd rule warning

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-com.rules
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/udev/rules.d/99-com.rules
@@ -1,9 +1,9 @@
 
 KERNEL=="ttyAMA0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -14,9 +14,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
 	if [ -e /dev/ttyAMA0 ]; then \
 		exit 1; \
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial0; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial0; then \
 		echo 0;\
-	elif cmp -s $ALIASES/uart0 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart0 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \
@@ -25,9 +25,9 @@ KERNEL=="ttyAMA1", PROGRAM="/bin/sh -c '\
 
 KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
 	ALIASES=/proc/device-tree/aliases; \
-	if cmp -s $ALIASES/uart1 $ALIASES/serial0; then \
+	if cmp -s $$ALIASES/uart1 $$ALIASES/serial0; then \
 		echo 0; \
-	elif cmp -s $ALIASES/uart1 $ALIASES/serial1; then \
+	elif cmp -s $$ALIASES/uart1 $$ALIASES/serial1; then \
 		echo 1; \
 	else \
 		exit 1; \


### PR DESCRIPTION
systemd-udevd substitutes variables starting with $ in the PROGRAM
argument. If a shell variable is to be used, two $ need to be used to
escape properly. This fixes three instances of the following warning:
Invalid value "..." for PROGRAM (char 58: invalid substitution type), ignoring, but please fix it.