### PR TITLE
Make AppArmor independent of Supervisor service

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-apparmor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-apparmor.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=HassOS AppArmor
-Wants=hassos-supervisor.service network-online.target time-sync.target
+Wants=network-online.target time-sync.target
 After=network-online.target time-sync.target
-Before=docker.service hassos-supervisor.service
+Before=docker.service
 RequiresMountsFor=/mnt/data
 
 [Service]

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -2,7 +2,7 @@
 Description=HassOS supervisor
 Requires=docker.service rauc.service dbus.service
 Wants=network-online.target hassos-apparmor.service time-sync.target
-After=docker.service rauc.service dbus.service network-online.target time-sync.target
+After=docker.service rauc.service dbus.service network-online.target hassos-apparmor.service time-sync.target
 RequiresMountsFor=/mnt/data /mnt/boot /mnt/overlay
 StartLimitIntervalSec=60
 StartLimitBurst=5


### PR DESCRIPTION
Currently the hassos-apparmor.service wants the
hassos-supervisor.service and vice-versa. This is unnecessary and leads
to activation of hassos-supervisor.service when reload/restart
hassos-apparmor.service (Supervisor is doing that on startup).

Make hassos-apparmor.service independent and add dependency as well as
ordering from hassos-supervisor.service side.