### PR TITLE
Update Linux kernel patches for Home Assistant Amber

### DIFF
--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
@@ -1,8 +1,8 @@
 From a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9 Mon Sep 17 00:00:00 2001
-Message-Id: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 3 Nov 2021 00:00:45 +0100
-Subject: [PATCH 1/7] ARM: dts: bcm2711: Add device tree for Home Assistant
+Subject: [PATCH 1/8] ARM: dts: bcm2711: Add device tree for Home Assistant
  Amber
 
 Add device tree for Home Assistant Amber, a Compute Module 4 based I/O

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0001-ARM-dts-bcm2711-Add-device-tree-for-Home-Assistant-A.patch
@@ -1,5 +1,5 @@
-From fa42d0ece205b3c2a8a06dac3e4436400cf59978 Mon Sep 17 00:00:00 2001
-Message-Id: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9 Mon Sep 17 00:00:00 2001
+Message-Id: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 3 Nov 2021 00:00:45 +0100
 Subject: [PATCH 1/7] ARM: dts: bcm2711: Add device tree for Home Assistant

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
@@ -1,10 +1,10 @@
 From c2cd4c6be5337c1998e789f5eab755c8a71030d9 Mon Sep 17 00:00:00 2001
-Message-Id: <c2cd4c6be5337c1998e789f5eab755c8a71030d9.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <c2cd4c6be5337c1998e789f5eab755c8a71030d9.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:33:09 +0100
-Subject: [PATCH 2/7] ARM: dts: bcm2711: amber: Mux UART4 for SiLabs radio
+Subject: [PATCH 2/8] ARM: dts: bcm2711: amber: Mux UART4 for SiLabs radio
  module
 
 Enable UART4 by default and mux pins including hardware flow control.

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0002-ARM-dts-bcm2711-amber-Mux-UART4-for-SiLabs-radio-mod.patch
@@ -1,7 +1,7 @@
-From 60125e49aff88c430ebc6b8702aaf3867f529b75 Mon Sep 17 00:00:00 2001
-Message-Id: <60125e49aff88c430ebc6b8702aaf3867f529b75.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From c2cd4c6be5337c1998e789f5eab755c8a71030d9 Mon Sep 17 00:00:00 2001
+Message-Id: <c2cd4c6be5337c1998e789f5eab755c8a71030d9.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:33:09 +0100
 Subject: [PATCH 2/7] ARM: dts: bcm2711: amber: Mux UART4 for SiLabs radio

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
@@ -1,7 +1,7 @@
-From 1e395219026ad0575483aecc9d49992099e73e8b Mon Sep 17 00:00:00 2001
-Message-Id: <1e395219026ad0575483aecc9d49992099e73e8b.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From 34ad3ae858d00c68703bea3b94dfb59c8bb928d9 Mon Sep 17 00:00:00 2001
+Message-Id: <34ad3ae858d00c68703bea3b94dfb59c8bb928d9.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:44:23 +0100
 Subject: [PATCH 3/7] ARM: dts: bcm2711: amber: Mux debug UART5

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0003-ARM-dts-bcm2711-amber-Mux-debug-UART5.patch
@@ -1,10 +1,10 @@
 From 34ad3ae858d00c68703bea3b94dfb59c8bb928d9 Mon Sep 17 00:00:00 2001
-Message-Id: <34ad3ae858d00c68703bea3b94dfb59c8bb928d9.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <34ad3ae858d00c68703bea3b94dfb59c8bb928d9.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:44:23 +0100
-Subject: [PATCH 3/7] ARM: dts: bcm2711: amber: Mux debug UART5
+Subject: [PATCH 3/8] ARM: dts: bcm2711: amber: Mux debug UART5
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0004-ARM-dts-bcm2711-amber-Enable-I2C6-by-default.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0004-ARM-dts-bcm2711-amber-Enable-I2C6-by-default.patch
@@ -1,10 +1,10 @@
 From 494a018160133dc908c7ceb42daa016d147e488c Mon Sep 17 00:00:00 2001
-Message-Id: <494a018160133dc908c7ceb42daa016d147e488c.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <494a018160133dc908c7ceb42daa016d147e488c.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:48:48 +0100
-Subject: [PATCH 4/7] ARM: dts: bcm2711: amber: Enable I2C6 by default
+Subject: [PATCH 4/8] ARM: dts: bcm2711: amber: Enable I2C6 by default
 
 The main I2C bus used on Amber is I2C6. Enable it by default.
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0004-ARM-dts-bcm2711-amber-Enable-I2C6-by-default.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0004-ARM-dts-bcm2711-amber-Enable-I2C6-by-default.patch
@@ -1,7 +1,7 @@
-From 071423b3beab53facdc69b7c945f82a907825f80 Mon Sep 17 00:00:00 2001
-Message-Id: <071423b3beab53facdc69b7c945f82a907825f80.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From 494a018160133dc908c7ceb42daa016d147e488c Mon Sep 17 00:00:00 2001
+Message-Id: <494a018160133dc908c7ceb42daa016d147e488c.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 14:48:48 +0100
 Subject: [PATCH 4/7] ARM: dts: bcm2711: amber: Enable I2C6 by default

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
@@ -1,10 +1,10 @@
 From 4311662759cc1a652859d61b62e2bf1e388a3bee Mon Sep 17 00:00:00 2001
