### PR TITLE
Use zip file format for virtual disk images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vdi.xz
-          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vdi.xz
-          asset_content_type: application/x-xz
+          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vdi.zip
+          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vdi.zip
+          asset_content_type: application/zip
 
       - name: Upload vhdx image
         if: ${{ matrix.board.name == 'ova' }}
@@ -132,9 +132,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vhdx.xz
-          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vhdx.xz
-          asset_content_type: application/x-xz
+          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vhdx.zip
+          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vhdx.zip
+          asset_content_type: application/zip
 
       - name: Upload vmdk image
         if: ${{ matrix.board.name == 'ova' }}
@@ -143,9 +143,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vmdk.xz
-          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vmdk.xz
-          asset_content_type: application/x-xz
+          asset_path: ${{ github.workspace }}/release/hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vmdk.zip
+          asset_name: hassos_${{ matrix.board.output }}-${{ needs.validate_release.outputs.version }}.vmdk.zip
+          asset_content_type: application/zip
 
   bump_version:
     name: Bump dev version to ${{ needs.validate_release.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         rsync \
         sudo \
         unzip \
+        zip \
         wget \
         qemu-utils \
         openssh-client \

--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -22,9 +22,9 @@ function hassos_post_image() {
     # Virtual Disk images
     convert_disk_image_virtual
 
-    convert_disk_image_xz vmdk
-    convert_disk_image_xz vhdx
-    convert_disk_image_xz vdi
+    convert_disk_image_zip vmdk
+    convert_disk_image_zip vhdx
+    convert_disk_image_zip vdi
     convert_disk_image_xz qcow2
 
     # OVA

--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -325,3 +325,11 @@ function convert_disk_image_xz() {
     rm -f "${hdd_img}.xz"
     xz -3 -T0 "${hdd_img}"
 }
+
+function convert_disk_image_zip() {
+    local hdd_ext=${1:-img}
+    local hdd_img="$(hassos_image_name "${hdd_ext}")"
+
+    rm -f "${hdd_img}.zip"
+    zip -r "${hdd_img}.zip" "${hdd_img}"
+}


### PR DESCRIPTION
Virtual Disk images are often used on Windows and/or Mac platforms where
xz is not a widely known file ending and also not supported by dafault.
Use zip which is much better known.

Keep using xz for boards since those are not meant to be extracted by
users but directly used in Etcher. Also keep using xz for qcow2, since
qcow2 is mostly used on Linux platforms where xz is available by default
and zip usually needs an extra package.