### PR TITLE
Add minimal message of the day

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/motd
+++ b/buildroot-external/rootfs-overlay/etc/motd
@@ -1,0 +1,3 @@
+Welcome to [01;34mHome Assistant OS[00m.
+
+Use `ha` to access the Home Assistant CLI.


### PR DESCRIPTION
Add a minimal motd so users know what kind of system they just logged
in. Also add the hint that the Home Assistant CLI is still available
using the command ha.