### PR TITLE
Support development builds in PRs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,16 +4,52 @@ name: Development build
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 jobs:
-  version:
-
-    name: Generate version
+  prepare:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.comment.body, '/ghaction') }}
+    name: Prepare build
     runs-on: [ "ubuntu-20.04" ]
     outputs:
       version_main: ${{ steps.version_main.outputs.version_main }}
-      version_dev: ${{ steps.version_dev.outputs.version_dev }}
+      version_dev: ${{ steps.version_dev.outputs.version_dev }}${{ steps.version_pr.outputs.version_pr }}
+      matrix: ${{ steps.generate_matrix.outputs.result }}
+      gitref: ${{ steps.generate_gitref.outputs.result }}
     steps:
+      - name: Check sources
+        uses: actions/github-script@v4
+        id: generate_gitref
+        with:
+          script: |
+            if (context.eventName == "workflow_dispatch")
+              return { "ref": context.ref }
+
+            const allowedAssociations = new Set(["OWNER", "MEMBER"])
+            if (!allowedAssociations.has(context.payload.comment.author_association))
+              core.setFailed(`Author's association ${context.payload.comment.author_association} not allowed.`)
+
+            if (!context.payload.comment.body.startsWith("/ghaction"))
+              core.setFailed(`ChatOps comment not valid.`)
+
+            if (!context.payload.comment.body.includes("build"))
+              core.setFailed(`Unknown ChatOps command.`)
+
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: "rocket",
+            }
+            try {
+              await github.reactions.createForIssueComment(request);
+            } catch (err) {
+              console.log(`Reaction request failed with error ${err}`)
+            }
+
+            return { "ref": `refs/pull/${context.payload.issue.number}/merge` }
+
       - name: Generate Development build version
         shell: bash
         id: version_dev
@@ -21,6 +57,14 @@ jobs:
           version_dev="dev$(date --utc +'%Y%m%d')"
           echo "Development version \"${version_dev}\""
           echo "::set-output name=version_dev::${version_dev}"
+      - name: Generate Development build version for PR
+        if: ${{ github.event.pull_request }}
+        shell: bash
+        id: version_pr
+        run: |
+          version_pr="+pr${{ github.event.pull_request.number }}"
+          echo "Development build for PR \"${version_pr}\""
+          echo "::set-output name=version_pr::${version_pr}"
       - uses: actions/checkout@v2
       - name: Get Major/Minor version
         id: version_main
@@ -28,35 +72,39 @@ jobs:
           major=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_MAJOR | cut -d'=' -f2)
           build=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_BUILD | cut -d'=' -f2)
           echo "::set-output name=version_main::${major}.${build}"
+      - name: Create build matrix
+        uses: actions/github-script@v4
+        id: generate_matrix
+        with:
+          script: |
+            const boards = require('./.github/workflows/matrix.json')
+
+            if (context.eventName == "workflow_dispatch") {
+              console.log("Run full build for all boards")
+              return { "board": boards }
+            }
+
+            const labels = context.payload.issue.labels.map(l => l.name)
+            const labelsSet = new Set(labels)
+            const buildBoards = boards.filter(b => labelsSet.has(b.label))
+
+            return { "board": buildBoards }
 
   build:
-    name: Release build for ${{ matrix.board.name }}
-    needs: version
+    name: Development build for ${{ matrix.board.id }}
+    needs: prepare
     strategy:
       fail-fast: false
-      matrix:
-        board:
-          - {"name": "ova", "output": "ova", "runner": "x86-64-runner"}
-          - {"name": "generic_x86_64", "output": "generic-x86-64", "runner": "x86-64-runner"}
-          - {"name": "odroid_c2", "output": "odroid-c2", "runner": "aarch64-runner"}
-          - {"name": "odroid_c4", "output": "odroid-c4", "runner": "aarch64-runner"}
-          - {"name": "odroid_n2", "output": "odroid-n2", "runner": "aarch64-runner"}
-          - {"name": "odroid_xu4", "output": "odroid-xu4" , "runner": "aarch64-runner"}
-          - {"name": "rpi", "output": "rpi", "runner": "arm-runner"}
-          - {"name": "rpi0_w", "output": "rpi0-w", "runner": "arm-runner"}
-          - {"name": "rpi2", "output": "rpi2", "runner": "arm-runner"}
-          - {"name": "rpi3", "output": "rpi3", "runner": "arm-runner"}
-          - {"name": "rpi3_64", "output": "rpi3-64", "runner": "aarch64-runner"}
-          - {"name": "rpi4", "output": "rpi4", "runner": "arm-runner"}
-          - {"name": "rpi4_64", "output": "rpi4-64", "runner": "aarch64-runner"}
-          - {"name": "tinker", "output": "tinker", "runner": "arm-runner"}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     runs-on: ${{ matrix.board.runner }}
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Checkout source
+        uses: actions/checkout@v2
         with:
           submodules: true
