### PR TITLE
Ignore build output directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,8 @@ buildroot/
 buildroot-external/
 buildroot-patches/
 
-# Release directory gets created using build scripts
+# Output/Release directory gets created using build scripts
+output*/
 release/
 
 # Ignore hidden directories as well

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /release
 *.pem
+output*/


### PR DESCRIPTION
Avoid Docker sending the complete build output directory when trying to
build the builder image.