### PR TITLE
Bump to latest OS Agent version to support Device Wipe

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -1,10 +1,10 @@
 ################################################################################
 #
-# foo
+# Home Assistant OS Agent
 #
 ################################################################################
 
-OS_AGENT_VERSION = 7bff7f5cd223ad439b738cea513cb558a18155c9
+OS_AGENT_VERSION = 8ce70291d410b2d32bac5057e1ada70e8c49bf12
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Home Assistant OS Device Wipe Service
+DefaultDependencies=no
+RefuseManualStart=true
+RefuseManualStop=true
+Wants=mnt-boot.mount
+Requires=haos-agent.service
+After=haos-agent.service mnt-boot.mount
+Before=mnt-data.mount mnt-overlay.mount
+ConditionKernelCommandLine=haos.wipe=1
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/busctl --verbose --timeout=1h call io.homeassistant.os /io/homeassistant/os/System io.homeassistant.os.System WipeDevice
+ExecStartPost=/usr/bin/sed -i 's/\s*haos.wipe=1//g' /mnt/boot/cmdline.txt
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
The latest version of OS Agent sets haos.wipe=1 as kernel argument to
trigger a device wipe. Let systemd pickup this kernel command line
argument and start haos-wipe.service.

This rather complex architecture allows to add other triggers in the
future, e.g. a button read in the boot loader.