### PR TITLE
Remove original images when creating zip

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -324,5 +324,5 @@ function convert_disk_image_zip() {
     local hdd_img="$(hassos_image_name "${hdd_ext}")"
 
     rm -f "${hdd_img}.zip"
-    zip -j -q -r "${hdd_img}.zip" "${hdd_img}"
+    zip -j -m -q -r "${hdd_img}.zip" "${hdd_img}"
 }


### PR DESCRIPTION
Other compression methods remove the original image file at compression.
Add the -m (move) command to zip to do the same when compressing with
zip. This saves some space in the builds image/release directory.