### PR TITLE
Drop directories when creating zip file

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -331,5 +331,5 @@ function convert_disk_image_zip() {
     local hdd_img="$(hassos_image_name "${hdd_ext}")"
 
     rm -f "${hdd_img}.zip"
-    zip -r "${hdd_img}.zip" "${hdd_img}"
+    zip -j -q -r "${hdd_img}.zip" "${hdd_img}"
 }


### PR DESCRIPTION
We zip a single file nested in a rather deep directory tree which stems
from the build system. This doesn't need to be exposed to users.