### PR TITLE
Accept installation with intel-nuc in compatible string

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -14,6 +14,12 @@ case "$1" in
          if [ "$rauc_os_compatible" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi
+         # generic-x86-64: Be compatible with intel-nuc
+         # shellcheck disable=SC2039
+         rauc_board_compatible=${RAUC_MF_COMPATIBLE/generic-x86-64/intel-nuc}
+         if [ "${rauc_board_compatible}" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
+             exit 0
+         fi
          echo "Compatible does not match!" 1>&2
          exit 10
          ;;

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -16,7 +16,7 @@ case "$1" in
          fi
          # generic-x86-64: Be compatible with intel-nuc
          # shellcheck disable=SC2039
-         rauc_board_compatible=${RAUC_MF_COMPATIBLE/generic-x86-64/intel-nuc}
+         rauc_board_compatible=${rauc_os_compatible/generic-x86-64/intel-nuc}
          if [ "${rauc_board_compatible}" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi


### PR DESCRIPTION
For the OS release 6 intel-nuc gets renamed to generic-x86-64. Since
the machine name is in the OS compatible string we need to make sure
OS release 5 installation can update to release 6 despite the new
machine name.