### PR TITLE
Fix 64-bit image to boot on Raspberry Pi 400 (#1134)

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/linux/0001-dt-bindings-arm-bcm-Convert-BCM2835-firmware-binding.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0001-dt-bindings-arm-bcm-Convert-BCM2835-firmware-binding.patch
@@ -1,5 +1,5 @@
 From 3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73 Mon Sep 17 00:00:00 2001
-Message-Id: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+Message-Id: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Florian Fainelli <f.fainelli@gmail.com>
 Date: Mon, 15 Jun 2020 10:40:41 +0200
 Subject: [PATCH 1/8] dt-bindings: arm: bcm: Convert BCM2835 firmware binding

--- a/buildroot-external/board/raspberrypi/patches/linux/0002-dt-bindings-clock-Add-a-binding-for-the-RPi-Firmware.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0002-dt-bindings-clock-Add-a-binding-for-the-RPi-Firmware.patch
@@ -1,7 +1,7 @@
 From 3ad7fb9329eabd1d7f692f612742ca5ac38854a5 Mon Sep 17 00:00:00 2001
-Message-Id: <3ad7fb9329eabd1d7f692f612742ca5ac38854a5.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+Message-Id: <3ad7fb9329eabd1d7f692f612742ca5ac38854a5.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Maxime Ripard <maxime@cerno.tech>
 Date: Mon, 15 Jun 2020 10:40:42 +0200
 Subject: [PATCH 2/8] dt-bindings: clock: Add a binding for the RPi Firmware

--- a/buildroot-external/board/raspberrypi/patches/linux/0003-dt-bindings-arm-bcm-Add-a-select-to-the-RPI-Firmware.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0003-dt-bindings-arm-bcm-Add-a-select-to-the-RPI-Firmware.patch
@@ -1,7 +1,7 @@
 From 305aeb868929695699e04e26dd590e64ad3c42dd Mon Sep 17 00:00:00 2001
-Message-Id: <305aeb868929695699e04e26dd590e64ad3c42dd.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+Message-Id: <305aeb868929695699e04e26dd590e64ad3c42dd.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Maxime Ripard <maxime@cerno.tech>
 Date: Fri, 26 Jun 2020 13:54:33 +0200
 Subject: [PATCH 3/8] dt-bindings: arm: bcm: Add a select to the RPI Firmware

--- a/buildroot-external/board/raspberrypi/patches/linux/0004-dt-bindings-reset-Add-a-binding-for-the-RPi-Firmware.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0004-dt-bindings-reset-Add-a-binding-for-the-RPi-Firmware.patch
@@ -1,7 +1,7 @@
 From 33743cfcff296b1011e46168ecab185a00e0f00d Mon Sep 17 00:00:00 2001
-Message-Id: <33743cfcff296b1011e46168ecab185a00e0f00d.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+Message-Id: <33743cfcff296b1011e46168ecab185a00e0f00d.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
 Date: Mon, 29 Jun 2020 18:18:37 +0200
 Subject: [PATCH 4/8] dt-bindings: reset: Add a binding for the RPi Firmware

--- a/buildroot-external/board/raspberrypi/patches/linux/0005-ARM-dts-bcm2711-Add-firmware-usb-reset-node.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0005-ARM-dts-bcm2711-Add-firmware-usb-reset-node.patch
@@ -1,7 +1,7 @@
-From fecb02cc3664de0d1c43ce566ff95c1b68fca51e Mon Sep 17 00:00:00 2001
-Message-Id: <fecb02cc3664de0d1c43ce566ff95c1b68fca51e.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+From a97dba6bf04aa09279a7c5b4aec6e4520e354fbd Mon Sep 17 00:00:00 2001
+Message-Id: <a97dba6bf04aa09279a7c5b4aec6e4520e354fbd.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
 Date: Mon, 29 Jun 2020 18:18:39 +0200
 Subject: [PATCH 5/8] ARM: dts: bcm2711: Add firmware usb reset node
@@ -16,7 +16,9 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 (cherry picked from commit b03300db06bed1997a1eecc4c26f3a2895c57726)
 ---
  arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 5 +++++
- 1 file changed, 5 insertions(+)
+ arch/arm/boot/dts/bcm2711-rpi-400.dts | 5 +++++
+ arch/arm/boot/dts/bcm2711-rpi-cm4.dts | 5 +++++
+ 3 files changed, 15 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 index 21b20e334b1a..d77d61d41bbc 100644
@@ -34,6 +36,38 @@ index 21b20e334b1a..d77d61d41bbc 100644
  };
  
  &gpio {
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-400.dts b/arch/arm/boot/dts/bcm2711-rpi-400.dts
+index afd1ca215518..3a1eb65f7075 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-400.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-400.dts
+@@ -72,6 +72,11 @@
+ 				  "SD_OC_N";
+ 		status = "okay";
+ 	};
++
++	reset: reset {
++		compatible = "raspberrypi,firmware-reset";
++		#reset-cells = <1>;
++	};
+ };
+ 
+ &gpio {
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+index 3ff0be02cb34..7f0a621a47f5 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+@@ -84,6 +84,11 @@
+ 			output-low;
+ 		};
+ 	};
++
++	reset: reset {
++		compatible = "raspberrypi,firmware-reset";
++		#reset-cells = <1>;
++	};
+ };
+ 
+ &pwm1 {
 -- 
 2.29.2
 

--- a/buildroot-external/board/raspberrypi/patches/linux/0006-ARM-dts-bcm2711-Add-reset-controller-to-xHCI-node.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0006-ARM-dts-bcm2711-Add-reset-controller-to-xHCI-node.patch
@@ -1,7 +1,7 @@
-From e0231cd65d8c13be1cebae1e6b5fbef61be6be0d Mon Sep 17 00:00:00 2001
-Message-Id: <e0231cd65d8c13be1cebae1e6b5fbef61be6be0d.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+From c19d86704ffaa9fbe830aaa2a4015259928abf70 Mon Sep 17 00:00:00 2001
+Message-Id: <c19d86704ffaa9fbe830aaa2a4015259928abf70.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
 Date: Mon, 29 Jun 2020 18:18:40 +0200
 Subject: [PATCH 6/8] ARM: dts: bcm2711: Add reset controller to xHCI node
@@ -18,7 +18,9 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 (cherry picked from commit 258f92d2f840b6ea62c0b33f04eb4d9270935bba)
 ---
  arch/arm/boot/dts/bcm2711-rpi-4-b.dts | 17 +++++++++++++++++
- 1 file changed, 17 insertions(+)
+ arch/arm/boot/dts/bcm2711-rpi-400.dts | 17 +++++++++++++++++
+ arch/arm/boot/dts/bcm2711-rpi-cm4.dts | 12 ++++++++++++
+ 3 files changed, 46 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
 index d77d61d41bbc..513cae21e64c 100644
@@ -49,6 +51,71 @@ index d77d61d41bbc..513cae21e64c 100644
 +			reg = <0x10000 0 0 0 0>;
 +			resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
 +		};