+          ref: ${{ fromJSON(needs.prepare.outputs.gitref).ref }}
 
       - name: Build container
         run: docker build -t haos-builder .
@@ -76,7 +124,7 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.version.outputs.version_dev }} ${{ matrix.board.name }}
+            haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.prepare.outputs.version_dev }} ${{ matrix.board.defconfig }}
 
       - name: Upload images
         uses: burnett01/rsync-deployments@4.1
@@ -84,15 +132,16 @@ jobs:
           rsh: -q
           switches: -aW --ignore-existing
           path: release/
-          remote_path: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.version.outputs.version_main }}.${{ needs.version.outputs.version_dev }}/
+          remote_path: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.prepare.outputs.version_main }}.${{ needs.prepare.outputs.version_dev }}/
           remote_host: ${{ secrets.DEV_HOST }}
           remote_port: ${{ secrets.DEV_PORT }}
           remote_user: ${{ secrets.DEV_USERNAME }}
           remote_key: ${{ secrets.DEV_SSH_KEY }}
 
   bump_version:
-    name: Bump dev version to ${{ needs.version.outputs.version_main }}.${{ needs.version.outputs.version_dev }}
-    needs: [ build, version ]
+    name: Bump dev channel version
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: [ build, prepare ]
     runs-on: [ "ubuntu-20.04" ]
 
     steps:
@@ -103,10 +152,10 @@ jobs:
         email: ${{ secrets.GIT_EMAIL }}
         token: ${{ secrets.GIT_TOKEN }}
 
-    - name: Bump Home Assistant OS dev version
+    - name: Bump Home Assistant OS dev channel version to ${{ needs.prepare.outputs.version_main }}.${{ needs.prepare.outputs.version_dev }}
       uses: home-assistant/actions/helpers/version-push@master
       with:
         key: "hassos[]"
         key-description: "Home Assistant OS"
-        version: ${{ needs.version.outputs.version_main }}.${{ needs.version.outputs.version_dev }}
+        version: ${{ needs.prepare.outputs.version_main }}.${{ needs.prepare.outputs.version_dev }}
         channel: "dev"

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ova",
+    "defconfig": "ova",
+    "runner": "x86-64-runner",
+    "label": "board/ova"
+  },
+  {
+    "id": "generic-x86-64",
+    "defconfig": "generic_x86_64",
+    "runner": "x86-64-runner",
+    "label": "board/generic-x86-64"
+  },
+  {
+    "id": "odroid-c2",
+    "defconfig": "odroid_c2",
+    "runner": "aarch64-runner",
+    "label": "board/odroid"
+  },
+  {
+    "id": "odroid-c4",
+    "defconfig": "odroid_c4",
+    "runner": "aarch64-runner",
+    "label": "board/odroid"
+  },
+  {
+    "id": "odroid-n2",
+    "defconfig": "odroid_n2",
+    "runner": "aarch64-runner",
+    "label": "board/odroid"
+  },
+  {
+    "id": "odroid-xu4",
+    "defconfig": "odroid_xu4",
+    "runner": "aarch64-runner",
+    "label": "board/odroid"
+  },
+  {
+    "id": "rpi",
+    "defconfig": "rpi",
+    "runner": "arm-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi0-w",
+    "defconfig": "rpi0_w",
+    "runner": "arm-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi2",
+    "defconfig": "rpi2",
+    "runner": "arm-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi3",
+    "defconfig": "rpi3",
+    "runner": "arm-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi3-64",
+    "defconfig": "rpi3_64",
+    "runner": "aarch64-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi4",
+    "defconfig": "rpi4",
+    "runner": "arm-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "rpi4-64",
+    "defconfig": "rpi4_64",
+    "runner": "aarch64-runner",
+    "label": "board/raspberrypi"
+  },
+  {
+    "id": "tinker",
+    "defconfig": "tinker",
+    "runner": "arm-runner",
+    "label": "board/tinker"
+  }
+]


### PR DESCRIPTION
Implement a "/ghaction build" command to trigger a development build.
The comment must come from the owner or member of the organization.
This will only generate a build for the machines the PR has been
labeled with.

This is an alternative to #1464.