### PR TITLE
Add hassos-apparmor dependency to supervisor

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=HassOS supervisor
 Requires=docker.service rauc.service dbus.service
-Wants=network-online.target
+Wants=network-online.target hassos-apparmor.service
 After=docker.service rauc.service dbus.service network-online.target
 RequiresMountsFor=/mnt/data /mnt/boot /mnt/overlay
 StartLimitIntervalSec=60


### PR DESCRIPTION
The supervisor container requires the "hassio-supervisor" AppArmor
profile. Make sure our AppArmor service hassos-apparmor is a dependency
of the hassos-supervisor.service.