### PR TITLE
Use interface-name to exclude veth

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -5,7 +5,7 @@ autoconnect-retries-default=0
 rc-manager=file
 
 [keyfile]
-unmanaged-devices=type:bridge;type:tun;interface-name:veth*
+unmanaged-devices=type:bridge;type:tun;driver:veth
 
 [logging]
 backend=journal

--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -5,7 +5,7 @@ autoconnect-retries-default=0
 rc-manager=file
 
 [keyfile]
-unmanaged-devices=type:bridge;type:tun;type:veth
+unmanaged-devices=type:bridge;type:tun;interface-name:veth*
 
 [logging]
 backend=journal


### PR DESCRIPTION
The type veth is not a valid type (see [1] for how to obtain a list of
valid device types. Use interface name with globbing to filter veth.

Note: It seems that NetworkManager did not manage veth so far, so this
change seems not to be relevant in practise.

[1] https://people.freedesktop.org/~lkundrak/nm-docs/NetworkManager.conf.html#device-spec