### PR TITLE
Remove OS mount in favor of os-agent

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -75,8 +75,6 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         -v /run/udev:/run/udev:ro \
         -v /etc/machine-id:/etc/machine-id:ro \
         -v ${SUPERVISOR_DATA}:/data:rw \
-        -v /mnt/overlay:/os/overlay:rw \
-        -v /mnt/boot:/os/boot:rw \
         -e SUPERVISOR_SHARE=${SUPERVISOR_DATA} \
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_CPU_RT=1 \


### PR DESCRIPTION
Network is now part of the backend and for overlay data, we can add an os-agent function to create a snapshot or restore overlay in our flow like with rauc.