### PR TITLE
Improve kernel update scripts

### DIFF
--- a/scripts/check-kernel-patches.sh
+++ b/scripts/check-kernel-patches.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+kernel_patches_with_version=$(find buildroot-external -type d -regextype sed -regex ".*/linux/[0-9\.]*")
+
+if [ -n "$kernel_patches_with_version" ]; then
+	echo ""
+	echo "WARNING: Kernel patch directories with kernel version found! Check if updates are needed."
+fi

--- a/scripts/update-kernel-odroid-n2.sh
+++ b/scripts/update-kernel-odroid-n2.sh
@@ -6,9 +6,9 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-defconfigs=(buildroot-external/configs/{generic_x86_64,ova,tinker,odroid_c*,odroid_xu4}_defconfig)
+defconfigs=(buildroot-external/configs/odroid_n2_defconfig)
 sed -i "s/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\".*\"/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\"$1\"/g" "${defconfigs[@]}"
-sed -i "s/| \(Open Virtual Appliance\|Generic x86-64\|Tinker Board\|Odroid-C.\|Odroid-XU4\) | .* |/| \1 | $1 |/g" Documentation/kernel.md
+sed -i "s/| \(Odroid-N2\) | .* |/| \1 | $1 |/g" Documentation/kernel.md
 git commit -m "Linux: Update kernel $1" "${defconfigs[@]}" Documentation/kernel.md
 
 kernel_patches_with_version=$(find buildroot-external -type d -regextype sed -regex ".*/linux/[0-9\.]*")

--- a/scripts/update-kernel-odroid-n2.sh
+++ b/scripts/update-kernel-odroid-n2.sh
@@ -11,9 +11,4 @@ sed -i "s/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\".*\"/BR2_LINUX_KERNEL_CUSTOM_V
 sed -i "s/| \(Odroid-N2\) | .* |/| \1 | $1 |/g" Documentation/kernel.md
 git commit -m "Linux: Update kernel $1" "${defconfigs[@]}" Documentation/kernel.md
 
-kernel_patches_with_version=$(find buildroot-external -type d -regextype sed -regex ".*/linux/[0-9\.]*")
-
-if [ -n "$kernel_patches_with_version" ]; then
-	echo ""
-	echo "WARNING: Kernel patch directories with kernel version found! Check if updates are needed."
-fi
+./scripts/check-kernel-patches.sh

--- a/scripts/update-kernel-rpi.sh
+++ b/scripts/update-kernel-rpi.sh
@@ -11,6 +11,9 @@ if [ -z "$2" ]; then
     exit 1
 fi
 
-sed -i "s|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/.*\"|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/archive/$1.tar.gz\"|g" buildroot-external/configs/*
+defconfigs=(buildroot-external/configs/rpi*_defconfig)
+sed -i "s|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/.*\"|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/archive/$1.tar.gz\"|g" "${defconfigs[@]}"
 sed -i "s/| Raspberry Pi\(.*\) | .* |/| Raspberry Pi\1 | $2 |/g" Documentation/kernel.md
-git commit -m "RaspberryPi: Update kernel $2 - $1" buildroot-external/configs/* Documentation/kernel.md
+git commit -m "RaspberryPi: Update kernel $2 - $1" "${defconfigs[@]}" Documentation/kernel.md
+
+./scripts/check-kernel-patches.sh

--- a/scripts/update-kernel-upstream.sh
+++ b/scripts/update-kernel-upstream.sh
@@ -11,9 +11,4 @@ sed -i "s/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\".*\"/BR2_LINUX_KERNEL_CUSTOM_V
 sed -i "s/| \(Open Virtual Appliance\|Generic x86-64\|Tinker Board\|Odroid-C.\|Odroid-XU4\) | .* |/| \1 | $1 |/g" Documentation/kernel.md
 git commit -m "Linux: Update kernel $1" "${defconfigs[@]}" Documentation/kernel.md
 
-kernel_patches_with_version=$(find buildroot-external -type d -regextype sed -regex ".*/linux/[0-9\.]*")
-
-if [ -n "$kernel_patches_with_version" ]; then
-	echo ""
-	echo "WARNING: Kernel patch directories with kernel version found! Check if updates are needed."
-fi
+./scripts/check-kernel-patches.sh


### PR DESCRIPTION
Use separate script for ODROID-N2 for now. Also warn if there are kernel
patches with a specific kernel version number in the source tree: They
typically can be just moved to the new kernel version, but one should
compile check them before committing.