### PR TITLE
Update Linux kernel patches for Home Assistant Amber

### DIFF
--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
@@ -1,8 +1,8 @@
-From 4000c39e3084ea0bdd76173fda310b6c32fd4734 Mon Sep 17 00:00:00 2001
-Message-Id: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
+From fa42d0ece205b3c2a8a06dac3e4436400cf59978 Mon Sep 17 00:00:00 2001
+Message-Id: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
-Date: Thu, 4 Mar 2021 14:28:29 +0100
-Subject: [PATCH 1/6] ARM: dts: bcm2711: Add device tree for Home Assistant
+Date: Wed, 3 Nov 2021 00:00:45 +0100
+Subject: [PATCH 1/7] ARM: dts: bcm2711: Add device tree for Home Assistant
  Amber
 
 Add device tree for Home Assistant Amber, a Compute Module 4 based I/O
@@ -11,10 +11,10 @@ board.
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
  arch/arm/boot/dts/Makefile                    |   3 +-
- .../arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts | 618 ++++++++++++++++++
+ .../arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts | 659 ++++++++++++++++++
  arch/arm64/boot/dts/broadcom/Makefile         |   1 +
  .../dts/broadcom/bcm2711-rpi-cm4-ha-amber.dts |   1 +
- 4 files changed, 622 insertions(+), 1 deletion(-)
+ 4 files changed, 663 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
  create mode 100644 arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4-ha-amber.dts
 
@@ -34,14 +34,16 @@ index 12cd8bf582e1..4fa8c7be516a 100644
  	alpine-db.dtb
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 new file mode 100644
-index 000000000000..11d8f87ac6d3
+index 000000000000..855da2b029a4
 --- /dev/null
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-@@ -0,0 +1,618 @@
+@@ -0,0 +1,659 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/dts-v1/;
 +#include "bcm2711.dtsi"
 +#include "bcm2835-rpi.dtsi"
++
++#include <dt-bindings/reset/raspberrypi,firmware-reset.h>
 +
 +/ {
 +	compatible = "raspberrypi,4-compute-module-ha-amber", "brcm,bcm2711";
@@ -62,14 +64,15 @@ index 000000000000..11d8f87ac6d3
 +		emmc2bus = &emmc2bus;
 +		ethernet0 = &genet;
 +		pcie0 = &pcie0;
++		blconfig = &blconfig;
 +	};
 +
 +	leds {
-+		act {
++		led-act {
 +			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		pwr {
++		led-pwr {
 +			label = "PWR";
 +			gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
 +			default-state = "keep";
@@ -116,6 +119,11 @@ index 000000000000..11d8f87ac6d3
 +};
 +
 +&firmware {
++	firmware_clocks: clocks {
++		compatible = "raspberrypi,firmware-clocks";
++		#clock-cells = <1>;
++	};
++
 +	expgpio: gpio {
 +		compatible = "raspberrypi,firmware-gpio";
 +		gpio-controller;
@@ -141,6 +149,11 @@ index 000000000000..11d8f87ac6d3
 +			gpios = <7 GPIO_ACTIVE_HIGH>;
 +			output-low;
 +		};
++	};
++
++	reset: reset {
++		compatible = "raspberrypi,firmware-reset";
++		#reset-cells = <1>;
 +	};
 +};
 +
@@ -220,12 +233,14 @@ index 000000000000..11d8f87ac6d3
 +&hdmi0 {
 +	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 0>, <&clk_27MHz>;
 +	clock-names = "hdmi", "bvb", "audio", "cec";
++	wifi-2.4ghz-coexistence;
 +	status = "okay";
 +};
 +
 +&hdmi1 {
 +	clocks = <&firmware_clocks 13>, <&firmware_clocks 14>, <&dvp 1>, <&clk_27MHz>;
 +	clock-names = "hdmi", "bvb", "audio", "cec";
++	wifi-2.4ghz-coexistence;
 +	status = "okay";
 +};
 +
@@ -249,18 +264,26 @@ index 000000000000..11d8f87ac6d3
 +	status = "okay";
 +};
 +
-+&vc4 {
-+	status = "okay";
-+};
-+
-+&vec {
-+	status = "disabled";
-+};
-+
 +&pwm1 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm1_0_gpio40 &pwm1_1_gpio41>;
 +	status = "okay";
++};
++
++&rmem {
++	/*
++	 * RPi4's co-processor will copy the board's bootloader configuration
++	 * into memory for the OS to consume. It'll also update this node with
++	 * its placement information.
++	 */
++	blconfig: nvram@0 {
++		compatible = "raspberrypi,bootloader-config", "nvmem-rmem";
++		#address-cells = <1>;
++		#size-cells = <1>;
++		reg = <0x0 0x0 0x0>;
++		no-map;
++		status = "disabled";
++	};
 +};
 +
 +/* SDHCI is used to control the SDIO for wireless */
@@ -296,9 +319,24 @@ index 000000000000..11d8f87ac6d3
 +};
 +
 +&genet_mdio {
-+	phy1: ethernet-phy@1 {
++	phy1: ethernet-phy@0 {
 +		/* No PHY interrupt */
-+		reg = <0x1>;
++		reg = <0x0>;
++	};
++};
++
++&pcie0 {
++	pci@1,0 {
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		reg = <0 0 0 0 0>;
++
++		usb@1,0 {
++			reg = <0x10000 0 0 0 0>;
++			resets = <&reset RASPBERRYPI_FIRMWARE_RESET_ID_USB>;
++		};
 +	};
 +};
 +
@@ -327,6 +365,14 @@ index 000000000000..11d8f87ac6d3
 +	interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
 +};
 +
