### PR TITLE
Restart console on tty1 on exit (#1387)

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
@@ -22,7 +22,6 @@ Before=rescue.service
 # option to preserve environment (-p), followed by '--' for safety, and then
 # the entered username.
 ExecStart=/usr/sbin/hassos-cli
-RemainAfterExit=yes
 Type=idle
 Restart=always
 RestartSec=0


### PR DESCRIPTION
Since we start the HomeAssistant shell directly on tty the service
responsible for starting did not restart the shell on exit. Remove the
RemainAfterExit flag to make sure that the shell restarts on exit.