### PR TITLE
Allow setting PREFIX in the build to dictate where to find directories

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -74,7 +74,7 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            haos-builder make VERSION_DEV=${{ needs.version.outputs.version_dev }} ${{ matrix.board.name }}
+            haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.version.outputs.version_dev }} ${{ matrix.board.name }}
 
       - name: Upload images
         uses: appleboy/scp-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            haos-builder make VERSION_DEV="" ${{ matrix.board.name }}
+            haos-builder make BUILDDIR=/build VERSION_DEV="" ${{ matrix.board.name }}
 
       - name: Upload disk image
         if: ${{ matrix.board.name != 'ova' }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-RELEASE_DIR = /build/release
+BUILDDIR:=$(shell pwd)
+RELEASE_DIR = $(BUILDDIR)/release
 
-BUILDROOT=/build/buildroot
-BUILDROOT_EXTERNAL=/build/buildroot-external
+BUILDROOT=$(BUILDDIR)/buildroot
+BUILDROOT_EXTERNAL=$(BUILDDIR)/buildroot-external
 DEFCONFIG_DIR = $(BUILDROOT_EXTERNAL)/configs
 VERSION_DATE := $(shell date --utc +'%Y%m%d')
 VERSION_DEV := "dev$(VERSION_DATE)"


### PR DESCRIPTION
This allows building many components without elevated permissions or needing to do it within a container.