++&vc4 {
++	status = "okay";
++};
++
++&vec {
++	status = "disabled";
++};
++
 +// =============================================
 +// Downstream rpi- changes
 +
@@ -346,6 +392,7 @@ index 000000000000..11d8f87ac6d3
 +#include "bcm283x-rpi-csi0-2lane.dtsi"
 +#include "bcm283x-rpi-csi1-4lane.dtsi"
 +#include "bcm283x-rpi-i2c0mux_0_44.dtsi"
++#include "bcm283x-rpi-cam1-regulator.dtsi"
 +
 +/ {
 +	chosen {
@@ -358,23 +405,20 @@ index 000000000000..11d8f87ac6d3
 +		mmc0 = &emmc2;
 +		mmc1 = &mmcnr;
 +		mmc2 = &sdhost;
-+		/delete-property/ i2c2;
 +		i2c3 = &i2c3;
 +		i2c4 = &i2c4;
 +		i2c5 = &i2c5;
 +		i2c6 = &i2c6;
++		i2c20 = &ddc0;
++		i2c21 = &ddc1;
++		spi3 = &spi3;
++		spi4 = &spi4;
++		spi5 = &spi5;
++		spi6 = &spi6;
 +		/delete-property/ intc;
 +	};
 +
 +	/delete-node/ wifi-pwrseq;
-+
-+	cam0_reg: cam1_reg: cam1_reg {
-+		compatible = "regulator-fixed";
-+		regulator-name = "cam1-reg";
-+		gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
-+		enable-active-high;
-+		status = "disabled";
-+	};
 +};
 +
 +&mmcnr {
@@ -572,13 +616,6 @@ index 000000000000..11d8f87ac6d3
 +	pinctrl-0 = <&i2s_pins>;
 +};
 +
-+/ {
-+	__overrides__ {
-+		/delete-property/ i2c2_baudrate;
-+		/delete-property/ i2c2_iknowwhatimdoing;
-+	};
-+};
-+
 +// =============================================
 +// Board specific stuff here
 +