++	};
++};
++
+ /* uart0 communicates with the BT module */
+ &uart0 {
+ 	pinctrl-names = "default";
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-400.dts b/arch/arm/boot/dts/bcm2711-rpi-400.dts
+index 3a1eb65f7075..c122aebd4d5e 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-400.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-400.dts
+@@ -3,6 +3,8 @@
+ #include "bcm2711.dtsi"
+ #include "bcm2835-rpi.dtsi"
+ 
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
++
+ / {
+ 	compatible = "raspberrypi,400", "brcm,bcm2711";
+ 	model = "Raspberry Pi 400";
+@@ -195,6 +197,21 @@
+ 	};
+ };
+ 
++&pcie0 {
++	pci@1,0 {
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		reg = <0 0 0 0 0>;
++
++		usb@1,0 {
++			reg = <0x10000 0 0 0 0>;
++			resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
++		};
++	};
++};
++
+ /* uart0 communicates with the BT module */
+ &uart0 {
+ 	pinctrl-names = "default";
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+index 7f0a621a47f5..5eda5d096bfb 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-cm4.dts
+@@ -3,6 +3,8 @@
+ #include "bcm2711.dtsi"
+ #include "bcm2835-rpi.dtsi"
+ 
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
++
+ / {
+ 	compatible = "raspberrypi,4-compute-module", "brcm,bcm2711";
+ 	model = "Raspberry Pi Compute Module 4";
+@@ -134,6 +136,16 @@
+ 	};
+ };
+ 
++&pcie0 {
++	pci@1,0 {
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		reg = <0 0 0 0 0>;
 +	};
 +};
 +

--- a/buildroot-external/board/raspberrypi/patches/linux/0007-arch-pgtable-define-MAX_POSSIBLE_PHYSMEM_BITS-where-.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0007-arch-pgtable-define-MAX_POSSIBLE_PHYSMEM_BITS-where-.patch
@@ -1,7 +1,7 @@
-From 5038cc5a33a1534bd0e521674314938224838ce4 Mon Sep 17 00:00:00 2001
-Message-Id: <5038cc5a33a1534bd0e521674314938224838ce4.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+From 189ef4e3aabe995021fdfb3ff9bfb3f9ffa5fae4 Mon Sep 17 00:00:00 2001
+Message-Id: <189ef4e3aabe995021fdfb3ff9bfb3f9ffa5fae4.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Arnd Bergmann <arnd@arndb.de>
 Date: Fri, 13 Nov 2020 15:59:32 +0100
 Subject: [PATCH 7/8] arch: pgtable: define MAX_POSSIBLE_PHYSMEM_BITS where

--- a/buildroot-external/board/raspberrypi/patches/linux/0008-ARM-dts-bcm283x-add-compatible-picked-up-by-U-Boot.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0008-ARM-dts-bcm283x-add-compatible-picked-up-by-U-Boot.patch
@@ -1,7 +1,7 @@
-From c18ca341da823bd2ec5aa04ea5970d3867eaae73 Mon Sep 17 00:00:00 2001
-Message-Id: <c18ca341da823bd2ec5aa04ea5970d3867eaae73.1605346684.git.stefan@agner.ch>
-In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
-References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1605346684.git.stefan@agner.ch>
+From febaf077f14b86da1edaa01abee2d0bfcf7bdece Mon Sep 17 00:00:00 2001
+Message-Id: <febaf077f14b86da1edaa01abee2d0bfcf7bdece.1609281882.git.stefan@agner.ch>
+In-Reply-To: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
+References: <3651b4af52d63d4e37f40c7a6d0809b0a6c9dd73.1609281882.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 2 Jun 2020 21:20:08 +0000
 Subject: [PATCH 8/8] ARM: dts: bcm283x: add compatible picked up by U-Boot


### PR DESCRIPTION
Add the missing PCIe node to make U-Boot's PCIe driver happy on
Raspberry Pi 400 as well.