### PR TITLE
Fix reboot on ODROID-N2 (again)

### DIFF
--- a/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-add-i2c3-rtc-nodes-and-rtc-aliases-t.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0001-arm64-dts-meson-add-i2c3-rtc-nodes-and-rtc-aliases-t.patch
@@ -1,9 +1,9 @@
 From c7825747afd8bb975dc918f28e4afe8058a518f3 Mon Sep 17 00:00:00 2001
-Message-Id: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Mon, 11 Jan 2021 13:58:31 +0000
-Subject: [PATCH 1/9] arm64: dts: meson: add i2c3/rtc nodes and rtc aliases to
- ODROID-N2 dtsi
+Subject: [PATCH 01/10] arm64: dts: meson: add i2c3/rtc nodes and rtc aliases
+ to ODROID-N2 dtsi
 
 Enable the onboard pcf8563 rtc hardware on ODROID N2/N2+ boards via the
 common dtsi. Also add aliases to ensure vrtc does not claim /dev/rtc0.
@@ -49,5 +49,5 @@ index 39a09661c5f6..b78be3e6974d 100644
  	pinctrl-0 = <&pwm_a_e_pins>;
  	pinctrl-names = "default";
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0002-arm64-dts-meson-add-saradc-node-to-ODROID-N2-N2.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0002-arm64-dts-meson-add-saradc-node-to-ODROID-N2-N2.patch
@@ -1,10 +1,10 @@
 From ec3b1240b428c5652ccb7fdadad217a2ff8ab4db Mon Sep 17 00:00:00 2001
-Message-Id: <ec3b1240b428c5652ccb7fdadad217a2ff8ab4db.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <ec3b1240b428c5652ccb7fdadad217a2ff8ab4db.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Hyeonki Hong <hhk7734@gmail.com>
 Date: Wed, 7 Apr 2021 04:26:08 +0000
-Subject: [PATCH 2/9] arm64: dts: meson: add saradc node to ODROID N2/N2+
+Subject: [PATCH 02/10] arm64: dts: meson: add saradc node to ODROID N2/N2+
 
 Add the meson saradc node to the ODROID N2/N2+ common dtsi.
 
