### PR TITLE
Pass ha command with quotes to CLI container

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/bin/ha
+++ b/buildroot-external/rootfs-overlay/usr/bin/ha
@@ -3,5 +3,4 @@
 # HA utility
 # ==============================================================================
 
-# shellcheck disable=SC2048,SC2086
-docker exec hassio_cli ha $*
+docker exec hassio_cli ha "$@"


### PR DESCRIPTION
When using quotes currently, they are not passed to HA due to $*. This
doesn't allow to use some commands properly, e.g. snapshot restore with
a passwort with spaces:

```
ha snapshot restore c31f3c93 --password "test test"
...
time="2021-05-26T11:24:19+02:00" level=fatal msg="Error while executing rootCmd: accepts 1 arg(s), received 2"
```

Properly pass all arguments using $@ in quotes.