### PR TITLE
Support OS releases with custom dev part

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: [ "ubuntu-20.04" ]
     outputs:
       version: ${{ steps.version_check.outputs.version }}
+      version_dev: ${{ steps.version_check.outputs.version_dev }}
     steps:
       - uses: actions/checkout@v2
       - name: Validate version
@@ -19,11 +20,18 @@ jobs:
         run: |
           major=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_MAJOR | cut -d'=' -f2)
           build=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_BUILD | cut -d'=' -f2)
-          if [ "${major}.${build}" != "${{ github.event.release.tag_name }}" ]; then
+          tag_major=$(echo "${{ github.event.release.tag_name }}" | cut -d '.' -f 1)
+          tag_build=$(echo "${{ github.event.release.tag_name }}" | cut -d '.' -f 2)
+          tag_dev=$(echo "${{ github.event.release.tag_name }}" | cut -d '.' -f 3)
+          if [ "${major}.${build}" != "${tag_major}.${tag_build}" ]; then
             echo "Version number in Buildroot metadata is does not match tag (${major}.${build} vs ${{ github.event.release.tag_name }})."
             exit 1
           fi
-          echo "::set-output name=version::${major}.${build}"
+          if [ "" != "${tag_dev}" ]; then
+            echo "Note: Release build with custom dev part: ${tag_dev}."
+          fi
+          echo "::set-output name=version::${major}.${build}.${tag_dev}"
+          echo "::set-output name=version_dev::${tag_dev}"
 
   build:
     name: Release build for ${{ matrix.board.name }}
@@ -69,7 +77,7 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            haos-builder make BUILDDIR=/build VERSION_DEV="" ${{ matrix.board.name }}
+            haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.validate_release.outputs.version_dev }} ${{ matrix.board.name }}
 
       - name: Upload disk image
         if: ${{ matrix.board.name != 'ova' }}


### PR DESCRIPTION
Support OS releases (tags) with custom dev part (3rd group of the
release number). This allows to create tagged release candidates with
the form 6.0.rc1.