### PR TITLE
integrated dual HomeMatic+homematicIP support for HmIP-RFUSB

### DIFF
--- a/buildroot-external/package/generic_raw_uart/generic_raw_uart.hash
+++ b/buildroot-external/package/generic_raw_uart/generic_raw_uart.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  1d2fadbf7eae5e578eaf492e4c5efa59c8a2ccfe2b289e24141494c00b3802a9  generic_raw_uart-c7c82ab6324af57d79c62532df4a79c0b0258562.tar.gz
 sha256  b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  LICENSE
+sha256  6c054e86c8edebfd7ee5f8c8e3ff2383ae624bb10c4e9936d75af8f57ae5cf56  generic_raw_uart-58b10fff652ad2e67f71e7e07270b50d27e55d40.tar.gz

--- a/buildroot-external/package/generic_raw_uart/generic_raw_uart.mk
+++ b/buildroot-external/package/generic_raw_uart/generic_raw_uart.mk
@@ -13,7 +13,7 @@
 #
 ################################################################################
 
-GENERIC_RAW_UART_VERSION = c7c82ab6324af57d79c62532df4a79c0b0258562
+GENERIC_RAW_UART_VERSION = 58b10fff652ad2e67f71e7e07270b50d27e55d40
 GENERIC_RAW_UART_SITE = $(call github,alexreinert,piVCCU,$(GENERIC_RAW_UART_VERSION))
 GENERIC_RAW_UART_LICENSE = GPL2
 GENERIC_RAW_UART_LICENSE_FILES = LICENSE

--- a/buildroot-external/rootfs-overlay/usr/lib/udev/rules.d/99-hmip-rfusb.rules
+++ b/buildroot-external/rootfs-overlay/usr/lib/udev/rules.d/99-hmip-rfusb.rules
@@ -1,1 +1,0 @@
-ACTION=="add", ATTRS{idVendor}=="1b1f", ATTRS{idProduct}=="c020", RUN+="/sbin/modprobe cp210x" RUN+="/bin/sh -c 'echo 1b1f c020 >/sys/bus/usb-serial/drivers/cp210x/new_id'"


### PR DESCRIPTION
This PR updates the `generic_raw_uart` kernel module package to its latest version.

This newer version of `generic_raw_uart` integrates support for the `HmIP-RFUSB` line of [homematic RF USB sticks](https://de.elv.com/elv-homematic-ip-arr-bausatz-rf-usb-stick-fuer-alternative-steuerungsplattformen-hmip-rfusb-fuer-smart-home-hausautomation-152306), which essentially is necessary to utilize the new 4.4.x dualcoprocessor firmware coming with the latest RaspberryMatic Add-on and which significantly enhances the capabilities of the `HmIP-RFUSB` to communicate and being compatible not only to homematicIP devices but also to the older BidCos-RF/HomeMatic devices by eQ3/ELV. In addition, this newer `HmIP-RFUSB` firmware also integrates support to link a `HmIP-HAP` or even `HmIPW-DRAP` homematicIP-Wired Gateway, which previously was only possible when using the GPIO-based `RPI-RF-MOD` rf module.