### PR TITLE
board: hardkernel: Fix random crash on Linux kernel 5.10 and newer

### DIFF
--- a/buildroot-external/board/hardkernel/patches/linux/5.10.53/0009-Revert-of-fdt-Make-sure-no-map-does-not-remove-alrea.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/5.10.53/0009-Revert-of-fdt-Make-sure-no-map-does-not-remove-alrea.patch
@@ -1,0 +1,52 @@
+From 19c34c0ceb6302b07e1017c426796c4cf7322d13 Mon Sep 17 00:00:00 2001
+Message-Id: <19c34c0ceb6302b07e1017c426796c4cf7322d13.1627311993.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 26 Jul 2021 16:59:08 +0200
+Subject: [PATCH 9/9] Revert "of/fdt: Make sure no-map does not remove already
+ reserved regions"
+
+U-Boot on Hardkernel ODROID-N2 adds fdt "memreserve" entries alongside
+the reserved-memory nodes present in upstream Linux. This causes
+reserving memory with the no-map flag to fail:
+[    0.000000] OF: fdt: Reserved memory: failed to reserve memory for node 'secmon@5000000': base 0x0000000005000000, size 3 MiB
+
+This seems to cause kernel crashes such as:
+[129988.642342] SError Interrupt on CPU4, code 0xbf000000 -- SError
+
+Restore the bahavior of Linux kernel 5.9 and older and don't fail
+updating the mapping with no-map.
+
+This reverts commit 8a5a75e5e9e55de1cef5d83ca3589cb4899193ef.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/of/fdt.c | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/drivers/of/fdt.c b/drivers/of/fdt.c
+index 57ff31b6b1e4..7ef2246e0b1e 100644
+--- a/drivers/of/fdt.c
++++ b/drivers/of/fdt.c
+@@ -1149,16 +1149,8 @@ int __init __weak early_init_dt_mark_hotplug_memory_arch(u64 base, u64 size)
+ int __init __weak early_init_dt_reserve_memory_arch(phys_addr_t base,
+ 					phys_addr_t size, bool nomap)
+ {
+-	if (nomap) {
+-		/*
+-		 * If the memory is already reserved (by another region), we
+-		 * should not allow it to be marked nomap.
+-		 */
+-		if (memblock_is_region_reserved(base, size))
+-			return -EBUSY;
+-
++	if (nomap)
+ 		return memblock_mark_nomap(base, size);
+-	}
+ 	return memblock_reserve(base, size);
+ }
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
Don't fail adding reserved memory when a memory region already has been
reserved (e.g. via  memreserve). This avoids conflicting no-map setting
and makes sure memory is properly reserved.