### PR TITLE
Use rauc hook to extend compatible for upcomming OS release 6

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -5,17 +5,19 @@
 
 case "$1" in
      install-check)
-         if [[ "$RAUC_MF_COMPATIBLE" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
+         if [ "$RAUC_MF_COMPATIBLE" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi
          # Be compatible with upcomming releases using haos OS ID
+         # shellcheck disable=SC2039
          rauc_new_os_compatible=${RAUC_SYSTEM_COMPATIBLE/hassos-/haos-}
-         if [[ "$RAUC_MF_COMPATIBLE" == "${rauc_new_os_compatible}" ]]; then
+         if [ "$RAUC_MF_COMPATIBLE" = "${rauc_new_os_compatible}" ]; then
              exit 0
          fi
          # intel-nuc: Be compatible with upcomming generic-x86-64
+         # shellcheck disable=SC2039
          rauc_new_board_compatible=${rauc_new_os_compatible/intel-nuc/generic-x86-64}
-         if [[ "$RAUC_MF_COMPATIBLE" == "${rauc_new_board_compatible}" ]]; then
+         if [ "$RAUC_MF_COMPATIBLE" = "${rauc_new_board_compatible}" ]; then
              exit 0
          fi
          echo "Compatible does not match!" 1>&2

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -2,7 +2,32 @@
 
 ##
 # Hooks
-env
+
+case "$1" in
+     install-check)
+         if [[ "$RAUC_MF_COMPATIBLE" == "$RAUC_SYSTEM_COMPATIBLE" ]]; then
+             exit 0
+         fi
+         # Be compatible with upcomming releases using haos OS ID
+         rauc_new_os_compatible=${RAUC_SYSTEM_COMPATIBLE/hassos-/haos-}
+         if [[ "$RAUC_MF_COMPATIBLE" == "${rauc_new_os_compatible}" ]]; then
+             exit 0
+         fi
+         # intel-nuc: Be compatible with upcomming generic-x86-64
+         rauc_new_board_compatible=${rauc_new_os_compatible/intel-nuc/generic-x86-64}
+         if [[ "$RAUC_MF_COMPATIBLE" == "${rauc_new_board_compatible}" ]]; then
+             exit 0
+         fi
+         echo "Compatible does not match!" 1>&2
+         exit 10
+         ;;
+    slot-install)
+        # Use install handlers below
+        ;;
+    *)
+        exit 1
+        ;;
+esac
 
 # Handle boot hocks
 if [ "${RAUC_SLOT_CLASS}" = "boot" ]; then

--- a/buildroot-external/scripts/ota.sh
+++ b/buildroot-external/scripts/ota.sh
@@ -32,6 +32,7 @@ function create_ota_update() {
         echo "version=$(hassos_version)"
         echo "[hooks]"
         echo "filename=hook"
+        echo "hooks=install-check"
         echo "[image.boot]"
         echo "filename=boot.vfat"
         echo "hooks=install"


### PR DESCRIPTION
In the OS release 6 the OS (HASSOS_ID) will be renamed to haos. The
variable is used to generate the image file name, OS name in os-release
as well as OS compatible string for RAUC updates.

Furthermore intel-nuc will be renamed to generic-x86-64.

To be able to downgrade from a release 6 installation back to release 5,
we need to make release 5 update bundles work with a release 6 system.
Use a custom install-check hook which checks the full compatible as well
as compatible strings which check against the new compatible strings.