### PR TITLE
ODROID XU4: Update U-Boot on eMMC boot partition

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -81,8 +81,11 @@ if [ "${RAUC_SLOT_CLASS}" = "spl" ]; then
     fi
 
     # Flash to eMMC boot partition if necessary
-    if [ "$RAUC_MF_COMPATIBLE" = "haos-odroid-xu4" ] && [ -b "${DEVICE_ROOT}/boot0" ]; then
-        dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}/boot0" bs=512 skip=1 count=2047
+    if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-odroid-xu4" ] && [ -b "${DEVICE_ROOT}boot0" ]; then
+        echo "Updating eMMC boot partition"
+        echo 0 > /sys/block/"$(basename "${DEVICE_ROOT}boot0")"/force_ro
+        dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}boot0" conv=notrunc ${FLAGS} bs=512 skip=1 count=2047
+        echo 1 > /sys/block/"$(basename "${DEVICE_ROOT}boot0")"/force_ro
     fi
 fi
 

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -79,6 +79,11 @@ if [ "${RAUC_SLOT_CLASS}" = "spl" ]; then
         dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=1 count=440
         dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=512 seek=1 skip=1
     fi
+
+    # Flash to eMMC boot partition if necessary
+    if [ "$RAUC_MF_COMPATIBLE" = "haos-odroid-xu4" ] && [ -b "${DEVICE_ROOT}/boot0" ]; then
+        dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}/boot0" bs=512 skip=1 count=2047
+    fi
 fi
 
 ##


### PR DESCRIPTION
Update the U-Boot on the eMMC boot partition if present. Only write the
first megabyte as the eMMC boot partition might be smaller than the SPL
image and only the first megabyte is occupied by FW/BL1/BL2/TZSW (see
https://wiki.odroid.com/odroid-xu4/software/partition_table#tab__odroid-xu341).