### PR TITLE
Remove git submodules before git checkout

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -77,6 +77,10 @@ jobs:
               return { "ref": context.ref }
             return { "ref": context.payload.pull_request.head.sha }
 
+      # Make sure directories of potentially removed submodules are cleaned correctly
+      - name: Cleanup git submodules
+        run: find . -name .git -type f -exec rm {} \;
+
       - name: Checkout source
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
     runs-on: ${{ matrix.board.runner }}
 
     steps:
+      # Make sure directories of potentially removed submodules are cleaned correctly
+      - name: Cleanup git submodules
+        run: find . -name .git -type f -exec rm {} \;
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
If a git submodule is converted to a regular git directory (e.g. when
moving from dev -> rel-6 branch), the directory is not properly cleaned
by the checkout action.

Remove the git submodule .git files which makes sure that git properly
reinitialize subdirectories, even if they have been a submodule before.

See also: https://github.com/actions/checkout/issues/624