### PR TITLE
Wait until Internet is available before starting AppArmor

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-apparmor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-apparmor.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=HassOS AppArmor
-Wants=hassos-supervisor.service
+Wants=hassos-supervisor.service network-online.target time-sync.target
+After=network-online.target time-sync.target
 Before=docker.service hassos-supervisor.service
 RequiresMountsFor=/mnt/data
 


### PR DESCRIPTION
This makes sure that internet connectivity is available to replace the
AppArmor configuration in case the device has been wiped.