### PR TITLE
Use file system extents for the kernel partition

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -90,7 +90,7 @@ function create_kernel_image() {
     # Make image
     rm -f "${kernel_img}"
     truncate --size="${KERNEL_SIZE}" "${kernel_img}"
-    mkfs.ext4 -L "hassos-kernel" -E lazy_itable_init=0,lazy_journal_init=0 -O ^extent,^64bit "${kernel_img}"
+    mkfs.ext4 -L "hassos-kernel" -E lazy_itable_init=0,lazy_journal_init=0 -O ^64bit "${kernel_img}"
 
     # Mount / init file structs
     sudo mkdir -p /mnt/data/


### PR DESCRIPTION
In the past file system extents have been deactivated to get better
performance in U-Boot. However, the performance issue has been addressed
with commit d5aee659f217 ("fs: ext4: cache extent data") in U-Boot. The
performance should be equal to regular files using no extents.

Enabling extents has an advantage however: Files are stored more
efficently, especially relatively large files like a kernel image. The
impact is not all that big (~100KiB), but worthwhile nonetheless.