@@ -33,5 +33,5 @@ index b78be3e6974d..8a5e132c4b79 100644
  &sd_emmc_b {
  	status = "okay";
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-add-GPIO-line-names-to-ODROID-N2-N2.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0003-arm64-dts-meson-add-GPIO-line-names-to-ODROID-N2-N2.patch
@@ -1,10 +1,10 @@
 From 5ca49a58577f7e9e6f8e0b1cb7c97e756a0e921f Mon Sep 17 00:00:00 2001
-Message-Id: <5ca49a58577f7e9e6f8e0b1cb7c97e756a0e921f.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <5ca49a58577f7e9e6f8e0b1cb7c97e756a0e921f.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Hyeonki Hong <hhk7734@gmail.com>
 Date: Wed, 7 Apr 2021 04:26:09 +0000
-Subject: [PATCH 3/9] arm64: dts: meson: add GPIO line names to ODROID N2/N2+
+Subject: [PATCH 03/10] arm64: dts: meson: add GPIO line names to ODROID N2/N2+
 
 Add GPIO line-name identifiers to the ODROID N2/N2+ common dtsi.
 
@@ -74,5 +74,5 @@ index 8a5e132c4b79..41b2f9c96b5f 100644
  	 * WARNING: The USB Hub on the Odroid-N2 needs a reset signal
  	 * to be turned high in order to be detected by the USB Controller
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-g12b-add-power-button-support.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0004-arm64-dts-meson-g12b-add-power-button-support.patch
@@ -1,10 +1,10 @@
 From 70e65f906389f7236fe9ad8e1c05dedac0d1988b Mon Sep 17 00:00:00 2001
-Message-Id: <70e65f906389f7236fe9ad8e1c05dedac0d1988b.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <70e65f906389f7236fe9ad8e1c05dedac0d1988b.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 11:20:48 +0100
-Subject: [PATCH 4/9] arm64: dts: meson: g12b: add power button support
+Subject: [PATCH 04/10] arm64: dts: meson: g12b: add power button support
 
 Add power button support on J2 pin 11 (GPIOX_3 on the SoC side). The
 GPIO is low active, e.g. when connecting with pin 9 (GND) a power
@@ -38,5 +38,5 @@ index 41b2f9c96b5f..4b6bb7e74e25 100644
  		compatible = "gpio-leds";
  
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0005-arm64-dts-meson-g12b-add-GPIO-fan-support.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0005-arm64-dts-meson-g12b-add-GPIO-fan-support.patch
@@ -1,10 +1,10 @@
 From 86d9151effff69d2a8fc2027a31dd60bd8c6eb05 Mon Sep 17 00:00:00 2001
-Message-Id: <86d9151effff69d2a8fc2027a31dd60bd8c6eb05.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <86d9151effff69d2a8fc2027a31dd60bd8c6eb05.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 11:38:54 +0100
-Subject: [PATCH 5/9] arm64: dts: meson: g12b: add GPIO fan support
+Subject: [PATCH 05/10] arm64: dts: meson: g12b: add GPIO fan support
 
 Add simple GPIO fan node to support a fan on GPIO J8. Unfortunately the
 pad used to control the fan does not support real PWM, hence the RPM
@@ -38,5 +38,5 @@ index 4b6bb7e74e25..e8a3ede698b5 100644
  		compatible = "gpio-keys-polled";
  		poll-interval = <100>;
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0006-arm64-dts-meson-g12b-odroid-n2-add-fan-as-cooling-de.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0006-arm64-dts-meson-g12b-odroid-n2-add-fan-as-cooling-de.patch
@@ -1,10 +1,10 @@
 From f1120f132dbdf2e7f7acf328de55bbdce877d882 Mon Sep 17 00:00:00 2001
-Message-Id: <f1120f132dbdf2e7f7acf328de55bbdce877d882.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <f1120f132dbdf2e7f7acf328de55bbdce877d882.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 15:53:55 +0100
-Subject: [PATCH 6/9] arm64: dts: meson: g12b: odroid-n2: add fan as cooling
+Subject: [PATCH 06/10] arm64: dts: meson: g12b: odroid-n2: add fan as cooling
  device
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -70,5 +70,5 @@ index e8a3ede698b5..dd345c6aa4b5 100644
  	cpu-supply = <&vddcpu_b>;
  	operating-points-v2 = <&cpu_opp_table_0>;
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0007-arm64-dts-meson-add-uart_A-node.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0007-arm64-dts-meson-add-uart_A-node.patch
@@ -1,10 +1,10 @@
 From dcaf2dc71dd62487eb37561682934414a5795e0e Mon Sep 17 00:00:00 2001
-Message-Id: <dcaf2dc71dd62487eb37561682934414a5795e0e.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <dcaf2dc71dd62487eb37561682934414a5795e0e.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Hyeonki Hong <hhk7734@gmail.com>
 Date: Fri, 27 Mar 2020 17:05:22 +0900
-Subject: [PATCH 7/9] arm64: dts: meson: add uart_A node
+Subject: [PATCH 07/10] arm64: dts: meson: add uart_A node
 
 The UART_A is available through J3 pin 8/10 and documented to be
 available as UART by default.
@@ -40,5 +40,5 @@ index dd345c6aa4b5..cec346178e3d 100644
  	status = "okay";
  	pinctrl-0 = <&uart_ao_a_pins>;
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0008-arm64-dts-meson-add-i2c2-node-to-ODROID-N2-N2.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0008-arm64-dts-meson-add-i2c2-node-to-ODROID-N2-N2.patch
@@ -1,10 +1,10 @@
 From d5d2d8b9eb93eab85af12f1844975903a7c5a879 Mon Sep 17 00:00:00 2001
-Message-Id: <d5d2d8b9eb93eab85af12f1844975903a7c5a879.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <d5d2d8b9eb93eab85af12f1844975903a7c5a879.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 29 Apr 2021 21:32:43 +0200
-Subject: [PATCH 8/9] arm64: dts: meson: add i2c2 node to ODROID N2/N2+
+Subject: [PATCH 08/10] arm64: dts: meson: add i2c2 node to ODROID N2/N2+
 
 The J2 connectors pinout documents "I2C.SDA0/SCL0" on pin 3 and 5, which
 are connected to GPIOX_17/18. This GPIO allow to mux I2C to the second
@@ -33,5 +33,5 @@ index cec346178e3d..f1c3356c78a0 100644
  	status = "okay";
  	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0009-Revert-of-fdt-Make-sure-no-map-does-not-remove-alrea.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0009-Revert-of-fdt-Make-sure-no-map-does-not-remove-alrea.patch
@@ -1,11 +1,11 @@
 From 19c34c0ceb6302b07e1017c426796c4cf7322d13 Mon Sep 17 00:00:00 2001
-Message-Id: <19c34c0ceb6302b07e1017c426796c4cf7322d13.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+Message-Id: <19c34c0ceb6302b07e1017c426796c4cf7322d13.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 26 Jul 2021 16:59:08 +0200
-Subject: [PATCH 9/9] Revert "of/fdt: Make sure no-map does not remove already
- reserved regions"
+Subject: [PATCH 09/10] Revert "of/fdt: Make sure no-map does not remove
+ already reserved regions"
 
 U-Boot on Hardkernel ODROID-N2 adds fdt "memreserve" entries alongside
 the reserved-memory nodes present in upstream Linux. This causes
@@ -48,5 +48,5 @@ index 57ff31b6b1e4..7ef2246e0b1e 100644
  }
  
 -- 
