### PR TITLE
Added helper to run workflows on forks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 `forked-helper.yml` workflow helper can help to run custom workflows on the forked repositories.
 
 1. Set `HAOS_SELF_DISPATCH_TOKEN` secret on your repository with `security_events` permissions.
-2. Helper will dispatch `repository_dispatch` event `hassos-dispatch` on `push`, `release`, `deployment`,
+2. Helper will dispatch `repository_dispatch` event `haos-dispatch` on `push`, `release`, `deployment`,
    `pull_request` and `workflow_dispatch` events. All needed event details you can find in `client_payload`
    property of the event.
 3. Create empty default branch in forked repository:
@@ -17,11 +17,11 @@ git commit --allow-empty -m "Initial commit"
 
 Workflow example:
 ```yaml
-name: Test HassOS dispatch
+name: Test haos dispatch
 
 on:
   repository_dispatch:
-    types: ["hassos-dispatch"]
+    types: ["haos-dispatch"]
 
 jobs:
   show-dispatch:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,32 @@
+# Use workflows in forked repositories
+
+`forked-helper.yml` workflow helper can help to run custom workflows on the forked repositories.
+
+1. Set `HAOS_SELF_DISPATCH_TOKEN` secret on your repository with `security_events` permissions.
+2. Helper will dispatch `repository_dispatch` event `hassos-dispatch` on `push`, `release`, `deployment`,
+   `pull_request` and `workflow_dispatch` events. All needed event details you can find in `client_payload`
+   property of the event.
+3. Create empty default branch in forked repository:
+```shell
+git checkout --orphan my-build-branch
+git rm -rf .
+git commit --allow-empty -m "Initial commit"
+```
+4. Create workflow with `repository_dispatch` in default branch.
+5. Run any need actions in this workflow.
+
+Workflow example:
+```yaml
+name: Test HassOS dispatch
+
+on:
+  repository_dispatch:
+    types: ["hassos-dispatch"]
+
+jobs:
+  show-dispatch:
+    name: Show dispatch event details
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/debug-action@v2
+```

--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Assign secret
         id: get_dispatch_secret
-        run: echo '::set-output name=dispatch_secret::${{ secrets.HASSOS_SELF_DISPATCH_TOKEN }}'
+        run: echo '::set-output name=dispatch_secret::${{ secrets.HAOS_SELF_DISPATCH_TOKEN }}'
       - name: Get event details
         id: get_event_details
         # Process JSON according https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
@@ -31,7 +31,7 @@ jobs:
         with:
           token: ${{ steps.get_dispatch_secret.outputs.dispatch_secret }}
           repository: ${{ github.repository }}
-          event-type: hassos-dispatch
+          event-type: haos-dispatch
           client-payload: >
             {
               "event": "${{ github.event_name }}",

--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -1,0 +1,42 @@
+name: Forked helper
+
+on:
+  push:
+  release:
+  deployment:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  fork-repository-dispatch:
+    name: 📢 Run repository dispatch to default fork branch
+    if: ${{ github.repository_owner != 'home-assistant' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign secret
+        id: get_dispatch_secret
+        run: echo '::set-output name=dispatch_secret::${{ secrets.HASSOS_SELF_DISPATCH_TOKEN }}'
+      - name: Get event details
+        id: get_event_details
+        # Process JSON according https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+        run: |
+          JSON=$(cat ${{ github.event_path }})
+          JSON="${JSON//'%'/'%25'}"
+          JSON="${JSON//$'\n'/'%0A'}"
+          JSON="${JSON//$'\r'/'%0D'}"
+          echo "::set-output name=event_details::${JSON}"
+      - name: Dispatch event on forked repostitory
+        if: steps.get_dispatch_secret.outputs.dispatch_secret
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ steps.get_dispatch_secret.outputs.dispatch_secret }}
+          repository: ${{ github.repository }}
+          event-type: hassos-dispatch
+          client-payload: >
+            {
+              "event": "${{ github.event_name }}",
+              "ref": "${{ github.ref }}",
+              "base_ref": "${{ github.base_ref }}",
+              "sha": "${{ github.sha }}",
+              "event_details": ${{ steps.get_event_details.outputs.event_details }}
+            }


### PR DESCRIPTION
Currently it is impossible to keep forked branch in sync with upstream (for PR purposes) and use custom workflows.

So, I made workflow which send event from any branch to the default branch.

I added howto to the `.github/workflows/README.md`

Same approved PR for Armbian: https://github.com/armbian/build/pull/3197

Tests:

- [X]  Emit dispatch event workflow: https://github.com/jethome-ru/homeassistant-operating-system/actions/runs/1448001048
- [X]  Receive dispatch event workflow: https://github.com/jethome-ru/homeassistant-operating-system/actions/runs/1448005475

