### PR TITLE
Dockerfile: Add dependencies for make graph-depends/-size targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         patch \
         perl \
         python \
+        python-matplotlib \
+        graphviz \
         rsync \
         sudo \
         unzip \


### PR DESCRIPTION
Install buildroot dependencies so make graph-depends/-size targets can
be used.