### PR TITLE
Fix buffer overflow when initialize USB keyboard in U-Boot (#1538)

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
@@ -1,8 +1,8 @@
 From 9cb97076d98f7f68534abb3d1f596644ae730841 Mon Sep 17 00:00:00 2001
-Message-Id: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+Message-Id: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 10 Dec 2019 09:48:46 +0000
-Subject: [PATCH 1/3] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
+Subject: [PATCH 1/4] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---

--- a/buildroot-external/board/raspberrypi/patches/uboot/0002-raspberrypi-Disable-simple-framebuffer-support.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0002-raspberrypi-Disable-simple-framebuffer-support.patch
@@ -1,10 +1,10 @@
 From 69ac2930e69ca876f8da95d80f4a1cb8cc23bb6a Mon Sep 17 00:00:00 2001
-Message-Id: <69ac2930e69ca876f8da95d80f4a1cb8cc23bb6a.1630679018.git.stefan@agner.ch>
-In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
-References: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+Message-Id: <69ac2930e69ca876f8da95d80f4a1cb8cc23bb6a.1631043469.git.stefan@agner.ch>
+In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
+References: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
 From: Florin Sarbu <florin@balena.io>
 Date: Thu, 12 Sep 2019 12:31:31 +0200
-Subject: [PATCH 2/3] raspberrypi: Disable simple framebuffer support
+Subject: [PATCH 2/4] raspberrypi: Disable simple framebuffer support
 
 On 4.19 kernels this u-boot driver clashes with bcm2708_fb.
 So let's disable it from here so that we have bcm2708_fb

--- a/buildroot-external/board/raspberrypi/patches/uboot/0003-ARM-bcm283x-change-the-virtual-address-of-the-XHCI-P.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0003-ARM-bcm283x-change-the-virtual-address-of-the-XHCI-P.patch
@@ -1,10 +1,10 @@
 From 72619dd5d0be59e702fd7b7090916ee688c34180 Mon Sep 17 00:00:00 2001
-Message-Id: <72619dd5d0be59e702fd7b7090916ee688c34180.1630679018.git.stefan@agner.ch>
-In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
-References: <9cb97076d98f7f68534abb3d1f596644ae730841.1630679018.git.stefan@agner.ch>
+Message-Id: <72619dd5d0be59e702fd7b7090916ee688c34180.1631043469.git.stefan@agner.ch>
+In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
+References: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
 From: Marek Szyprowski <m.szyprowski@samsung.com>
 Date: Thu, 17 Jun 2021 11:22:03 +0200
-Subject: [PATCH 3/3] ARM: bcm283x: change the virtual address of the XHCI PCI
+Subject: [PATCH 3/4] ARM: bcm283x: change the virtual address of the XHCI PCI
  device base
 
 Move the XHCI PCI device base up in the virtual address space. This fixes

--- a/buildroot-external/board/raspberrypi/patches/uboot/0004-IOMUX-Fix-buffer-overflow-in-iomux_replace_device.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0004-IOMUX-Fix-buffer-overflow-in-iomux_replace_device.patch
@@ -1,0 +1,44 @@
+From 0a33e4e03b9266818d6f0a6d566bf12be55c657c Mon Sep 17 00:00:00 2001
+Message-Id: <0a33e4e03b9266818d6f0a6d566bf12be55c657c.1631043469.git.stefan@agner.ch>
+In-Reply-To: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
+References: <9cb97076d98f7f68534abb3d1f596644ae730841.1631043469.git.stefan@agner.ch>
+From: Yuichiro Goto <goto@k-tech.co.jp>
+Date: Mon, 26 Apr 2021 08:08:03 +0900
+Subject: [PATCH 4/4] IOMUX: Fix buffer overflow in iomux_replace_device()
+
+Use of strcat() against an uninitialized buffer would lead
+to buffer overflow. This patch fixes it.
+
+Fixes: 694cd5618c ("IOMUX: Introduce iomux_replace_device()")
+Signed-off-by: Yuichiro Goto <goto@k-tech.co.jp>
+Cc: Peter Robinson <pbrobinson@gmail.com>
+Cc: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Cc: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>
+Reviewed-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Tested-by: Peter Robinson <pbrobinson@gmail.com>
+---
+ common/iomux.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/common/iomux.c b/common/iomux.c
+index b9088aa3b5..c428f7110a 100644
+--- a/common/iomux.c
++++ b/common/iomux.c
+@@ -158,8 +158,12 @@ int iomux_replace_device(const int console, const char *old, const char *new)
+ 			return -ENOMEM;
+ 		}
+ 
+-		strcat(tmp, ",");
+-		strcat(tmp, name);
++		if (arg) {
++			strcat(tmp, ",");
++			strcat(tmp, name);
++		}
++		else
++			strcpy(tmp, name);
+ 
+ 		arg = tmp;
+ 		size = strlen(tmp) + 1;
+-- 
+2.33.0
+


### PR DESCRIPTION
When a USB keyboard is connected to Raspberry Pi 32-bit versions of
U-Boot crashed in certain situations just before booting Linux. This
seems to be cause by a buffer overflow when removing the USB keyboard
before hand-over to Linux.