### PR TITLE
Fix reboot issue on ODROID-N2+ on Linux 5.10

### DIFF
--- a/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-add-RTC-to-ODROID-N2-boards.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-add-RTC-to-ODROID-N2-boards.patch
@@ -1,8 +1,8 @@
-From 516c081bcdd8f248982588aa8ca5bd8d24b2e7ef Mon Sep 17 00:00:00 2001
-Message-Id: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
+From bcbcd8967de78638e5b861ceb9caa73da003280a Mon Sep 17 00:00:00 2001
+Message-Id: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 16 Nov 2020 23:11:02 +0100
-Subject: [PATCH 1/4] arm64: dts: meson: add RTC to ODROID-N2 boards
+Subject: [PATCH 1/5] arm64: dts: meson: add RTC to ODROID-N2 boards
 
 All ODROID-N2 boards come with a NXP PCF8563TS RTC connected to I2C bus
 3. This is the RTC which is connected to the on-board RTC backup battery.
@@ -46,5 +46,5 @@ index 39a09661c5f6..445d90d25aa3 100644
  	status = "okay";
  	pinctrl-0 = <&remote_input_ao_pins>;
 -- 
-2.30.0
+2.31.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0002-arm64-dts-meson-g12b-add-power-button-support.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0002-arm64-dts-meson-g12b-add-power-button-support.patch
@@ -1,10 +1,10 @@
-From 3a2086e15c0b121250dd4c48214cd0486a67fde1 Mon Sep 17 00:00:00 2001
-Message-Id: <3a2086e15c0b121250dd4c48214cd0486a67fde1.1612541102.git.stefan@agner.ch>
-In-Reply-To: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
-References: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
+From 22e84d9b5b5ed45ee67e8bfde9af7518bdbbbdf3 Mon Sep 17 00:00:00 2001
+Message-Id: <22e84d9b5b5ed45ee67e8bfde9af7518bdbbbdf3.1619651621.git.stefan@agner.ch>
+In-Reply-To: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
+References: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 11:20:48 +0100
-Subject: [PATCH 2/4] arm64: dts: meson: g12b: add power button support
+Subject: [PATCH 2/5] arm64: dts: meson: g12b: add power button support
 
 Add power button support on J2 pin 11 (GPIOX_3 on the SoC side). The
 GPIO is low active, e.g. when connecting with pin 9 (GND) a power
@@ -38,5 +38,5 @@ index 445d90d25aa3..ddc7ad9a7d8d 100644
  		compatible = "gpio-leds";
  
 -- 
-2.30.0
+2.31.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-g12b-add-GPIO-fan-support.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-g12b-add-GPIO-fan-support.patch
@@ -1,10 +1,10 @@
-From 0a4d355fe7b8245427ba7d774b082ea5f2d257d9 Mon Sep 17 00:00:00 2001
-Message-Id: <0a4d355fe7b8245427ba7d774b082ea5f2d257d9.1612541102.git.stefan@agner.ch>
-In-Reply-To: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
-References: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
+From 753ddc99cabde67b7f2e5e6282432361c1c8c443 Mon Sep 17 00:00:00 2001
+Message-Id: <753ddc99cabde67b7f2e5e6282432361c1c8c443.1619651621.git.stefan@agner.ch>
+In-Reply-To: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
+References: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 11:38:54 +0100
-Subject: [PATCH 3/4] arm64: dts: meson: g12b: add GPIO fan support
+Subject: [PATCH 3/5] arm64: dts: meson: g12b: add GPIO fan support
 
 Add simple GPIO fan node to support a fan on GPIO J8. Unfortunately the
 pad used to control the fan does not support real PWM, hence the RPM
@@ -38,5 +38,5 @@ index ddc7ad9a7d8d..4d96732d0613 100644
  		compatible = "gpio-keys-polled";
  		poll-interval = <100>;
 -- 
