### PR TITLE
Improve dropbear.service to avoid failed state after stop

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/hassos.conf
@@ -3,6 +3,9 @@ RequiresMountsFor=/etc/dropbear
 ConditionFileNotEmpty=/root/.ssh/authorized_keys
 
 [Service]
+Type=forking
+PIDFile=/run/dropbear.pid
 ExecStartPre=
 ExecStart=
-ExecStart=/usr/sbin/dropbear -F -R -E -p 22222 -s
+ExecStart=-/usr/sbin/dropbear -R -E -p 22222 -s
+KillMode=mixed


### PR DESCRIPTION
So far the exit code has been evaluated, which seems to be non-zero even
with a regular term signal. With that systemd assumed the service is in
a failed state, when in fact this seems the regular behavior of dropbear
when shutting it down.