@@ -602,13 +639,13 @@ index 000000000000..11d8f87ac6d3
 +};
 +
 +&leds {
-+	act_led: act {
++	act_led: led-act {
 +		label = "led0";
 +		linux,default-trigger = "mmc0";
 +		gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
 +	};
 +
-+	pwr_led: pwr {
++	pwr_led: led-pwr {
 +		label = "led1";
 +		linux,default-trigger = "default-on";
 +		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
@@ -623,6 +660,10 @@ index 000000000000..11d8f87ac6d3
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&audio_pins>;
 +	brcm,disable-headphones = <1>;
++};
++
++cam0_reg: &cam1_reg {
++	gpio = <&expgpio 5 GPIO_ACTIVE_HIGH>;
 +};
 +
 +/ {
@@ -676,5 +717,5 @@ index 000000000000..728975338bf0
 @@ -0,0 +1 @@
 +#include "../../../../arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts"
 -- 
-2.33.0
+2.33.1
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
@@ -1,10 +1,10 @@
-From 0113b0cf3e1e1d64234a3674a159e3af6f082000 Mon Sep 17 00:00:00 2001
-Message-Id: <0113b0cf3e1e1d64234a3674a159e3af6f082000.1633341968.git.stefan@agner.ch>
-In-Reply-To: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
-References: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
+From 60125e49aff88c430ebc6b8702aaf3867f529b75 Mon Sep 17 00:00:00 2001
+Message-Id: <60125e49aff88c430ebc6b8702aaf3867f529b75.1635895105.git.stefan@agner.ch>
+In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:33:09 +0100
-Subject: [PATCH 2/6] ARM: dts: bcm2711: amber: Mux UART4 for SiLabs radio
+Subject: [PATCH 2/7] ARM: dts: bcm2711: amber: Mux UART4 for SiLabs radio
  module
 
 Enable UART4 by default and mux pins including hardware flow control.
@@ -15,10 +15,10 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index 11d8f87ac6d3..48a56bf7e3d8 100644
+index 855da2b029a4..ba4116cdffc4 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-@@ -19,6 +19,7 @@ memory@0 {
+@@ -21,6 +21,7 @@ memory@0 {
  	};
  
  	aliases {
@@ -26,7 +26,7 @@ index 11d8f87ac6d3..48a56bf7e3d8 100644
  		emmc2bus = &emmc2bus;
  		ethernet0 = &genet;
  		pcie0 = &pcie0;
-@@ -283,6 +284,14 @@ &uart1 {
+@@ -321,6 +322,14 @@ &uart1 {
  	status = "okay";
  };
  
@@ -41,7 +41,7 @@ index 11d8f87ac6d3..48a56bf7e3d8 100644
  &vchiq {
  	interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
  };
-@@ -505,9 +514,9 @@ uart3_pins: uart3_pins {
+@@ -549,9 +558,9 @@ uart3_pins: uart3_pins {
  	};
  
  	uart4_pins: uart4_pins {
@@ -54,5 +54,5 @@ index 11d8f87ac6d3..48a56bf7e3d8 100644
  
  	uart5_pins: uart5_pins {
 -- 
-2.33.0
+2.33.1
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
@@ -1,30 +1,21 @@
-From c9f08bb9ed2f72ec76651552e85c4fa5ccbab6f3 Mon Sep 17 00:00:00 2001
-Message-Id: <c9f08bb9ed2f72ec76651552e85c4fa5ccbab6f3.1633341968.git.stefan@agner.ch>
-In-Reply-To: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
-References: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
+From 1e395219026ad0575483aecc9d49992099e73e8b Mon Sep 17 00:00:00 2001
+Message-Id: <1e395219026ad0575483aecc9d49992099e73e8b.1635895105.git.stefan@agner.ch>
+In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:44:23 +0100
-Subject: [PATCH 3/6] ARM: dts: bcm2711: amber: Mux debug UART5
+Subject: [PATCH 3/7] ARM: dts: bcm2711: amber: Mux debug UART5
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
- arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
+ arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index 48a56bf7e3d8..f0f83ff79882 100644
+index ba4116cdffc4..4c2fe964eb72 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-@@ -9,7 +9,7 @@ / {
- 
- 	chosen {
- 		/* 8250 auxiliary UART instead of pl011 */
--		stdout-path = "serial1:115200n8";
-+		stdout-path = "serial5:115200n8";
- 	};
- 
- 	/* Will be filled by the bootloader */
-@@ -20,6 +20,7 @@ memory@0 {
+@@ -22,6 +22,7 @@ memory@0 {
  
  	aliases {
  		serial4 = &uart4;
@@ -32,7 +23,7 @@ index 48a56bf7e3d8..f0f83ff79882 100644
  		emmc2bus = &emmc2bus;
  		ethernet0 = &genet;
  		pcie0 = &pcie0;
-@@ -292,6 +293,13 @@ &uart4 {
+@@ -330,6 +331,13 @@ &uart4 {
  	status = "okay";
  };
  
@@ -46,6 +37,14 @@ index 48a56bf7e3d8..f0f83ff79882 100644
  &vchiq {
  	interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
  };
+@@ -366,6 +374,7 @@ soc {
+ / {
+ 	chosen {
+ 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
++		stdout-path = "serial5:115200n8";
+ 	};
+ 
+ 	aliases {
 -- 
-2.33.0
+2.33.1
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
@@ -1,10 +1,10 @@
-From b56cab462d92c755a34dc4bb4d901fb86cf81a5b Mon Sep 17 00:00:00 2001
-Message-Id: <b56cab462d92c755a34dc4bb4d901fb86cf81a5b.1633341968.git.stefan@agner.ch>
-In-Reply-To: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
-References: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
+From 3fa8a55b7fd515f0ffe8b000be23080003ed5ac4 Mon Sep 17 00:00:00 2001
+Message-Id: <3fa8a55b7fd515f0ffe8b000be23080003ed5ac4.1635895105.git.stefan@agner.ch>
+In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 17:19:01 +0100
-Subject: [PATCH 5/6] ARM: dts: bcm2711: amber: add I2S audio codec
+Subject: [PATCH 5/7] ARM: dts: bcm2711: amber: add I2S audio codec
 
 Add TI PCM5122 I2S audio codec.
 
@@ -14,10 +14,10 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 26 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index c4b0432b81a4..8d8d31a2fafb 100644
+index a95c3f96044a..637ce01618d8 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-@@ -548,11 +548,22 @@ &i2c6 {
+@@ -593,11 +593,22 @@ &i2c6 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c6_pins>;
  	status = "okay";
@@ -39,8 +39,8 @@ index c4b0432b81a4..8d8d31a2fafb 100644
 +	status = "okay";
  };
  
- / {
-@@ -602,6 +613,21 @@ &pwm1 {
+ // =============================================
+@@ -640,6 +651,21 @@ &pwm1 {
  	status = "disabled";
  };
  
@@ -63,5 +63,5 @@ index c4b0432b81a4..8d8d31a2fafb 100644
  	pinctrl-names = "default";
  	pinctrl-0 = <&audio_pins>;
 -- 
-2.33.0
+2.33.1
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
@@ -1,10 +1,10 @@
-From 5d8c4f62c8e254380b9cb83f22fa035311bc3bfb Mon Sep 17 00:00:00 2001
-Message-Id: <5d8c4f62c8e254380b9cb83f22fa035311bc3bfb.1633341968.git.stefan@agner.ch>
-In-Reply-To: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
-References: <4000c39e3084ea0bdd76173fda310b6c32fd4734.1633341968.git.stefan@agner.ch>
+From 7e2f95935408ec5b1d7a2b63daaef7fdb01d642c Mon Sep 17 00:00:00 2001
+Message-Id: <7e2f95935408ec5b1d7a2b63daaef7fdb01d642c.1635895105.git.stefan@agner.ch>
+In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 9 Mar 2021 15:02:53 +0100
-Subject: [PATCH 6/6] ARM: dts: bcm2711: amber: enable GPIO keys
+Subject: [PATCH 6/7] ARM: dts: bcm2711: amber: enable GPIO keys
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index 8d8d31a2fafb..7badb6073729 100644
+index 637ce01618d8..a2cbb8510491 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 @@ -2,6 +2,7 @@
@@ -21,10 +21,10 @@ index 8d8d31a2fafb..7badb6073729 100644
  #include "bcm2835-rpi.dtsi"
 +#include <dt-bindings/input/input.h>
  
- / {
- 	compatible = "raspberrypi,4-compute-module-ha-amber", "brcm,bcm2711";
-@@ -26,6 +27,29 @@ aliases {
- 		pcie0 = &pcie0;
+ #include <dt-bindings/reset/raspberrypi,firmware-reset.h>
+ 
+@@ -29,6 +30,29 @@ aliases {
+ 		blconfig = &blconfig;
  	};
  
 +	keys: gpio-keys {
@@ -51,9 +51,9 @@ index 8d8d31a2fafb..7badb6073729 100644
 +	};
 +
  	leds {
- 		act {
+ 		led-act {
  			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
-@@ -393,6 +417,12 @@ spidev1: spidev@1{
+@@ -438,6 +462,12 @@ spidev1: spidev@1{
  };
  
  &gpio {
@@ -67,5 +67,5 @@ index 8d8d31a2fafb..7badb6073729 100644
  		brcm,pins = <9 10 11>;
  		brcm,function = <BCM2835_FSEL_ALT0>;
 -- 
-2.33.0
+2.33.1
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
@@ -1,12 +1,12 @@
-From 071423b3beab53facdc69b7c945f82a907825f80 Mon Sep 17 00:00:00 2001
-Message-Id: <071423b3beab53facdc69b7c945f82a907825f80.1635895105.git.stefan@agner.ch>
+From c9b6a336142c18892a1b617e8e1460ddd89a0991 Mon Sep 17 00:00:00 2001
+Message-Id: <c9b6a336142c18892a1b617e8e1460ddd89a0991.1635895105.git.stefan@agner.ch>
 In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
-Date: Thu, 4 Mar 2021 14:48:48 +0100
-Subject: [PATCH 4/7] ARM: dts: bcm2711: amber: Enable I2C6 by default
+Date: Thu, 28 Oct 2021 19:38:04 +0200
+Subject: [PATCH 7/7] ARM: dts: bcm2711: amber: add user LED
 
-The main I2C bus used on Amber is I2C6. Enable it by default.
+Add yellow user LED.
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
@@ -14,22 +14,22 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 6 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index 4c2fe964eb72..a95c3f96044a 100644
+index a2cbb8510491..a80a50de399e 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-@@ -589,6 +589,12 @@ &i2c1 {
- 	clock-frequency = <100000>;
+@@ -675,6 +675,12 @@ pwr_led: led-pwr {
+ 		linux,default-trigger = "default-on";
+ 		gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
+ 	};
++
++	user_led: led-user {
++		label = "led2";
++		linux,default-trigger = "heartbeat";
++		gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
++	};
  };
  
-+&i2c6 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&i2c6_pins>;
-+	status = "okay";
-+};
-+
- &i2s {
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&i2s_pins>;
+ &pwm1 {
 -- 
 2.33.1
 


### PR DESCRIPTION
Support the user LED available on the latest revision of the PCB. Also
rebase the patchset ontop of the Raspberry Pi kernel 1.20210928.