### PR TITLE
Fix U-Boot USB initialization failure (#1203, #1490)

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
@@ -1,8 +1,8 @@
-From 76cd0b31510f2019e411593e1a177ca8280b56b3 Mon Sep 17 00:00:00 2001
-Message-Id: <76cd0b31510f2019e411593e1a177ca8280b56b3.1619686343.git.stefan@agner.ch>
+From 9cb97076d98f7f68534abb3d1f596644ae730841 Mon Sep 17 00:00:00 2001
+Message-Id: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 10 Dec 2019 09:48:46 +0000
-Subject: [PATCH 1/2] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
+Subject: [PATCH 1/3] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---
@@ -79,5 +79,5 @@ index 78638105f7..06b390d907 100644
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
 -- 
-2.31.1
+2.33.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0002-raspberrypi-Disable-simple-framebuffer-support.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0002-raspberrypi-Disable-simple-framebuffer-support.patch
@@ -1,10 +1,10 @@
-From 8c11937b388dfafcdff27914d361532dc805245f Mon Sep 17 00:00:00 2001
-Message-Id: <8c11937b388dfafcdff27914d361532dc805245f.1619686343.git.stefan@agner.ch>
-In-Reply-To: <76cd0b31510f2019e411593e1a177ca8280b56b3.1619686343.git.stefan@agner.ch>
-References: <76cd0b31510f2019e411593e1a177ca8280b56b3.1619686343.git.stefan@agner.ch>
+From 69ac2930e69ca876f8da95d80f4a1cb8cc23bb6a Mon Sep 17 00:00:00 2001
+Message-Id: <69ac2930e69ca876f8da95d80f4a1cb8cc23bb6a.1630679018.git.stefan@agner.ch>
+In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+References: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
 From: Florin Sarbu <florin@balena.io>
 Date: Thu, 12 Sep 2019 12:31:31 +0200
-Subject: [PATCH 2/2] raspberrypi: Disable simple framebuffer support
+Subject: [PATCH 2/3] raspberrypi: Disable simple framebuffer support
 
 On 4.19 kernels this u-boot driver clashes with bcm2708_fb.
 So let's disable it from here so that we have bcm2708_fb
@@ -61,5 +61,5 @@ index 834f1cd236..19a0d611c4 100644
  #ifdef CONFIG_CMD_USB
  #define CONFIG_TFTP_TSIZE
 -- 
-2.31.1
+2.33.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0003-ARM-bcm283x-change-the-virtual-address-of-the-XHCI-P.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0003-ARM-bcm283x-change-the-virtual-address-of-the-XHCI-P.patch
@@ -1,0 +1,49 @@
+From 72619dd5d0be59e702fd7b7090916ee688c34180 Mon Sep 17 00:00:00 2001
+Message-Id: <72619dd5d0be59e702fd7b7090916ee688c34180.1630679018.git.stefan@agner.ch>
+In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+References: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+From: Marek Szyprowski <m.szyprowski@samsung.com>
+Date: Thu, 17 Jun 2021 11:22:03 +0200
+Subject: [PATCH 3/3] ARM: bcm283x: change the virtual address of the XHCI PCI
+ device base
+
+Move the XHCI PCI device base up in the virtual address space. This fixes
+initialization failure observed with newer Raspberry Pi firmware, later
+than 63b1922311 ("firmware: arm_loader: Update armstubs with those from
+PR 117). It looks that chosing 0xff800000 as the XHCI PCI device base
+conflicts with the updated ARM/VideoCore firmware.
+
+This also requires to reduce the size of the mapped PCI device region
+from 8MiB to 4MiB to fit into 32bit address space. This is still enough
+for the XHCI PCI device.
+
+Signed-off-by: Marek Szyprowski <m.szyprowski@samsung.com>
+---
+ arch/arm/mach-bcm283x/init.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-bcm283x/init.c b/arch/arm/mach-bcm283x/init.c
+index 49027ce0a2..9803499985 100644
+--- a/arch/arm/mach-bcm283x/init.c
++++ b/arch/arm/mach-bcm283x/init.c
+@@ -14,7 +14,7 @@
+ #include <asm/global_data.h>
+ 
+ #define BCM2711_RPI4_PCIE_XHCI_MMIO_PHYS	0x600000000UL
+-#define BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE	0x800000UL
++#define BCM2711_RPI4_PCIE_XHCI_MMIO_SIZE	0x400000UL
+ 
+ #ifdef CONFIG_ARM64
+ #include <asm/armv8/mmu.h>
+@@ -148,7 +148,7 @@ int mach_cpu_init(void)
+ 
+ #ifdef CONFIG_ARMV7_LPAE
+ #ifdef CONFIG_TARGET_RPI_4_32B
+-#define BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT	0xff800000UL
++#define BCM2711_RPI4_PCIE_XHCI_MMIO_VIRT	0xffc00000UL
+ #include <addr_map.h>
+ #include <asm/system.h>
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
Add a patch to fix a U-Boot issue causing troubles when enumerating USB
devices (required when booting from USB devices).