### PR TITLE
Rename hassos to haos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(TARGETS_CONFIG): %-config:
 $(TARGETS): %: $(RELEASE_DIR) %-config
 	@echo "build $@"
 	$(MAKE) -C $(BUILDROOT) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) VERSION_DEV=$(VERSION_DEV)
-	cp -f $(O)/images/hassos_* $(RELEASE_DIR)/
+	cp -f $(O)/images/haos_* $(RELEASE_DIR)/
 
 	# Do not clean when building for one target
 ifneq ($(words $(filter $(TARGETS),$(MAKECMDGOALS))), 1)

--- a/buildroot-external/meta
+++ b/buildroot-external/meta
@@ -2,6 +2,6 @@ VERSION_MAJOR=6
 VERSION_BUILD=0
 
 HASSOS_NAME="Home Assistant OS"
-HASSOS_ID="hassos"
+HASSOS_ID="haos"
 
 DEPLOYMENT="development"

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -2,7 +2,27 @@
 
 ##
 # Hooks
-env
+
+case "$1" in
+     install-check)
+         if [[ "$RAUC_MF_COMPATIBLE" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
+             exit 0
+         fi
+         # Be compatible with hassos OS ID
+         rauc_os_compatible=${RAUC_MF_COMPATIBLE/haos-/hassos-}
+         if [[ "$RAUC_MF_COMPATIBLE" == "$rauc_os_compatible" ]]; then
+             exit 0
+         fi
+         echo "Compatible does not match!" 1>&2
+         exit 10
+         ;;
+    slot-install)
+        # Use install handlers below
+        ;;
+    *)
+        exit 1
+        ;;
+esac
 
 # Handle boot hocks
 if [ "${RAUC_SLOT_CLASS}" = "boot" ]; then

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -10,7 +10,7 @@ case "$1" in
          fi
          # Be compatible with hassos OS ID
          rauc_os_compatible=${RAUC_MF_COMPATIBLE/haos-/hassos-}
-         if [[ "$RAUC_MF_COMPATIBLE" == "$rauc_os_compatible" ]]; then
+         if [[ "$rauc_os_compatible" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
              exit 0
          fi
          echo "Compatible does not match!" 1>&2

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -5,12 +5,13 @@
 
 case "$1" in
      install-check)
-         if [[ "$RAUC_MF_COMPATIBLE" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
+         if [ "$RAUC_MF_COMPATIBLE" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi
          # Be compatible with hassos OS ID
+	 # shellcheck disable=SC2039
          rauc_os_compatible=${RAUC_MF_COMPATIBLE/haos-/hassos-}
-         if [[ "$rauc_os_compatible" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
+         if [ "$rauc_os_compatible" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi
          echo "Compatible does not match!" 1>&2

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -9,7 +9,7 @@ case "$1" in
              exit 0
          fi
          # Be compatible with hassos OS ID
-	 # shellcheck disable=SC2039
+         # shellcheck disable=SC2039
          rauc_os_compatible=${RAUC_MF_COMPATIBLE/haos-/hassos-}
          if [ "$rauc_os_compatible" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0

--- a/buildroot-external/scripts/ota.sh
+++ b/buildroot-external/scripts/ota.sh
@@ -32,6 +32,7 @@ function create_ota_update() {
         echo "version=$(hassos_version)"
         echo "[hooks]"
         echo "filename=hook"
+        echo "hooks=install-check"
         echo "[image.boot]"
         echo "filename=boot.vfat"
         echo "hooks=install"

--- a/buildroot-external/scripts/post-build.sh
+++ b/buildroot-external/scripts/post-build.sh
@@ -26,7 +26,7 @@ install_hassos_cli
     echo "ID=${HASSOS_ID}"
     echo "VERSION_ID=$(hassos_version)"
     echo "PRETTY_NAME=\"${HASSOS_NAME} $(hassos_version)\""
-    echo "CPE_NAME=cpe:2.3:o:home_assistant:${HASSOS_ID}:$(hassos_version):*:${DEPLOYMENT}:*:*:*:${BOARD_ID}:*"
+    echo "CPE_NAME=cpe:2.3:o:home-assistant:${HASSOS_ID}:$(hassos_version):*:${DEPLOYMENT}:*:*:*:${BOARD_ID}:*"
     echo "HOME_URL=https://hass.io/"
     echo "VARIANT=\"${HASSOS_NAME} ${BOARD_NAME}\""
     echo "VARIANT_ID=${BOARD_ID}"


### PR DESCRIPTION
This "only" renames the `HASSOS_ID` for now, which has far reaching consequences: Rauc compatible is handled via hook, but this will need supervisor change since the CPE product name changes as well.