### PR TITLE
Re-upload rebuilt files

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -112,7 +112,7 @@ jobs:
         uses: burnett01/rsync-deployments@4.1
         with:
           rsh: -q
-          switches: -aW --ignore-existing
+          switches: -aW
           path: release/
           remote_path: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.prepare.outputs.version_main }}.${{ needs.prepare.outputs.version_dev }}/
           remote_host: ${{ secrets.DEV_HOST }}


### PR DESCRIPTION
Make sure to overwrite existing files on upload. This allows to trigger
rebuilds and have the latest builds on the os-builds server.

Note: When using GitHub Actions, the release/ directory is cleared at
the beginning (by the checkout action, which has the clean option set
by default which also causes files in .gitignore to be deleted).