-2.32.0
+2.34.1
 

--- a/buildroot-external/board/hardkernel/patches/linux/0010-Revert-drm-meson_drv-add-shutdown-function.patch
+++ b/buildroot-external/board/hardkernel/patches/linux/0010-Revert-drm-meson_drv-add-shutdown-function.patch
@@ -1,0 +1,48 @@
+From be21685475a0739d44ca4c63fcb7f50b324593c9 Mon Sep 17 00:00:00 2001
+Message-Id: <be21685475a0739d44ca4c63fcb7f50b324593c9.1642331593.git.stefan@agner.ch>
+In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1642331593.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Sun, 16 Jan 2022 12:12:29 +0100
+Subject: [PATCH 10/10] Revert "drm: meson_drv add shutdown function"
+
+This reverts commit d4ec1ffbdaa8939a208656e9c1440742c457ef16.
+
+It seems that this patch actually breaks reboot on ODROID-N2+.
+---
+ drivers/gpu/drm/meson/meson_drv.c | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/drivers/gpu/drm/meson/meson_drv.c b/drivers/gpu/drm/meson/meson_drv.c
+index 2753067c08e6..3d1de9cbb1c8 100644
+--- a/drivers/gpu/drm/meson/meson_drv.c
++++ b/drivers/gpu/drm/meson/meson_drv.c
+@@ -482,17 +482,6 @@ static int meson_probe_remote(struct platform_device *pdev,
+ 	return count;
+ }
+ 
+-static void meson_drv_shutdown(struct platform_device *pdev)
+-{
+-	struct meson_drm *priv = dev_get_drvdata(&pdev->dev);
+-
+-	if (!priv)
+-		return;
+-
+-	drm_kms_helper_poll_fini(priv->drm);
+-	drm_atomic_helper_shutdown(priv->drm);
+-}
+-
+ static int meson_drv_probe(struct platform_device *pdev)
+ {
+ 	struct component_match *match = NULL;
+@@ -564,7 +553,6 @@ static const struct dev_pm_ops meson_drv_pm_ops = {
+ 
+ static struct platform_driver meson_drm_platform_driver = {
+ 	.probe      = meson_drv_probe,
+-	.shutdown   = meson_drv_shutdown,
+ 	.driver     = {
+ 		.name	= "meson-drm",
+ 		.of_match_table = dt_match,
+-- 
+2.34.1
+


### PR DESCRIPTION
To make HDMI CEC work, we have to compile MESON_DRM as a module
(see #1717). However, this essentially reverts #1347, which fixed the
reboot problem by compiling the driver into the kernel.

Hence we need to reintroduce the earlier fix from #1345, which reverts
the offending commit causing the reboot problem.