### PR TITLE
Remove unnecessary avahi-daemon.service configs

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/avahi-daemon.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/avahi-daemon.service.d/hassos.conf
@@ -1,2 +1,0 @@
-[Unit]
-RequiresMountsFor=/etc/hostname

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/avahi-daemon.service.d/nm.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/avahi-daemon.service.d/nm.conf
@@ -1,3 +1,0 @@
-[Unit]
-Wants=network-online.target
-After=network-online.target


### PR DESCRIPTION
The avahi-daemon.service has been removed a while ago, this extra
systemd configurations are no longer necessary.