### PR TITLE
Fix rauc hook compatible compare logic

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -10,13 +10,13 @@ case "$1" in
          fi
          # Be compatible with upcomming releases using haos OS ID
          # shellcheck disable=SC2039
-         rauc_new_os_compatible=${RAUC_SYSTEM_COMPATIBLE/hassos-/haos-}
+         rauc_new_os_compatible=${RAUC_SYSTEM_COMPATIBLE/haos-/hassos-}
          if [ "$RAUC_MF_COMPATIBLE" = "${rauc_new_os_compatible}" ]; then
              exit 0
          fi
          # intel-nuc: Be compatible with upcomming generic-x86-64
          # shellcheck disable=SC2039
-         rauc_new_board_compatible=${rauc_new_os_compatible/intel-nuc/generic-x86-64}
+         rauc_new_board_compatible=${rauc_new_os_compatible/generic-x86-64/intel-nuc}
          if [ "$RAUC_MF_COMPATIBLE" = "${rauc_new_board_compatible}" ]; then
              exit 0
          fi


### PR DESCRIPTION
The script looks at the current installations strings, which use haos
and generic-x86-64 respectively. Replace them with the old strings to
make the compare match and allow downgrades.