### PR TITLE
Devices description update

### DIFF
--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -20,7 +20,7 @@ The following boards/devices are supported:
   - Odroid-XU4
 - Asus
   - Tinker Board
-- Intel NUC
+- Generic x86-64 (UEFI, not suited for virtualization)
   - Intel NUC5CPYH
   - Intel NUC6CAYH
   - Intel NUC10I3FNK2

--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -5,26 +5,27 @@
 The following boards/devices are supported:
 
 - Raspberry Pi
-  - Pi 4 Model B (1 GB, 2 GB and 4 GB model) 32-bit
-  - Pi 4 Model B (1 GB, 2 GB and 4 GB model) 64-bit (recommended)
-  - Pi 3 Model B and B+ 32-bit
+  - Pi 4 Model B (1 GB, 2 GB, 4 GB and 8 GB model) 64-bit (recommended)
+  - Pi 4 Model B (1 GB, 2 GB, 4 GB and 8 GB model) 32-bit
   - Pi 3 Model B and B+ 64-bit (recommended)
+  - Pi 3 Model B and B+ 32-bit
   - Pi 2 (not recommended)
   - Pi Zero-W (not recommended)
   - Pi (not recommended)
 - Hardkernel
-  - Odroid-C2
-  - Odroid-C4 (_experimental_)
   - Odroid-N2
+  - Odroid-N2+
+  - Odroid-C2
+  - Odroid-C4
   - Odroid-XU4
-- Generic x86-64 (UEFI, not suited for virtualization)
+- Asus
+  - Tinker Board
+- Intel NUC
   - Intel NUC5CPYH
   - Intel NUC6CAYH
   - Intel NUC10I3FNK2
   - Gigabyte GB-BPCE-3455
-  - Computers supporting x86-64 architecture and UEFI boot should generally work
-- Asus
-  - Tinker Board
+  - Others recent Intel NUC computers are likely to work too, only those listed above have been tested.
 - Virtual appliance (x86_64/UEFI):
   - VMDK
   - OVA ?
@@ -39,17 +40,17 @@ Notes:
 
 |Board|Build|Config|Docs|
 |-----|----|------|----|