-Message-Id: <4311662759cc1a652859d61b62e2bf1e388a3bee.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <4311662759cc1a652859d61b62e2bf1e388a3bee.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 17:19:01 +0100
-Subject: [PATCH 5/7] ARM: dts: bcm2711: amber: add I2S audio codec
+Subject: [PATCH 5/8] ARM: dts: bcm2711: amber: add I2S audio codec
 
 Add TI PCM5122 I2S audio codec.
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0005-ARM-dts-bcm2711-amber-add-I2S-audio-codec.patch
@@ -1,7 +1,7 @@
-From 3fa8a55b7fd515f0ffe8b000be23080003ed5ac4 Mon Sep 17 00:00:00 2001
-Message-Id: <3fa8a55b7fd515f0ffe8b000be23080003ed5ac4.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From 4311662759cc1a652859d61b62e2bf1e388a3bee Mon Sep 17 00:00:00 2001
+Message-Id: <4311662759cc1a652859d61b62e2bf1e388a3bee.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 4 Mar 2021 17:19:01 +0100
 Subject: [PATCH 5/7] ARM: dts: bcm2711: amber: add I2S audio codec

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
@@ -1,7 +1,7 @@
-From 7e2f95935408ec5b1d7a2b63daaef7fdb01d642c Mon Sep 17 00:00:00 2001
-Message-Id: <7e2f95935408ec5b1d7a2b63daaef7fdb01d642c.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From a5961a4bdb240848bcce5129a587fde6ce1fce9a Mon Sep 17 00:00:00 2001
+Message-Id: <a5961a4bdb240848bcce5129a587fde6ce1fce9a.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 9 Mar 2021 15:02:53 +0100
 Subject: [PATCH 6/7] ARM: dts: bcm2711: amber: enable GPIO keys

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0006-ARM-dts-bcm2711-amber-enable-GPIO-keys.patch
@@ -1,10 +1,10 @@
 From a5961a4bdb240848bcce5129a587fde6ce1fce9a Mon Sep 17 00:00:00 2001
-Message-Id: <a5961a4bdb240848bcce5129a587fde6ce1fce9a.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <a5961a4bdb240848bcce5129a587fde6ce1fce9a.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 9 Mar 2021 15:02:53 +0100
-Subject: [PATCH 6/7] ARM: dts: bcm2711: amber: enable GPIO keys
+Subject: [PATCH 6/8] ARM: dts: bcm2711: amber: enable GPIO keys
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
@@ -1,7 +1,7 @@
-From c9b6a336142c18892a1b617e8e1460ddd89a0991 Mon Sep 17 00:00:00 2001
-Message-Id: <c9b6a336142c18892a1b617e8e1460ddd89a0991.1635895105.git.stefan@agner.ch>
-In-Reply-To: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
-References: <fa42d0ece205b3c2a8a06dac3e4436400cf59978.1635895105.git.stefan@agner.ch>
+From 702c3ef370741afce83cfb9a2fb166da0a94fdc7 Mon Sep 17 00:00:00 2001
+Message-Id: <702c3ef370741afce83cfb9a2fb166da0a94fdc7.1636733804.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 28 Oct 2021 19:38:04 +0200
 Subject: [PATCH 7/7] ARM: dts: bcm2711: amber: add user LED
@@ -14,7 +14,7 @@ Signed-off-by: Stefan Agner <stefan@agner.ch>
  1 file changed, 6 insertions(+)
 
 diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
-index a2cbb8510491..a80a50de399e 100644
+index a2cbb8510491..3b69185ef840 100644
 --- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 +++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
 @@ -675,6 +675,12 @@ pwr_led: led-pwr {
@@ -25,7 +25,7 @@ index a2cbb8510491..a80a50de399e 100644
 +	user_led: led-user {
 +		label = "led2";
 +		linux,default-trigger = "heartbeat";
-+		gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
++		gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 +	};
  };
  

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0007-ARM-dts-bcm2711-amber-add-user-LED.patch
@@ -1,10 +1,10 @@
 From 702c3ef370741afce83cfb9a2fb166da0a94fdc7 Mon Sep 17 00:00:00 2001
-Message-Id: <702c3ef370741afce83cfb9a2fb166da0a94fdc7.1636733804.git.stefan@agner.ch>
-In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
-References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636733804.git.stefan@agner.ch>
+Message-Id: <702c3ef370741afce83cfb9a2fb166da0a94fdc7.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 28 Oct 2021 19:38:04 +0200
-Subject: [PATCH 7/7] ARM: dts: bcm2711: amber: add user LED
+Subject: [PATCH 7/8] ARM: dts: bcm2711: amber: add user LED
 
 Add yellow user LED.
 

--- a/buildroot-external/board/raspberrypi/amber/patches/linux/0008-ARM-dts-bcm2711-amber-Add-NXP-PCF85063A-RTC.patch
+++ b/buildroot-external/board/raspberrypi/amber/patches/linux/0008-ARM-dts-bcm2711-amber-Add-NXP-PCF85063A-RTC.patch
@@ -1,0 +1,32 @@
+From 1cb48f353aab457185274b734063fbdd2fc0f3df Mon Sep 17 00:00:00 2001
+Message-Id: <1cb48f353aab457185274b734063fbdd2fc0f3df.1636734839.git.stefan@agner.ch>
+In-Reply-To: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+References: <a08d21ffe9957db5f00b1ee8f0d1667b11a25cb9.1636734839.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 12 Nov 2021 17:33:32 +0100
+Subject: [PATCH 8/8] ARM: dts: bcm2711: amber: Add NXP PCF85063A RTC
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
+index 3b69185ef840..01d98b05517f 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-amber.dts
+@@ -633,6 +633,11 @@ card_codec: pcm5121@4c {
+ 		CPVDD-supply = <&vdd_3v3_reg>;
+ 		status = "okay";
+ 	};
++
++	pcf85063a: rtc@51 {
++		compatible = "nxp,pcf85063a";
++		reg = <0x51>;
++	};
+ };
+ 
+ &i2s {
+-- 
+2.33.1
+


### PR DESCRIPTION
Fix user LED polarity. Also rebase the patchset ontop of the Raspberry Pi
kernel 1.20211029.