### PR TITLE
Synchronize Raspberry Pi config.txt with Raspberry Pi OS

### DIFF
--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -71,6 +71,11 @@ kernel=u-boot.bin
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+[pi4]
+# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+dtoverlay=vc4-fkms-v3d
+max_framebuffers=2
+
 [all]
 #dtoverlay=vc4-fkms-v3d
 #max_framebuffers=2


### PR DESCRIPTION
It seems that Raspberry Pi OS by default applies an overlay for
Raspberry Pi 4. Apply this change to the HAOS config.txt as well.