-|Pi4B 32-bit    |`make rpi4`           |[rpi4](../../buildroot-external/configs/rpi4_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi4B 64-bit    |`make rpi4_64`        |[rpi4_64](../../buildroot-external/configs/rpi4_64_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi3B 32-bit    |`make rpi3`           |[rpi3](../../buildroot-external/configs/rpi3_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi3B 64-bit    |`make rpi3_64`        |[rpi3_64](../../buildroot-external/configs/rpi3_64_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi2            |`make rpi2`           |[rpi2](../../buildroot-external/configs/rpi2_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi Zero        |`make rpi0_w`         |[rpi0_w](../../buildroot-external/configs/rpi0_w_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi             |`make rpi`            |[rpi](../../buildroot-external/configs/rpi_defconfig)|[raspberrypi](./raspberrypi/)|
-|Odroid-C2      |`make odroid_c2`      |[odroid_c2](../../buildroot-external/configs/odroid_c2_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-C4      |`make odroid_c4`      |[odroid_c4](../../buildroot-external/configs/odroid_c4_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-N2      |`make odroid_n2`      |[odroid_n2](../../buildroot-external/configs/odroid_n2_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-XU4     |`make odroid_xu4`     |[odroid_xu4](../../buildroot-external/configs/odroid_xu4_defconfig)|[hardkernel](./hardkernel/)|
-|Tinker Board   |`make tinker`         |[tinker](../../buildroot-external/configs/tinker_defconfig)|[asus](./asus/)|
-|Generic x86-64 |`make generic_x86_64` |[generic_x86_64](../../buildroot-external/configs/generic_x86_64_defconfig)|[generic-x86-64](./generic-x86-64/)|
-|OVA            |`make ova`            |[ova](../../buildroot-external/configs/ova_defconfig)|[ova](./ova/)|
+|Pi4B 64-bit     |`make rpi4_64`   |[rpi4_64](../../buildroot-external/configs/rpi4_64_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi4B 32-bit     |`make rpi4`      |[rpi4](../../buildroot-external/configs/rpi4_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi3B 64-bit     |`make rpi3_64`   |[rpi3_64](../../buildroot-external/configs/rpi3_64_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi3B 32-bit     |`make rpi3`      |[rpi3](../../buildroot-external/configs/rpi3_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi2             |`make rpi2`      |[rpi2](../../buildroot-external/configs/rpi2_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi Zero         |`make rpi0_w`    |[rpi0_w](../../buildroot-external/configs/rpi0_w_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi              |`make rpi`       |[rpi](../../buildroot-external/configs/rpi_defconfig)|[raspberrypi](./raspberrypi/)|
+|Odroid-N2/N2+   |`make odroid_n2` |[odroid_n2](../../buildroot-external/configs/odroid_n2_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-C2       |`make odroid_c2` |[odroid_c2](../../buildroot-external/configs/odroid_c2_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-C4       |`make odroid_c4` |[odroid_c4](../../buildroot-external/configs/odroid_c4_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-XU4      |`make odroid_xu4`|[odroid_xu4](../../buildroot-external/configs/odroid_xu4_defconfig)|[hardkernel](./hardkernel/)|
+|Tinker Board    |`make tinker`    |[tinker](../../buildroot-external/configs/tinker_defconfig)|[asus](./asus/)|
+|NUC             |`make intel_nuc` |[intel_nuc](../../buildroot-external/configs/intel_nuc_defconfig)|[intel](./intel/)|
+|OVA             |`make ova`       |[ova](../../buildroot-external/configs/ova_defconfig)|[ova](./ova/)|

--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -25,7 +25,7 @@ The following boards/devices are supported:
   - Intel NUC6CAYH
   - Intel NUC10I3FNK2
   - Gigabyte GB-BPCE-3455
-  - Others recent Intel NUC computers are likely to work too, only those listed above have been tested.
+  - Computers supporting x86-64 architecture and UEFI boot should generally work
 - Virtual appliance (x86_64/UEFI):
   - VMDK
   - OVA ?

--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -45,8 +45,6 @@ Notes:
 |Pi3B 64-bit   |`make rpi3_64`       |[rpi3_64](../../buildroot-external/configs/rpi3_64_defconfig)|[raspberrypi](./raspberrypi/)|
 |Pi3B 32-bit   |`make rpi3`          |[rpi3](../../buildroot-external/configs/rpi3_defconfig)|[raspberrypi](./raspberrypi/)|
 |Pi2           |`make rpi2`          |[rpi2](../../buildroot-external/configs/rpi2_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi Zero       |`make rpi0_w`        |[rpi0_w](../../buildroot-external/configs/rpi0_w_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi            |`make rpi`           |[rpi](../../buildroot-external/configs/rpi_defconfig)|[raspberrypi](./raspberrypi/)|
 |Odroid-N2/N2+ |`make odroid_n2`     |[odroid_n2](../../buildroot-external/configs/odroid_n2_defconfig)|[hardkernel](./hardkernel/)|
 |Odroid-C2     |`make odroid_c2`     |[odroid_c2](../../buildroot-external/configs/odroid_c2_defconfig)|[hardkernel](./hardkernel/)|
 |Odroid-C4     |`make odroid_c4`     |[odroid_c4](../../buildroot-external/configs/odroid_c4_defconfig)|[hardkernel](./hardkernel/)|

--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -40,17 +40,17 @@ Notes:
 
 |Board|Build|Config|Docs|
 |-----|----|------|----|
-|Pi4B 64-bit     |`make rpi4_64`   |[rpi4_64](../../buildroot-external/configs/rpi4_64_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi4B 32-bit     |`make rpi4`      |[rpi4](../../buildroot-external/configs/rpi4_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi3B 64-bit     |`make rpi3_64`   |[rpi3_64](../../buildroot-external/configs/rpi3_64_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi3B 32-bit     |`make rpi3`      |[rpi3](../../buildroot-external/configs/rpi3_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi2             |`make rpi2`      |[rpi2](../../buildroot-external/configs/rpi2_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi Zero         |`make rpi0_w`    |[rpi0_w](../../buildroot-external/configs/rpi0_w_defconfig)|[raspberrypi](./raspberrypi/)|
-|Pi              |`make rpi`       |[rpi](../../buildroot-external/configs/rpi_defconfig)|[raspberrypi](./raspberrypi/)|
-|Odroid-N2/N2+   |`make odroid_n2` |[odroid_n2](../../buildroot-external/configs/odroid_n2_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-C2       |`make odroid_c2` |[odroid_c2](../../buildroot-external/configs/odroid_c2_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-C4       |`make odroid_c4` |[odroid_c4](../../buildroot-external/configs/odroid_c4_defconfig)|[hardkernel](./hardkernel/)|
-|Odroid-XU4      |`make odroid_xu4`|[odroid_xu4](../../buildroot-external/configs/odroid_xu4_defconfig)|[hardkernel](./hardkernel/)|
-|Tinker Board    |`make tinker`    |[tinker](../../buildroot-external/configs/tinker_defconfig)|[asus](./asus/)|
-|NUC             |`make intel_nuc` |[intel_nuc](../../buildroot-external/configs/intel_nuc_defconfig)|[intel](./intel/)|
-|OVA             |`make ova`       |[ova](../../buildroot-external/configs/ova_defconfig)|[ova](./ova/)|
+|Pi4B 64-bit   |`make rpi4_64`       |[rpi4_64](../../buildroot-external/configs/rpi4_64_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi4B 32-bit   |`make rpi4`          |[rpi4](../../buildroot-external/configs/rpi4_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi3B 64-bit   |`make rpi3_64`       |[rpi3_64](../../buildroot-external/configs/rpi3_64_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi3B 32-bit   |`make rpi3`          |[rpi3](../../buildroot-external/configs/rpi3_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi2           |`make rpi2`          |[rpi2](../../buildroot-external/configs/rpi2_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi Zero       |`make rpi0_w`        |[rpi0_w](../../buildroot-external/configs/rpi0_w_defconfig)|[raspberrypi](./raspberrypi/)|
+|Pi            |`make rpi`           |[rpi](../../buildroot-external/configs/rpi_defconfig)|[raspberrypi](./raspberrypi/)|
+|Odroid-N2/N2+ |`make odroid_n2`     |[odroid_n2](../../buildroot-external/configs/odroid_n2_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-C2     |`make odroid_c2`     |[odroid_c2](../../buildroot-external/configs/odroid_c2_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-C4     |`make odroid_c4`     |[odroid_c4](../../buildroot-external/configs/odroid_c4_defconfig)|[hardkernel](./hardkernel/)|
+|Odroid-XU4    |`make odroid_xu4`    |[odroid_xu4](../../buildroot-external/configs/odroid_xu4_defconfig)|[hardkernel](./hardkernel/)|
+|Tinker Board  |`make tinker`        |[tinker](../../buildroot-external/configs/tinker_defconfig)|[asus](./asus/)|
+|Generic x86-64|`make generic_x86_64`|[generic_x86_64](../../buildroot-external/configs/generic_x86_64_defconfig)|[generic-x86-64](./generic-x86-64/)|
+|OVA           |`make ova`           |[ova](../../buildroot-external/configs/ova_defconfig)|[ova](./ova/)|

--- a/Documentation/boards/raspberrypi/README.md
+++ b/Documentation/boards/raspberrypi/README.md
@@ -11,11 +11,7 @@
 | Raspberry Pi 3 B/B+ |2016/2018      | yes             | [rpi3](../../../buildroot-external/configs/rpi3_defconfig) / [rpi3_64](../../../buildroot-external/configs/rpi3_64_defconfig) |
 | Raspberry Pi 4 B    |2019           | yes*            | [rpi4](../../../buildroot-external/configs/rpi4_defconfig) / [rpi4_64](../../../buildroot-external/configs/rpi4_64_defconfig) |
 
-\*1,2 and 4 GiB versions of the Raspberry Pi 4 B are supported. Support for the 8 GiB version is coming soon is part of #740.
-
-## Limitation 64bit
-
-The 64bit version is under development by RPi-Team. It work very nice but it could have some impacts. Actual we see that the SDcard access with ext4 are a bit slower than on 32bit.
+\*1, 2, 4 and 8 GiB versions of the Raspberry Pi 4 B are supported.
 
 ## Serial console
 

--- a/Documentation/boards/raspberrypi/README.md
+++ b/Documentation/boards/raspberrypi/README.md
@@ -6,12 +6,8 @@
 |---------------------|---------------|-----------------|--------------------|
 | Raspberry Pi B/B+/A+|2012/2014/2014 | not recommended | [rpi](../../../buildroot-external/configs/rpi_defconfig)              |
 | Raspberry Pi 2 B    |2015           | not recommended | [rpi2](../../../buildroot-external/configs/rpi2_defconfig)             |
-| Raspberry Pi Zero   |2015           | not recommended | [rpi](../../../buildroot-external/configs/rpi_defconfig)              |
-| Raspberry Pi Zero W |2017           | not recommended | [rpi0_w](../../../buildroot-external/configs/rpi0_w_defconfig)           |
 | Raspberry Pi 3 B/B+ |2016/2018      | yes             | [rpi3](../../../buildroot-external/configs/rpi3_defconfig) / [rpi3_64](../../../buildroot-external/configs/rpi3_64_defconfig) |
-| Raspberry Pi 4 B    |2019           | yes*            | [rpi4](../../../buildroot-external/configs/rpi4_defconfig) / [rpi4_64](../../../buildroot-external/configs/rpi4_64_defconfig) |
-
-\*1, 2, 4 and 8 GiB versions of the Raspberry Pi 4 B are supported.
+| Raspberry Pi 4 B    |2019           | yes             | [rpi4](../../../buildroot-external/configs/rpi4_defconfig) / [rpi4_64](../../../buildroot-external/configs/rpi4_64_defconfig) |
 
 ## Serial console
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Home Assistant Operating System uses Docker as Container engine. It by default d
 
 - Raspberry Pi
 - Hardkernel ODROID
-- Intel NUC
 - Asus Tinker Board
+- Intel NUC
 - Virtual appliances
 
 See the full list and specific models [here](./Documentation/boards/README.md)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Home Assistant Operating System uses Docker as Container engine. It by default d
 - Raspberry Pi
 - Hardkernel ODROID
 - Asus Tinker Board
-- Intel NUC
+- Generic x86-64 (e.g. Intel NUC)
 - Virtual appliances
 
 See the full list and specific models [here](./Documentation/boards/README.md)


### PR DESCRIPTION
I noticed that the device list is a bit outdated. I updated it according to: https://www.home-assistant.io/installation/

Additionally, [it looks like the Raspberry Pi Compute Module 4 is supported](https://community.home-assistant.io/t/ha-on-raspberry-pi-compute-modules/237182/10). Maybe it is worth adding some information about it here and on the website?