### PR TITLE
Verify Power Supply Size

### DIFF
--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -77,5 +77,5 @@ $ systemctl status mnt-data.mount
 If the data partition was moved to your USB drive you should see ```sh Active: active (mounted)  ``` in the output. Also, it will show, which drive got mounted as /mnt/data (```sh Where ``` and ```sh what ``` section of the output)
 
 
-## Power supply
+## Verify Power Supply Size (3.5A strongly recommended)
 Using an attached SSD will most likely draw more power than the official Power supply that go with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternative can be to use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -75,3 +75,7 @@ Within the Home Assistant interface you won't see if the move was succesful. To 
 $ systemctl status mnt-data.mount
 ```
 If the data partition was moved to your USB drive you should see ```sh Active: active (mounted)  ``` in the output. Also, it will show, which drive got mounted as /mnt/data (```sh Where ``` and ```sh what ``` section of the output)
+
+
+## Power supply
+Using an attached SSD will most likely draw more power than the official Power supply that go with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternative can be to use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -78,4 +78,4 @@ If the data partition was moved to your USB drive you should see ```sh Active: a
 
 
 ## Verify Power Supply Size (3.5A strongly recommended)
-Using an attached SSD will most likely draw more power than the official Power supply (PS) that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternatively use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Rpi will only have to take care of the Rpi.
+Using an USB attached SSD can draw quite some power. For instance on Raspberry Pi 3 the official Raspberry Pi power supply (PSU) only provides 2.5A which can be too tight. Use a power supply which can at least provide 3.5A. Alternatively use a powered USB hub. Connect the Hub to one of the USB slots of your Raspberry Pi, and connect the SSD to the Hub. The power supply that came with the Hub will power the attached device(s).

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -78,4 +78,4 @@ If the data partition was moved to your USB drive you should see ```sh Active: a
 
 
 ## Verify Power Supply Size (3.5A strongly recommended)
-Using an attached SSD will most likely draw more power than the official Power supply that go with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternative can be to use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.
+Using an attached SSD will most likely draw more power than the official Power supply that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternative can be to use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -78,4 +78,4 @@ If the data partition was moved to your USB drive you should see ```sh Active: a
 
 
 ## Verify Power Supply Size (3.5A strongly recommended)
-Using an attached SSD will most likely draw more power than the official Power supply that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternative can be to use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.
+Using an attached SSD will most likely draw more power than the official Power supply that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternatively use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -77,5 +77,5 @@ $ systemctl status mnt-data.mount
 If the data partition was moved to your USB drive you should see ```sh Active: active (mounted)  ``` in the output. Also, it will show, which drive got mounted as /mnt/data (```sh Where ``` and ```sh what ``` section of the output)
 
 
-## Verify Power Supply Size (3.5A strongly recommended)
+## Check Power Supply Rating
 Using an USB attached SSD can draw quite some power. For instance on Raspberry Pi 3 the official Raspberry Pi power supply (PSU) only provides 2.5A which can be too tight. Use a power supply which can at least provide 3.5A. Alternatively use a powered USB hub. Connect the Hub to one of the USB slots of your Raspberry Pi, and connect the SSD to the Hub. The power supply that came with the Hub will power the attached device(s).

--- a/Documentation/partition.md
+++ b/Documentation/partition.md
@@ -78,4 +78,4 @@ If the data partition was moved to your USB drive you should see ```sh Active: a
 
 
 ## Verify Power Supply Size (3.5A strongly recommended)
-Using an attached SSD will most likely draw more power than the official Power supply that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternatively use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Pi will only have to take care of the Pi.
+Using an attached SSD will most likely draw more power than the official Power supply (PS) that comes with the Rpi can deliver. Advice is to use one that provides at least 3.5A These will not be available in every region. Alternatively use a powered USB hub. Connect the Hub to 1 of the USB slots of your Rpi, and connect the SSD to the Hub. The PS that came with the Hub will power the attached device(s), and the PS for the Rpi will only have to take care of the Rpi.


### PR DESCRIPTION
Because of intermittent inadequate power issues and https://jamesachambers.com/raspberry-pi-4-ubuntu-20-04-usb-mass-storage-boot-guide/ explicitly stating 3.5A is needed to run an SSD off of a Rpi, added the paragraph