### PR TITLE
Fix connectivity check updated NM

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -14,5 +14,8 @@ backend=journal
 connection.mdns=2
 connection.llmnr=2
 
+[connectivity]
+uri=https://version.home-assistant.io/online.txt
+
 [device]
 wifi.scan-rand-mac-address=no


### PR DESCRIPTION
The update of the NM between REl-4 / REL-5 changed the behavior of the connectivity check. Currently, it's broken now on REL-5. This version of NM needs a predefined URL. This would use now the same URL as we do on Supervisor.