### PR TITLE
Disable fsck.fat for boot partition (might help #1125)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-boot.mount
@@ -3,8 +3,6 @@ Description=HassOS boot partition
 DefaultDependencies=no
 Before=umount.target local-fs.target
 Conflicts=umount.target
-After=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2dboot.service
-Wants=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2dboot.service
 
 [Mount]
 What=/dev/disk/by-label/hassos-boot


### PR DESCRIPTION
There are incident reports on the internet where poeple report that
fsck.(v)fat actually leads to problems rather file system fixes. Around
the time when Home Assistant OS added fsck.fat for the boot partition,
reports of empty boot partitions or file with weired filenames started
to appear. This could be caused by fsck.fat.

Disable fsck on the boot partition.