### PR TITLE
Adjust ova to support VMware ESXi (#826)

### DIFF
--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -32,7 +32,7 @@ function hassos_post_image() {
 
     cp -a "${BOARD_DIR}/home-assistant.ovf" "${OVA_DATA}/home-assistant.ovf"
     qemu-img convert -O vmdk -o subformat=streamOptimized "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
-    (cd "${OVA_DATA}" || exit 1; sha256sum --tag home-assistant.* >home-assistant.mf)
+    (cd "${OVA_DATA}" || exit 1; openssl sha256 home-assistant.* >home-assistant.mf)
     tar -C "${OVA_DATA}" --owner=root --group=root -cf "${HDD_OVA}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
 
     # Cleanup

--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -32,7 +32,7 @@ function hassos_post_image() {
 
     cp -a "${BOARD_DIR}/home-assistant.ovf" "${OVA_DATA}/home-assistant.ovf"
     qemu-img convert -O vmdk -o subformat=streamOptimized "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
-    (cd "${OVA_DATA}" || exit 1; openssl sha256 home-assistant.* >home-assistant.mf)
+    (cd "${OVA_DATA}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* >home-assistant.mf)
     tar -C "${OVA_DATA}" --owner=root --group=root -cf "${HDD_OVA}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
 
     # Cleanup

--- a/buildroot-external/board/pc/ova/home-assistant.ovf
+++ b/buildroot-external/board/pc/ova/home-assistant.ovf
@@ -53,12 +53,12 @@
       </Item>
       <Item>
         <rasd:Address>0</rasd:Address>
-        <rasd:Caption>sataController0</rasd:Caption>
-        <rasd:Description>SATA Controller</rasd:Description>
-        <rasd:ElementName>sataController0</rasd:ElementName>
+        <rasd:Caption>SCSIController</rasd:Caption>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSIController</rasd:ElementName>
         <rasd:InstanceID>3</rasd:InstanceID>
-        <rasd:ResourceSubType>AHCI</rasd:ResourceSubType>
-        <rasd:ResourceType>20</rasd:ResourceType>
+        <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
       </Item>
       <Item ovf:required="false">
         <rasd:Address>0</rasd:Address>
@@ -136,7 +136,7 @@
         <RTC localOrUTC="UTC"/>
       </Hardware>
       <StorageControllers>
-        <StorageController name="SATA" type="AHCI" PortCount="1">
+        <StorageController name="LsiLogic" type="LsiLogic" PortCount="16" useHostIOCache="true" Bootable="true">
           <AttachedDevice type="HardDisk" hotpluggable="false" port="0" device="0">
             <Image uuid="{5f042839-c478-43d9-9eb0-fd8a902146ec}"/>
           </AttachedDevice>


### PR DESCRIPTION
Use OpenSSL to generate OVA manifest file. It seems that sha256sum adds a
space after the hash algorithm which causes "Invalid OVF checksum algorithm"
on certain VMware virtualization products.

Using OpenSSL avoids the space and makes the manifest file compatible
with VMware products.

Use the common LSI Logic SCSI controller for disks. This is supported by Virtual Box
as well as VMware.