### PR TITLE
rtl8812au: bump to latest aircrack-ng 5.7.0 version

### DIFF
--- a/buildroot-external/package/rtl8812au/rtl8812au.mk
+++ b/buildroot-external/package/rtl8812au/rtl8812au.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RTL8812AU_VERSION = cc4c64deef8090515a3dea8b709bfff0a1007d8b
+RTL8812AU_VERSION = 1c9d034b20aa5c15dbf5bb5dfcb83346a692f827
 RTL8812AU_SITE = $(call github,aircrack-ng,rtl8812au,$(RTL8812AU_VERSION))
 RTL8812AU_LICENSE = GPL-2.0
 RTL8812AU_LICENSE_FILES = COPYING


### PR DESCRIPTION
Bump to the latest git version of this out-of-tree driver. This allows
to compile the driver against Linux 5.12.