### PR TITLE
Update ovf:id to get Synology VMM detect Guest Agent

### DIFF
--- a/buildroot-external/board/intel/ova/home-assistant.ovf
+++ b/buildroot-external/board/intel/ova/home-assistant.ovf
@@ -21,7 +21,7 @@
       <Product>Home Assistant Operating System</Product>
       <ProductUrl>https://www.home-assistant.io</ProductUrl>
     </ProductSection>
-    <OperatingSystemSection ovf:id="100" vmw:osType="other4xLinux64Guest">
+    <OperatingSystemSection ovf:id="102" vmw:osType="otherGuest64">
       <Info>The kind of installed guest operating system</Info>
       <Description>Linux</Description>
     </OperatingSystemSection>


### PR DESCRIPTION
The Synology VMM only detects running Guest Agent if the `ovf:id="102"`. I've done some extensive testing and this is the only way to get the VMM to detect Guest Agent.

I'm aware of #660 but I don't have access to ESXi so I can't verify that this change will work for those users too.

The `102` and `otherGuest64` have been matched from this page: https://wiki.abiquo.com/display/ABI310/Extended+OVF+Support+and+Template+Definition