### PR TITLE
Avoid race condition when fetching containers during build

### DIFF
--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -36,4 +36,4 @@ dst_image_file_path="${dst_dir}/${image_file_name}.tar"
 	fi
 
 	cp "${image_file_path}" "${dst_image_file_path}"
-) 3>${image_file_path}.lock
+) 3>"${image_file_path}.lock"

--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -24,15 +24,16 @@ image_file_name="${full_image_name//[:\/]/_}@${image_digest//[:\/]/_}"
 image_file_path="${dl_dir}/${image_file_name}.tar"
 dst_image_file_path="${dst_dir}/${image_file_name}.tar"
 
-if [ -f "${image_file_path}" ]
-then
-	echo "Skipping download of existing image: ${full_image_name} (digest ${image_digest})"
+(
+	# Use file locking to avoid race condition
+	flock --verbose 3
+	if [ ! -f "${image_file_path}" ]
+	then
+		echo "Fetching image: ${full_image_name} (digest ${image_digest})"
+		skopeo copy "docker://${image_name}@${image_digest}" "docker-archive:${image_file_path}:${full_image_name}"
+	else
+		echo "Skipping download of existing image: ${full_image_name} (digest ${image_digest})"
+	fi
+
 	cp "${image_file_path}" "${dst_image_file_path}"
-	exit 0
-fi
-
-# Use digest here to avoid race conditions of any sort...
-echo "Fetching image: ${full_image_name}"
-skopeo copy "docker://${image_name}@${image_digest}" "docker-archive:${image_file_path}:${full_image_name}"
-
-cp "${image_file_path}" "${dst_image_file_path}"
+) 3>${image_file_path}.lock


### PR DESCRIPTION
So far only a single builder was active for each architecture. This
toghether with the naming scheme to include architecture/machine name
made sure that an image could only be fetched or used by a single
builder.

However, since most systems are now aarch64, multiple runners are now
active for a single architecture. This makes it necessary to lock
fetching/coping of container images to avoid race conditions.