### PR TITLE
Fix boot from eMMC on ODROID-C2 (#1142)

### DIFF
--- a/buildroot-external/board/hardkernel/patches/uboot/0001-ARM-meson-isolate-loading-of-socinfo.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0001-ARM-meson-isolate-loading-of-socinfo.patch
@@ -1,8 +1,8 @@
-From 526ccae8321b9b48925c44999611c3c5a374328e Mon Sep 17 00:00:00 2001
-Message-Id: <526ccae8321b9b48925c44999611c3c5a374328e.1607542946.git.stefan@agner.ch>
+From f9877c2895d6c05710a828d0cd46d9f25626b070 Mon Sep 17 00:00:00 2001
+Message-Id: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 31 Aug 2020 13:40:18 +0200
-Subject: [PATCH 1/3] ARM: meson: isolate loading of socinfo
+Subject: [PATCH 1/4] ARM: meson: isolate loading of socinfo
 
 Move loading of socinfo into a separate function so the value can be
 reused later.
@@ -47,5 +47,5 @@ index 3abb27e03b..c585b12ca5 100644
  	       socinfo_to_soc_id(socinfo),
  	       socinfo_to_package_id(socinfo),
 -- 
-2.29.2
+2.30.0
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0002-meson-Add-board_rev-to-env.patch
@@ -1,10 +1,10 @@
-From 2b2ad8c105cbb5fb48c3c5f0512c031f6533d522 Mon Sep 17 00:00:00 2001
-Message-Id: <2b2ad8c105cbb5fb48c3c5f0512c031f6533d522.1607542946.git.stefan@agner.ch>
-In-Reply-To: <526ccae8321b9b48925c44999611c3c5a374328e.1607542946.git.stefan@agner.ch>
-References: <526ccae8321b9b48925c44999611c3c5a374328e.1607542946.git.stefan@agner.ch>
+From 31e32295dc261032d7f5540a0b7f79a4f5a5b807 Mon Sep 17 00:00:00 2001
+Message-Id: <31e32295dc261032d7f5540a0b7f79a4f5a5b807.1609421746.git.stefan@agner.ch>
+In-Reply-To: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
+References: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 4 Aug 2020 13:50:57 +0000
-Subject: [PATCH 2/3] meson: Add board_rev to env
+Subject: [PATCH 2/4] meson: Add board_rev to env
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 Signed-off-by: Stefan Agner <stefan@agner.ch>
@@ -78,5 +78,5 @@ index caf7fd6810..c2a191ba6a 100644
  
  	if (!eth_env_get_enetaddr("ethaddr", mac_addr)) {
 -- 
-2.29.2
+2.30.0
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0003-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0003-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,10 +1,10 @@
-From 0077176ac369a1125c3fb22f7ba8e5d53576a1b3 Mon Sep 17 00:00:00 2001
-Message-Id: <0077176ac369a1125c3fb22f7ba8e5d53576a1b3.1607542946.git.stefan@agner.ch>
-In-Reply-To: <526ccae8321b9b48925c44999611c3c5a374328e.1607542946.git.stefan@agner.ch>
-References: <526ccae8321b9b48925c44999611c3c5a374328e.1607542946.git.stefan@agner.ch>
+From 01ba1339ffd095b146b9d9d772aea6f2b3594a06 Mon Sep 17 00:00:00 2001
+Message-Id: <01ba1339ffd095b146b9d9d772aea6f2b3594a06.1609421746.git.stefan@agner.ch>
+In-Reply-To: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
+References: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Mon, 2 Sep 2019 15:42:04 +0200
-Subject: [PATCH 3/3] HACK: mmc: meson-gx: limit to 24MHz
+Subject: [PATCH 3/4] HACK: mmc: meson-gx: limit to 24MHz
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
@@ -25,5 +25,5 @@ index 719dd1e5e5..dd3dd7c08c 100644
  	cfg->name = dev->name;
  
 -- 
-2.29.2
+2.30.0
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0004-pinctrl-meson-fix-bit-manipulation-of-pin-bias-confi.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0004-pinctrl-meson-fix-bit-manipulation-of-pin-bias-confi.patch
@@ -1,0 +1,43 @@
+From 26e152c0929702a9dfca4a8967601b59de77a57d Mon Sep 17 00:00:00 2001
+Message-Id: <26e152c0929702a9dfca4a8967601b59de77a57d.1609421746.git.stefan@agner.ch>
+In-Reply-To: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
+References: <f9877c2895d6c05710a828d0cd46d9f25626b070.1609421746.git.stefan@agner.ch>
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Mon, 14 Dec 2020 19:39:07 +0100
+Subject: [PATCH 4/4] pinctrl: meson: fix bit manipulation of pin bias
+ configuration
+
+This fixes the wrong usage of clrsetbits_le32(), badly setting the set argument.
+
+Fixes: c4c726c26b ("pinctrl: meson: add pinconf support")
+Reported-by: Anton Arapov <arapov@gmail.com>
+Reported-by: Otto Meier <gf435@gmx.net>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+(cherry picked from commit 5ccd5d2cc98224108ae9fb09593a862c9caa5e80)
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index d4539b02d8..5065b62436 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -216,13 +216,13 @@ static int meson_pinconf_bias_set(struct udevice *dev, unsigned int pin,
+ 	}
+ 
+ 	/* othewise, enable the bias and select level */
+-	clrsetbits_le32(priv->reg_pullen + reg, BIT(bit), 1);
++	clrsetbits_le32(priv->reg_pullen + reg, BIT(bit), BIT(bit));
+ 	ret = meson_gpio_calc_reg_and_bit(dev, offset, REG_PULL, &reg, &bit);
+ 	if (ret)
+ 		return ret;
+ 
+ 	clrsetbits_le32(priv->reg_pull + reg, BIT(bit),
+-			param == PIN_CONFIG_BIAS_PULL_UP);
++			(param == PIN_CONFIG_BIAS_PULL_UP ? BIT(bit) : 0));
+ 
+ 	return 0;
+ }
+-- 
+2.30.0
+


### PR DESCRIPTION
Latest U-Boot broke boot from eMMC on ODROID-C2. Revert the offending
device tree change to make the system boot again.