### PR TITLE
Enable serial console as well (#1339)

### DIFF
--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -10,7 +10,7 @@ function hassos_pre_image() {
     cp "${BINARIES_DIR}/barebox.bin" "${BOOT_DATA}/EFI/BOOT/BOOTx64.EFI"
     cp "${BR2_EXTERNAL_HASSOS_PATH}/bootloader/barebox-state-efi.dtb" "${BOOT_DATA}/EFI/barebox/state.dtb"
 
-    echo "console=tty1" > "${BOOT_DATA}/cmdline.txt"
+    echo "console=ttyS0 console=tty1" > "${BOOT_DATA}/cmdline.txt"
 }
 
 


### PR DESCRIPTION
Using console focused virtualization environments such as virsh having
a serial console is the easiest way to interact with a virtual machine.
It also saves resources since no video memory needs to be allocated.
Enable serial console besides tty1 by default.

Note: The bootloader as well as the kernel shows its boot messages on
all consoles. However, only the last console is mapped to /dev/console,
which systemd is using to show service startup messages. Putting tty1 as
last console makes sure that systemd messages are still shown on the
console screen.