### PR TITLE
Use LSI Logic SCSI controller

### DIFF
--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -31,7 +31,7 @@ function hassos_post_image() {
     rm -f "${HDD_OVA}"
 
     cp -a "${BOARD_DIR}/home-assistant.ovf" "${OVA_DATA}/home-assistant.ovf"
-    qemu-img convert -O vmdk -o subformat=streamOptimized "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
+    qemu-img convert -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
     (cd "${OVA_DATA}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* >home-assistant.mf)
     tar -C "${OVA_DATA}" --owner=root --group=root -cf "${HDD_OVA}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
 

--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -14,9 +14,7 @@ function hassos_pre_image() {
 
 
 function hassos_post_image() {
-    local HDD_IMG="$(hassos_image_name img)"
-    local HDD_OVA="$(hassos_image_name ova)"
-    local OVA_DATA="${BINARIES_DIR}/ova"
+    local hdd_img="$(hassos_image_name img)"
 
     # Virtual Disk images
     convert_disk_image_virtual
@@ -27,14 +25,8 @@ function hassos_post_image() {
     convert_disk_image_xz qcow2
 
     # OVA
-    mkdir -p "${OVA_DATA}"
-    rm -f "${HDD_OVA}"
-
-    cp -a "${BOARD_DIR}/home-assistant.ovf" "${OVA_DATA}/home-assistant.ovf"
-    qemu-img convert -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic "${HDD_IMG}" "${OVA_DATA}/home-assistant.vmdk"
-    (cd "${OVA_DATA}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* >home-assistant.mf)
-    tar -C "${OVA_DATA}" --owner=root --group=root -cf "${HDD_OVA}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
+    convert_disk_image_ova
 
     # Cleanup
-    rm -f "${HDD_IMG}"
+    rm -f "${hdd_img}"
 }

--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -310,6 +310,19 @@ function convert_disk_image_virtual() {
     qemu-img convert -O qcow2 "${hdd_img}" "${hdd_qcow2}"
 }
 
+function convert_disk_image_ova() {
+    local hdd_img="$(hassos_image_name img)"
+    local hdd_ova="$(hassos_image_name ova)"
+    local ova_data="${BINARIES_DIR}/ova"
+
+    mkdir -p "${ova_data}"
+    rm -f "${hdd_ova}"
+
+    cp -a "${BOARD_DIR}/home-assistant.ovf" "${ova_data}/home-assistant.ovf"
+    qemu-img convert -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic "${hdd_img}" "${ova_data}/home-assistant.vmdk"
+    (cd "${ova_data}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* >home-assistant.mf)
+    tar -C "${ova_data}" --owner=root --group=root -cf "${hdd_ova}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
+}
 
 function convert_disk_image_xz() {
     local hdd_ext=${1:-img}

--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -304,7 +304,7 @@ function convert_disk_image_virtual() {
     rm -f "${hdd_vdi}"
     rm -f "${hdd_qcow2}"
 
-    qemu-img convert -O vmdk "${hdd_img}" "${hdd_vmdk}"
+    qemu-img convert -O vmdk -o adapter_type=lsilogic "${hdd_img}" "${hdd_vmdk}"
     qemu-img convert -O vhdx "${hdd_img}" "${hdd_vhdx}"
     qemu-img convert -O vdi "${hdd_img}" "${hdd_vdi}"
     qemu-img convert -O qcow2 "${hdd_img}" "${hdd_qcow2}"


### PR DESCRIPTION
For some reason, the vmdk disk format's descriptor contains the
controller type as well. By default, qemu-img sets it to "ide", which
seems not optimal especially for VMware's ESXi. Set adapter type to
commonly supported "lsilogic".
