### PR TITLE
Don't filter previous releases on dev branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,8 @@ categories:
     label: 'board/odroid'
   - title: 'ASUS Tinker'
     label: 'board/tinker'
+filter-by-commitish: true
+commitish: dev
 template: |
   ## Changes
 


### PR DESCRIPTION
It seems that the release drafter filters commits which have been made
before the last release has been made. If the last release is a
unrelated stable release, this clears the full changelog for the next
major release. It seems `filter-by-commitish` should prevent that.

While at it, also set `commitish` to be dev (which is the default, but
being explicit certainly doesn't hurt).