-2.30.0
+2.31.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-g12b-odroid-n2-add-fan-as-cooling-de.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-g12b-odroid-n2-add-fan-as-cooling-de.patch
@@ -1,10 +1,10 @@
-From 575ca5decaccee6cdea036ce88711dac6672cc4b Mon Sep 17 00:00:00 2001
-Message-Id: <575ca5decaccee6cdea036ce88711dac6672cc4b.1612541102.git.stefan@agner.ch>
-In-Reply-To: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
-References: <516c081bcdd8f248982588aa8ca5bd8d24b2e7ef.1612541102.git.stefan@agner.ch>
+From 5df619f3887d30a74355ee62dca06d5e674e6463 Mon Sep 17 00:00:00 2001
+Message-Id: <5df619f3887d30a74355ee62dca06d5e674e6463.1619651621.git.stefan@agner.ch>
+In-Reply-To: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
+References: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 15:53:55 +0100
-Subject: [PATCH 4/4] arm64: dts: meson: g12b: odroid-n2: add fan as cooling
+Subject: [PATCH 4/5] arm64: dts: meson: g12b: odroid-n2: add fan as cooling
  device
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -70,5 +70,5 @@ index 4d96732d0613..30d79175fa3e 100644
  	cpu-supply = <&vddcpu_b>;
  	operating-points-v2 = <&cpu_opp_table_0>;
 -- 
-2.30.0
+2.31.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0005-Revert-drm-meson_drv-add-shutdown-function.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0005-Revert-drm-meson_drv-add-shutdown-function.patch
@@ -1,0 +1,47 @@
+From a58cdfdb13d2728a7fc826cead1b29eacbffa453 Mon Sep 17 00:00:00 2001
+Message-Id: <a58cdfdb13d2728a7fc826cead1b29eacbffa453.1619651621.git.stefan@agner.ch>
+In-Reply-To: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
+References: <bcbcd8967de78638e5b861ceb9caa73da003280a.1619651621.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 29 Apr 2021 01:04:32 +0200
+Subject: [PATCH 5/5] Revert "drm: meson_drv add shutdown function"
+
+This reverts commit d4ec1ffbdaa8939a208656e9c1440742c457ef16.
+
+It seems that this patch actually breaks reboot on ODROID-N2+.
+---
+ drivers/gpu/drm/meson/meson_drv.c | 11 -----------
+ 1 file changed, 11 deletions(-)
+
+diff --git a/drivers/gpu/drm/meson/meson_drv.c b/drivers/gpu/drm/meson/meson_drv.c
+index db56732bdd26..3d1de9cbb1c8 100644
+--- a/drivers/gpu/drm/meson/meson_drv.c
++++ b/drivers/gpu/drm/meson/meson_drv.c
+@@ -482,16 +482,6 @@ static int meson_probe_remote(struct platform_device *pdev,
+ 	return count;
+ }
+ 
+-static void meson_drv_shutdown(struct platform_device *pdev)
+-{
+-	struct meson_drm *priv = dev_get_drvdata(&pdev->dev);
+-	struct drm_device *drm = priv->drm;
+-
+-	DRM_DEBUG_DRIVER("\n");
+-	drm_kms_helper_poll_fini(drm);
+-	drm_atomic_helper_shutdown(drm);
+-}
+-
+ static int meson_drv_probe(struct platform_device *pdev)
+ {
+ 	struct component_match *match = NULL;
+@@ -563,7 +553,6 @@ static const struct dev_pm_ops meson_drv_pm_ops = {
+ 
+ static struct platform_driver meson_drm_platform_driver = {
+ 	.probe      = meson_drv_probe,
+-	.shutdown   = meson_drv_shutdown,
+ 	.driver     = {
+ 		.name	= "meson-drm",
+ 		.of_match_table = dt_match,
+-- 
+2.31.1
+


### PR DESCRIPTION
In Linux 5.10.24 a regression has been introduced which broke reboot on
ODROID-N2(+). Interestingly the patch should improve reboot stability
for VIM3, which uses the same SoC. However, it seems that in the
ODROID-N2 case, this causes more problems then it fixes. Revert the
offending patch.