### PR TITLE
Delay Supervisor start until time has been sychronized

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/timeout.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/timeout.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStartSec=90s

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system-preset/70-haos.preset
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system-preset/70-haos.preset
@@ -1,1 +1,3 @@
 disable apparmor.service
+
+enable systemd-time-wait-sync.service

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=HassOS supervisor
 Requires=docker.service rauc.service dbus.service
-Wants=network-online.target hassos-apparmor.service
-After=docker.service rauc.service dbus.service network-online.target
+Wants=network-online.target hassos-apparmor.service time-sync.target
+After=docker.service rauc.service dbus.service network-online.target time-sync.target
 RequiresMountsFor=/mnt/data /mnt/boot /mnt/overlay
 StartLimitIntervalSec=60
 StartLimitBurst=5


### PR DESCRIPTION
On first boot, the RTC of many embedded boards can be off. Currently the Supervisor gets started immediately, which then leads to conection failures when trying to connect to https targets since the certificate appears to be invalid (typically the validity is in the future from the boards perspective).

Make sure to delay Supervisor start until time has been synchronized. Wait a maximum of 90s, and continue boot in case synchronization isn't possible (no Internet connectivity).