### PR TITLE
board: hardkernel: Fix random crash on Linux kernel 5.10 and newer

### DIFF
--- a/buildroot-external/board/hardkernel/patches/uboot/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,8 +1,8 @@
 From 8511fa06c13a9761e53ed72fe7111f5c3e3514a0 Mon Sep 17 00:00:00 2001
-Message-Id: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1617731946.git.stefan@agner.ch>
+Message-Id: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1627298114.git.stefan@agner.ch>
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Mon, 2 Sep 2019 15:42:04 +0200
-Subject: [PATCH] HACK: mmc: meson-gx: limit to 24MHz
+Subject: [PATCH 1/3] HACK: mmc: meson-gx: limit to 24MHz
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
@@ -23,5 +23,5 @@ index fcf4f03d1e..6ded4b619b 100644
  	cfg->name = dev->name;
  
 -- 
-2.31.1
+2.32.0
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0002-arm64-dts-meson-odroidc2-readd-PHY-reset-properties.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0002-arm64-dts-meson-odroidc2-readd-PHY-reset-properties.patch
@@ -1,10 +1,10 @@
-From e194459c7459a1c6f9d1183e05186d164f0c6715 Mon Sep 17 00:00:00 2001
-Message-Id: <e194459c7459a1c6f9d1183e05186d164f0c6715.1617807077.git.stefan@agner.ch>
-In-Reply-To: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1617807077.git.stefan@agner.ch>
-References: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1617807077.git.stefan@agner.ch>
+From 357280fce339e7cfde76b90a19f0cb164ce6ca8c Mon Sep 17 00:00:00 2001
+Message-Id: <357280fce339e7cfde76b90a19f0cb164ce6ca8c.1627298114.git.stefan@agner.ch>
+In-Reply-To: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1627298114.git.stefan@agner.ch>
+References: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1627298114.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 1 Apr 2021 14:33:57 +0200
-Subject: [PATCH 2/2] arm64: dts: meson: odroidc2: readd PHY reset properties
+Subject: [PATCH 2/3] arm64: dts: meson: odroidc2: readd PHY reset properties
 
 The sync of the device tree and dt-bindings from Linux v5.6-rc2
 11a48a5a18c6 ("Linux 5.6-rc2") causes Ethernet to break on some
@@ -15,24 +15,26 @@ dwmac until we support the new bindings in the PHY node.
 Fixes: dd5f2351e99a ("arm64: dts: meson: sync dt and bindings from v5.6-rc2")
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
- arch/arm/dts/meson-gxbb-odroidc2.dts | 4 ++++
- 1 file changed, 4 insertions(+)
+ arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
-diff --git a/arch/arm/dts/meson-gxbb-odroidc2.dts b/arch/arm/dts/meson-gxbb-odroidc2.dts
-index 70fcfb7b06..8b80bbc90b 100644
---- a/arch/arm/dts/meson-gxbb-odroidc2.dts
-+++ b/arch/arm/dts/meson-gxbb-odroidc2.dts
-@@ -188,6 +188,10 @@
- 	phy-handle = <&eth_phy0>;
- 	phy-mode = "rgmii";
+diff --git a/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi b/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi
+index 90087b00db..5a2be8171e 100644
+--- a/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi
++++ b/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi
+@@ -29,6 +29,12 @@
+ 	};
+ };
  
++&ethmac {
 +	snps,reset-gpio = <&gpio GPIOZ_14 0>;
 +	snps,reset-delays-us = <0 10000 1000000>;
 +	snps,reset-active-low;
++};
 +
- 	amlogic,tx-delay-ns = <2>;
- 
- 	mdio {
+ &usb0 {
+ 	status = "disabled";
+ };
 -- 
-2.31.1
+2.32.0
 

--- a/buildroot-external/board/hardkernel/patches/uboot/0003-HACK-ARM-meson-don-t-add-memory-to-memreserve.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0003-HACK-ARM-meson-don-t-add-memory-to-memreserve.patch
@@ -1,0 +1,54 @@
+From 295121994fc4413c7b2bcecb8ce4d076034d59a2 Mon Sep 17 00:00:00 2001
+Message-Id: <295121994fc4413c7b2bcecb8ce4d076034d59a2.1627298114.git.stefan@agner.ch>
+In-Reply-To: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1627298114.git.stefan@agner.ch>
+References: <8511fa06c13a9761e53ed72fe7111f5c3e3514a0.1627298114.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 26 Jul 2021 13:05:50 +0200
+Subject: [PATCH 3/3] HACK: ARM: meson: don't add memory to memreserve
+
+With 8a5a75e5e9e55 ("of/fdt: Make sure no-map does not remove already
+reserved regions") a change got introduced which doesn't update the
+mapping of a reserved region to nomap if it already exists.
+
+Upstream Linux marks the secmon region as reserved memory in the device
+tree reserved-memory node. Adding it to the memreserve section too
+causes the mappping update to fail since the above change got introduced
+in Linux 5.10, causing the following message in the kernel log:
+...
+[    0.000000] OF: fdt: Reserved memory: failed to reserve memory for node 'secmon@5000000': base 0x0000000005000000, size 3 MiB
+...
+
+Don't add the regions to memreserve so that the memory gets reserved
+properly with the no-map flag. This fixes random crashes like:
+[129988.642342] SError Interrupt on CPU4, code 0xbf000000 -- SError
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/mach-meson/board-common.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/mach-meson/board-common.c b/arch/arm/mach-meson/board-common.c
+index 34b3c8f399..1d81be06f1 100644
+--- a/arch/arm/mach-meson/board-common.c
++++ b/arch/arm/mach-meson/board-common.c
+@@ -66,6 +66,7 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	return meson_ft_board_setup(blob, bd);
+ }
+ 
++#if 0
+ void meson_board_add_reserved_memory(void *fdt, u64 start, u64 size)
+ {
+ 	int ret;
+@@ -77,6 +78,9 @@ void meson_board_add_reserved_memory(void *fdt, u64 start, u64 size)
+ 	if (IS_ENABLED(CONFIG_EFI_LOADER))
+ 		efi_add_memory_map(start, size, EFI_RESERVED_MEMORY_TYPE);
+ }
++#else
++void meson_board_add_reserved_memory(void *fdt, u64 start, u64 size) {}
++#endif
+ 
+ int meson_generate_serial_ethaddr(void)
+ {
+-- 
+2.32.0
+


### PR DESCRIPTION
Avoid adding memreserve since the device tree already reserves the
memory regions in reserved-memory nodes in device tree. This avoids
conflicting no-map setting and makes sure memory is properly reserved.