### PR TITLE
buildroot: package/lvm2: install dmsetup only (#1448)

### DIFF
--- a/buildroot-patches/0001-docker-add-AppArmor-support.patch
+++ b/buildroot-patches/0001-docker-add-AppArmor-support.patch
@@ -1,8 +1,8 @@
 From 09f9b55b419ef01ad24998bbacb1a49976b58bfa Mon Sep 17 00:00:00 2001
-Message-Id: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Mon, 13 Jan 2020 12:27:06 +0000
-Subject: [PATCH 1/8] docker: add AppArmor support
+Subject: [PATCH 1/9] docker: add AppArmor support
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 Signed-off-by: Stefan Agner <stefan@agner.ch>

--- a/buildroot-patches/0002-network-manager-wpa_supplicant.patch
+++ b/buildroot-patches/0002-network-manager-wpa_supplicant.patch
@@ -1,10 +1,10 @@
 From e06ba47c59eec31475a8302fca569a0315158154 Mon Sep 17 00:00:00 2001
-Message-Id: <e06ba47c59eec31475a8302fca569a0315158154.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <e06ba47c59eec31475a8302fca569a0315158154.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Thu, 16 Apr 2020 14:32:45 +0000
-Subject: [PATCH 2/8] network-manager: wpa_supplicant
+Subject: [PATCH 2/9] network-manager: wpa_supplicant
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---

--- a/buildroot-patches/0003-Fix-dhcp-client.patch
+++ b/buildroot-patches/0003-Fix-dhcp-client.patch
@@ -1,10 +1,10 @@
 From 654f5326428f1f442369589ce74333a44293fac2 Mon Sep 17 00:00:00 2001
-Message-Id: <654f5326428f1f442369589ce74333a44293fac2.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <654f5326428f1f442369589ce74333a44293fac2.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Thu, 16 Apr 2020 12:01:44 +0000
-Subject: [PATCH 3/8] Fix dhcp client
+Subject: [PATCH 3/9] Fix dhcp client
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---

--- a/buildroot-patches/0004-package-rpi-firmware-Allow-to-deploy-multiple-firmwa.patch
+++ b/buildroot-patches/0004-package-rpi-firmware-Allow-to-deploy-multiple-firmwa.patch
@@ -1,10 +1,10 @@
 From 81093c8655737f9208df3b75371290600625bec8 Mon Sep 17 00:00:00 2001
-Message-Id: <81093c8655737f9208df3b75371290600625bec8.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <81093c8655737f9208df3b75371290600625bec8.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 8 Feb 2021 14:08:28 +0100
-Subject: [PATCH 4/8] package/rpi-firmware: Allow to deploy multiple firmware
+Subject: [PATCH 4/9] package/rpi-firmware: Allow to deploy multiple firmware
  files
 
 Add a new config option to allow a specific list of firmware files to be

--- a/buildroot-patches/0005-package-linux-firmware-add-RTL87XX-RTL88XX-Bluetooth.patch
+++ b/buildroot-patches/0005-package-linux-firmware-add-RTL87XX-RTL88XX-Bluetooth.patch
@@ -1,10 +1,10 @@
 From f93e6246fbc58814dd4547eade63102c7626b76b Mon Sep 17 00:00:00 2001
-Message-Id: <f93e6246fbc58814dd4547eade63102c7626b76b.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <f93e6246fbc58814dd4547eade63102c7626b76b.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 17 Mar 2021 14:48:43 +0100
-Subject: [PATCH 5/8] package/linux-firmware: add RTL87XX/RTL88XX Bluetooth
+Subject: [PATCH 5/9] package/linux-firmware: add RTL87XX/RTL88XX Bluetooth
  firmware
 
 Add firmware files for Realtek 87XX and 88XX Bluetooth chipsets. Those

--- a/buildroot-patches/0006-package-docker-proxy-bump-version-to-b3507428be5b.patch
+++ b/buildroot-patches/0006-package-docker-proxy-bump-version-to-b3507428be5b.patch
@@ -1,10 +1,10 @@
 From 28a2450108743762b3b43629c86248f5fe45aa70 Mon Sep 17 00:00:00 2001
-Message-Id: <28a2450108743762b3b43629c86248f5fe45aa70.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <28a2450108743762b3b43629c86248f5fe45aa70.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 15 Apr 2021 17:22:59 +0200
-Subject: [PATCH 6/8] package/docker-proxy: bump version to b3507428be5b
+Subject: [PATCH 6/9] package/docker-proxy: bump version to b3507428be5b
 
 Which is the version used by docker 20.10.6:
 https://github.com/moby/moby/commit/88470052e7d42f3dc774442241fd6bab817876f6

--- a/buildroot-patches/0007-package-rpi-firmware-bump-version-to-1.20210303.patch
+++ b/buildroot-patches/0007-package-rpi-firmware-bump-version-to-1.20210303.patch
@@ -1,10 +1,10 @@
 From 30030f11ea80bee5f25136a3caf070a9b97e8b10 Mon Sep 17 00:00:00 2001
-Message-Id: <30030f11ea80bee5f25136a3caf070a9b97e8b10.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <30030f11ea80bee5f25136a3caf070a9b97e8b10.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 19 Apr 2021 10:59:03 +0200
-Subject: [PATCH 7/8] package/rpi-firmware: bump version to 1.20210303
+Subject: [PATCH 7/9] package/rpi-firmware: bump version to 1.20210303
 
 Keep rpi-firmware up-to-date with the kernel version bump (tag
 1.20210303).

--- a/buildroot-patches/0008-package-linux-firmware-add-rtl8761b-rtl8761bu-firmwa.patch
+++ b/buildroot-patches/0008-package-linux-firmware-add-rtl8761b-rtl8761bu-firmwa.patch
@@ -1,10 +1,10 @@
 From af2981f04e79fc5d4298e027d7a02ecfd3316bd7 Mon Sep 17 00:00:00 2001
-Message-Id: <af2981f04e79fc5d4298e027d7a02ecfd3316bd7.1624121036.git.stefan@agner.ch>
-In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
-References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1624121036.git.stefan@agner.ch>
+Message-Id: <af2981f04e79fc5d4298e027d7a02ecfd3316bd7.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Sat, 19 Jun 2021 18:20:46 +0200
-Subject: [PATCH 8/8] package/linux-firmware: add rtl8761b/rtl8761bu firmware
+Subject: [PATCH 8/9] package/linux-firmware: add rtl8761b/rtl8761bu firmware
 
 Bumpt to latest git hash and deploy rtl8761b/rtl8761bu firmwares as
 well.

--- a/buildroot-patches/0009-package-lvm2-fix-installation-of-systemd-units.patch
+++ b/buildroot-patches/0009-package-lvm2-fix-installation-of-systemd-units.patch
@@ -1,0 +1,62 @@
+From f358c8ba53970154054bc2140fb4127a116d97ff Mon Sep 17 00:00:00 2001
+Message-Id: <f358c8ba53970154054bc2140fb4127a116d97ff.1627475933.git.stefan@agner.ch>
+In-Reply-To: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+References: <09f9b55b419ef01ad24998bbacb1a49976b58bfa.1627475933.git.stefan@agner.ch>
+From: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Date: Fri, 21 May 2021 16:44:36 +0200
+Subject: [PATCH 9/9] package/lvm2: fix installation of systemd units
+
+Since we bump the version in commit 80997acd3587 (package/lvm2: bump
+version to 2.03.12), the installation of systemd units is no longer
+functional without a full installation.
+
+As Pascal puts it: the systemd service files don't make a whole lot of
+sense when there isn't a full lvm2 install.
+
+Move the conditional block that install system units, so that it only
+occurs when we do a full installation.
+
+Fixes;
+    http://autobuild.buildroot.org/results/f47/f470ffb55625e2639cecde713442550eb532d0d7/
+    http://autobuild.buildroot.org/results/954/9547929292e81671fbe3a5b4bbc87a6424edb1ca/
+    http://autobuild.buildroot.org/results/303/30359c351a6ce2f9139494a531e036f0b0406ccf
+
+Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>
+Co-Developped-by: Pascal de Bruijn <p.debruijn@unilogic.nl>
+Cc: Pascal de Bruijn <p.debruijn@unilogic.nl>
+Cc: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
+(cherry picked from commit 8a313b019c7d7e898186a8b08f9c25ae0194fa16)
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ package/lvm2/lvm2.mk | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/package/lvm2/lvm2.mk b/package/lvm2/lvm2.mk
+index 19e8757e54..87c1c761ea 100644
+--- a/package/lvm2/lvm2.mk
++++ b/package/lvm2/lvm2.mk
+@@ -53,6 +53,9 @@ LVM2_INSTALL_TARGET_OPTS += install_device-mapper
+ else
+ LVM2_INSTALL_STAGING_OPTS += install
+ LVM2_INSTALL_TARGET_OPTS += install
++ifeq ($(BR2_INIT_SYSTEMD),y)
++LVM2_INSTALL_TARGET_OPTS += install_systemd_units install_systemd_generators
++endif
+ endif
+ 
+ ifeq ($(BR2_PACKAGE_LVM2_APP_LIBRARY),y)
+@@ -67,10 +70,6 @@ else
+ LVM2_CONF_OPTS += --disable-lvmetad
+ endif
+ 
+-ifeq ($(BR2_INIT_SYSTEMD),y)
+-LVM2_INSTALL_TARGET_OPTS += install_systemd_units install_systemd_generators
+-endif
+-
+ ifeq ($(BR2_TOOLCHAIN_SUPPORTS_PIE),)
+ LVM2_CONF_ENV += ac_cv_flag_HAVE_PIE=no
+ endif
+-- 
+2.32.0
+

--- a/buildroot/package/lvm2/lvm2.mk
+++ b/buildroot/package/lvm2/lvm2.mk
@@ -53,6 +53,9 @@ LVM2_INSTALL_TARGET_OPTS += install_device-mapper
 else
 LVM2_INSTALL_STAGING_OPTS += install
 LVM2_INSTALL_TARGET_OPTS += install
+ifeq ($(BR2_INIT_SYSTEMD),y)
+LVM2_INSTALL_TARGET_OPTS += install_systemd_units install_systemd_generators
+endif
 endif
 
 ifeq ($(BR2_PACKAGE_LVM2_APP_LIBRARY),y)
@@ -65,10 +68,6 @@ ifeq ($(BR2_PACKAGE_LVM2_LVMETAD),y)
 LVM2_CONF_OPTS += --enable-lvmetad
 else
 LVM2_CONF_OPTS += --disable-lvmetad
-endif
-
-ifeq ($(BR2_INIT_SYSTEMD),y)
-LVM2_INSTALL_TARGET_OPTS += install_systemd_units install_systemd_generators
 endif
 
 ifeq ($(BR2_TOOLCHAIN_SUPPORTS_PIE),)


### PR DESCRIPTION
LVM2 is not really required in the embedded use case. Opt out of
installing the standard installation which will install only dmsetup.
This requires a backported fix for the lvm2 package to not install
unnecessary systemd services.

Fixes: #1448
Related: #1449