### PR TITLE
Fix partition resize for MBR for all sizes (#1193)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-expand
@@ -31,8 +31,7 @@ else
 
     # For MBR, we have to calculate the last usable sector by ourselfs
     DEVICE_SIZE=$(blockdev --getsize64 "${DEVICE_ROOT}")
-    SECTOR_SIZE=$(echo "${PART_TABLE}" | jq -r '.partitiontable.sectorsize')
-    LAST_USABLE_LBA="$((DEVICE_SIZE / SECTOR_SIZE))"
+    LAST_USABLE_LBA=$(echo "${PART_TABLE}" | jq -r "${DEVICE_SIZE} / .partitiontable.sectorsize")
 fi
 echo "[INFO] Last usable logical block ${LAST_USABLE_LBA}"
 


### PR DESCRIPTION
It seems that Busybox shell (ash) cannot calculate the disk size
properly probably due to integer overflow. Use jq to calculate the last
usable LBA which seems to be able to handle large integers.