### PR TITLE
Rename NetworkManager default profile

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -28,13 +28,15 @@ file called `my-network` and add the appropriate contents below:
 
 ### Default
 
-A preinstalled connection profile is provided by default:
+A preinstalled connection profile for wired network is active by default:
 
 ```ini
 [connection]
-id=my-network
+id=Home Assistant OS default
 uuid=f62bf7c2-e565-49ff-bbfc-a4cf791e6add
 type=802-3-ethernet
+llmnr=2
+mdns=2
 
 [ipv4]
 method=auto
@@ -51,6 +53,8 @@ method=auto
 id=my-network
 uuid=d55162b4-6152-4310-9312-8f4c54d86afa
 type=802-3-ethernet
+llmnr=2
+mdns=2
 
 [ipv4]
 method=auto
@@ -89,8 +93,6 @@ method=auto
 
 ### Static IP
 
-*Since Supervisor 2020.12 and newer network settings can be edited in the Supervisor UI web frontend, click change next to ip address then select static, review all values and click save.
-
 Replace the following configuration:
 
 ```ini
@@ -106,13 +108,15 @@ For `address`, the value before the semicolon is the IP address and subnet prefi
 
 ### Reset network
 
-If you want to reset the network configuration back to the default DHCP settings, use the following commands on the host:
+If you want to reset the network configuration back to the default connection
+profile using DHCP, use the following commands on the host console:
 
 ```bash
-# rm /etc/NetworkManager/system-connections/*
-# cp /usr/share/system-connections/* /etc/NetworkManager/system-connections/
-# nmcli con reload
+# rm -r /mnt/overlay/etc/NetworkManager/system-connections
+# reboot
 ```
+
+Home Assistant OS will recreate the default connection profile during boot.
 
 ### Powersave
 
@@ -126,7 +130,7 @@ powersave=0
 
 ## Using `nmcli` to set a static IPv4 address
 
-Log into the the HassOS base system via a console:
+Log into the the Home Assistant OS base system via a console:
 
 ```bash
 Welcome to Home Assistant
@@ -137,13 +141,13 @@ homeassistant login:
 
 From there you use the `nmcli` configuration tool.
 
-- `# nmcli con show` will list the "HassOS default" connection in use.
-- `# nmcli con show "HassOS default"` will list all the properties of the connection.
+- `# nmcli con show` will list the "Home Assistant OS default" connection in use.
+- `# nmcli con show "Home Assistant OS default"` will list all the properties of the connection.
 
-To start editing the configuration setting for "HassOS default":
+To start editing the configuration setting for "Home Assistant OS default":
 
 ```bash
-# nmcli con edit "HassOS default"
+# nmcli con edit "Home Assistant OS default"
 ```
 
 To add your static IP address (select 'yes' for manual method);

--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -7,14 +7,24 @@ Home Assistant Operating System uses NetworkManager to control the host network.
 By default the device will be in DHCP state.
 
 Basic network settings can be set through the Supervisor frontend in the System
-tab. A bit more advanced configurations such as VLAN are also available through
-the `ha network` CLI command.
+tab. Advanced configurations such as VLAN are also available through the
+`ha network` CLI command.
+
+To restore the default configuration the `ha network` CLI command can be used as
+well:
+
+```
+ha network update default --ipv4-method auto
+```
 
 If more advanced network settings are required network connection files can be
 placed on a USB drive and imported to the host as described in
 [Configuration][configuration-usb].
 
-## Configuration examples
+## Manual Network Configuration
+
+If the frontend or `ha network` CLI cannot meet your use case, it is still
+possible to configure the underlying NetworkManager manually.
 
 You can read the [NetworkManager manual][nm-manual] or find many configuration
 examples across the internet. Note that changes to `NetworkManager.conf` are

--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/system-connections/default
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/system-connections/default
@@ -1,5 +1,5 @@
 [connection]
-id=HassOS default
+id=Home Assistant OS default
 uuid=f62bf7c2-e565-49ff-bbfc-a4cf791e6add
 type=802-3-ethernet
 llmnr=2


### PR DESCRIPTION
Rename the NetworkManager default profile to "Home Assistant OS
default". Improve documentation on how to reset to default
configuration.