### PR TITLE
Increase minimal free memory for Raspberry Pis

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/etc/sysctl.d/98-rpi.conf
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/etc/sysctl.d/98-rpi.conf
@@ -1,0 +1,1 @@
+vm.min_free_kbytes = 16384


### PR DESCRIPTION
The minimal memory reserved parameter vm.min_free_kbytes should be
between 1-3% according to RedHat.

However, the kernel by default reserves around 3MB (e.g. only 3285 on a
32-bit Raspberry Pi 4 2GB installation). This seems to be too low for
network intensive applications such as ours: Under memory pressure
"page allocation failure" on various orders have been observed.

Raspberry Pi OS uses a fixed value of 16MB. Follow this setting for now.

Note: We cannot set this globally for Home Assistant: x86-64 machines
can have quite a bit more memory, which also requires increased
min_free_kbytes parameter. ODROID-N2 on the other hand uses transparent
huge pages: If enabled, the kernel requires higher min_free_kbytes
values, and sets those also by default (e.g. on ODROID-N2+ with 4GB
memory its set to 22528 by default).