### PR TITLE
Update hassos-overlay

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-overlay
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-overlay
@@ -17,6 +17,11 @@ if [ ! -f /mnt/overlay/etc/hosts ]; then
     cp -fp /etc/hosts /mnt/overlay/etc/hosts
 fi
 
+if [ ! -f /mnt/overlay/etc/fstab ]; then
+    cp -fp /etc/fstab /mnt/overlay/etc/fstab
+fi
+
+
 # TimeSync
 if [ ! -f /mnt/overlay/etc/systemd/timesyncd.conf ]; then
     mkdir -p /mnt/overlay/etc/systemd


### PR DESCRIPTION
Feature request is on forum,everything is detailed explained.
Over 17K+ views on this issue.
We need to be able to copy fstab from overlay so the fstab settings on remote mount will stay after update/upgrade on squashfs.

https://community.home-assistant.io/t/nas-mount-on-hass-os/320218