### PR TITLE
Bump OS Agent to 1.2.1

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.2.0
+OS_AGENT_VERSION = 1.2.1
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This should make the D-Bus method ReloadDevice working and show the
current data disk correctly.