### PR TITLE
Enable ForwardToSyslog in journald

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/journald.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/journald.conf
@@ -1,3 +1,4 @@
 [Journal]
 Storage=auto
 Compress=yes
+ForwardToSyslog=yes


### PR DESCRIPTION
This will enable `ForwardToSyslog` in journald, so that all log messages become available via `/dev/log` socket.
So we get the possibility to have addons (_maybe core or user_) to gather logs from this socket and - for example - forward them to a remote syslog server or do some kind of monitoring and alerting based on defined search pattern...