### PR TITLE
Fix Compute Module 4 USB driver (#1281)

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
@@ -1,8 +1,8 @@
 From d7ec084799b394cc02395829dc97019c8834e944 Mon Sep 17 00:00:00 2001
-Message-Id: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 10 Dec 2019 09:48:46 +0000
-Subject: [PATCH 1/9] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
+Subject: [PATCH 01/10] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
 
 Signed-off-by: Pascal Vizeli <pvizeli@syshack.ch>
 ---

--- a/buildroot-external/board/raspberrypi/patches/uboot/0002-usb-xhci-reset-endpoint-on-USB-stall.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0002-usb-xhci-reset-endpoint-on-USB-stall.patch
@@ -1,10 +1,10 @@
 From 3d471d3be58ccd899d29bf57ad669e7a51d0b47d Mon Sep 17 00:00:00 2001
-Message-Id: <3d471d3be58ccd899d29bf57ad669e7a51d0b47d.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <3d471d3be58ccd899d29bf57ad669e7a51d0b47d.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 27 Sep 2021 12:28:04 +0200
-Subject: [PATCH 2/9] usb: xhci: reset endpoint on USB stall
+Subject: [PATCH 02/10] usb: xhci: reset endpoint on USB stall
 
 There are devices which cause a USB stall when trying to read strings.
 Specifically Arduino Mega R3 stalls when trying to read the product

--- a/buildroot-external/board/raspberrypi/patches/uboot/0003-rpi-add-NVMe-to-boot-order.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0003-rpi-add-NVMe-to-boot-order.patch
@@ -1,10 +1,10 @@
 From 698fc7c39fb3265ccb9cc7f3bb08432b76f3cdf5 Mon Sep 17 00:00:00 2001
-Message-Id: <698fc7c39fb3265ccb9cc7f3bb08432b76f3cdf5.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <698fc7c39fb3265ccb9cc7f3bb08432b76f3cdf5.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 29 Dec 2020 23:34:52 +0100
-Subject: [PATCH 3/9] rpi: add NVMe to boot order
+Subject: [PATCH 03/10] rpi: add NVMe to boot order
 
 The Compute Module 4 I/O Board can support a NVMe. Add NVMe to the boot
 order.

--- a/buildroot-external/board/raspberrypi/patches/uboot/0004-Revert-nvme-Correct-the-prps-per-page-calculation-me.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0004-Revert-nvme-Correct-the-prps-per-page-calculation-me.patch
@@ -1,10 +1,10 @@
 From fdacde2c24e052938cbb54d15dabc541304d8f40 Mon Sep 17 00:00:00 2001
-Message-Id: <fdacde2c24e052938cbb54d15dabc541304d8f40.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <fdacde2c24e052938cbb54d15dabc541304d8f40.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:43:31 +0200
-Subject: [PATCH 4/9] Revert "nvme: Correct the prps per page calculation
+Subject: [PATCH 04/10] Revert "nvme: Correct the prps per page calculation
  method"
 
 This reverts commit 859b33c948945f7904f60a2c12a3792d356d51ad.

--- a/buildroot-external/board/raspberrypi/patches/uboot/0005-nvme-improve-readability-of-nvme_setup_prps.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0005-nvme-improve-readability-of-nvme_setup_prps.patch
@@ -1,10 +1,10 @@
 From d7a7036c90d0f65c8345b9f75ac1e817c48c998f Mon Sep 17 00:00:00 2001
-Message-Id: <d7a7036c90d0f65c8345b9f75ac1e817c48c998f.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <d7a7036c90d0f65c8345b9f75ac1e817c48c998f.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:52:44 +0200
-Subject: [PATCH 5/9] nvme: improve readability of nvme_setup_prps()
+Subject: [PATCH 05/10] nvme: improve readability of nvme_setup_prps()
 
 Improve readability by introducing consts, reuse consts where
 appropriate and adding variables with discriptive name.

--- a/buildroot-external/board/raspberrypi/patches/uboot/0006-nvme-Use-pointer-for-CPU-addressed-buffers.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0006-nvme-Use-pointer-for-CPU-addressed-buffers.patch
@@ -1,10 +1,10 @@
 From 27a4d59876323a0e13807ac3614b01700b8cfe83 Mon Sep 17 00:00:00 2001
-Message-Id: <27a4d59876323a0e13807ac3614b01700b8cfe83.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <27a4d59876323a0e13807ac3614b01700b8cfe83.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:58:35 +0200
-Subject: [PATCH 6/9] nvme: Use pointer for CPU addressed buffers
+Subject: [PATCH 06/10] nvme: Use pointer for CPU addressed buffers
 
 Pass buffers which use CPU addressing as void pointers. This aligns with
 DMA APIs which use void pointers as argument. It will avoid unnecessary

--- a/buildroot-external/board/raspberrypi/patches/uboot/0007-nvme-translate-virtual-addresses-into-the-bus-s-addr.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0007-nvme-translate-virtual-addresses-into-the-bus-s-addr.patch
@@ -1,11 +1,11 @@
 From bdaf8f67fd33ae1d38011a2b6f9da4884ec11dd2 Mon Sep 17 00:00:00 2001
-Message-Id: <bdaf8f67fd33ae1d38011a2b6f9da4884ec11dd2.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <bdaf8f67fd33ae1d38011a2b6f9da4884ec11dd2.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 24 Sep 2021 00:27:39 +0200
-Subject: [PATCH 7/9] nvme: translate virtual addresses into the bus's address
- space
+Subject: [PATCH 07/10] nvme: translate virtual addresses into the bus's
+ address space
 
 So far we've been content with passing physical/CPU addresses when
 configuring memory addresses into NVMe controllers, but not all

--- a/buildroot-external/board/raspberrypi/patches/uboot/0008-nvme-invalidate-correct-memory-range-after-read.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0008-nvme-invalidate-correct-memory-range-after-read.patch
@@ -1,10 +1,10 @@
 From e55ccb4af869726b9579596ad37f3e7f33b5332d Mon Sep 17 00:00:00 2001
-Message-Id: <e55ccb4af869726b9579596ad37f3e7f33b5332d.1633447374.git.stefan@agner.ch>
-In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
-References: <d7ec084799b394cc02395829dc97019c8834e944.1633447374.git.stefan@agner.ch>
+Message-Id: <e55ccb4af869726b9579596ad37f3e7f33b5332d.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 28 Sep 2021 00:52:51 +0200
-Subject: [PATCH 8/9] nvme: invalidate correct memory range after read
+Subject: [PATCH 08/10] nvme: invalidate correct memory range after read
 
 The current code invalidates the range after the read buffer since the
 buffer pointer gets incremented in the read loop. Use a temporary

--- a/buildroot-external/board/raspberrypi/patches/uboot/0009-usb-xhci-brcm-Include-header-file-needed-for-dev_err.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0009-usb-xhci-brcm-Include-header-file-needed-for-dev_err.patch
@@ -1,0 +1,32 @@
+From dedd65ecd36cee5610022bbab4a8bf92c2401df9 Mon Sep 17 00:00:00 2001
+Message-Id: <dedd65ecd36cee5610022bbab4a8bf92c2401df9.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 5 Oct 2021 17:07:22 +0200
+Subject: [PATCH 09/10] usb: xhci-brcm: Include header file needed for dev_err
+
+dev_err seems to be moved to different header file. Include
+dm/device_compat.h file to compile properly.
+
+Fixes: 69dae8902b16 ("linux/compat.h: Remove redefinition of dev_xxx macros")
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/usb/host/xhci-brcm.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/usb/host/xhci-brcm.c b/drivers/usb/host/xhci-brcm.c
+index 27c4bbfcba..fe17924028 100644
+--- a/drivers/usb/host/xhci-brcm.c
++++ b/drivers/usb/host/xhci-brcm.c
+@@ -8,6 +8,7 @@
+ #include <fdtdec.h>
+ #include <usb.h>
+ #include <asm/io.h>
++#include <dm/device_compat.h>
+ #include <usb/xhci.h>
+ 
+ #define DRD2U3H_XHC_REGS_AXIWRA	0xC08
+-- 
+2.33.0
+

--- a/buildroot-external/board/raspberrypi/patches/uboot/0010-usb-xhci-brcm-Make-driver-compatible-with-downstream.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0010-usb-xhci-brcm-Make-driver-compatible-with-downstream.patch
@@ -1,0 +1,33 @@
+From 2b09a341c0e7e508565926c1b6f383bdd5259d8b Mon Sep 17 00:00:00 2001
+Message-Id: <2b09a341c0e7e508565926c1b6f383bdd5259d8b.1633601057.git.stefan@agner.ch>
+In-Reply-To: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+References: <d7ec084799b394cc02395829dc97019c8834e944.1633601057.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 7 Oct 2021 12:02:39 +0200
+Subject: [PATCH 10/10] usb: xhci-brcm: Make driver compatible with downstream
+ device tree
+
+The downstream device tree uses just "generic-xhci" as compatible
+string. Use this string to make U-Boot work with the downstream Kernel.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/usb/host/xhci-brcm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/usb/host/xhci-brcm.c b/drivers/usb/host/xhci-brcm.c
+index fe17924028..0c6938187b 100644
+--- a/drivers/usb/host/xhci-brcm.c
++++ b/drivers/usb/host/xhci-brcm.c
+@@ -82,7 +82,7 @@ static int xhci_brcm_deregister(struct udevice *dev)
+ }
+ 
+ static const struct udevice_id xhci_brcm_ids[] = {
+-	{ .compatible = "brcm,generic-xhci" },
++	{ .compatible = "generic-xhci" },
+ 	{ }
+ };
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
The BCM2711 has two USB 2.0 IPs: A Broadcom XHCI USB 2.0 controller and
a Synopsys DWC2 USB 2.0 Host/Device controller. When USB boot is used
the former is active. Make sure the driver has the correct device tree
compatible.