### PR TITLE
Increase maximum IGMP memberships

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/20-network.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/20-network.conf
@@ -1,0 +1,3 @@
+# Since multicast is rather popular and we have many integrations running,
+# more than the default of 20 memberships might be required.
+net.ipv4.igmp_max_memberships = 1024


### PR DESCRIPTION
Currently Linux has a limit of IGMP memberships of 20. When trying to
add membership to more than that, Linux fails with:
OSError: [Errno 105] No buffer space available

Allowing more memberships should not really be problematic as memory is
allocated dynamically when membership is actually added.

However, there is a protocol limit of how many memberships a host can be
in. The number of memberships needs to fit in a single group report
datagram of 64kB. In total 5459 group records fit in a datagram, but due
to IP header options this might be slightly smaller in practise.
(see https://github.com/home-assistant/core/issues/45957).

Use a limit of 1024, which should be plenty of headroom in both
directions.

Related to: https://github.com/home-assistant/core/issues/45957