### PR TITLE
Fix migration from Barebox GRUB

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
+++ b/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
@@ -9,7 +9,14 @@ function hassos_pre_image() {
 
     cp "${BOARD_DIR}/../grub.cfg" "${EFIPART_DATA}/EFI/BOOT/grub.cfg"
     cp "${BOARD_DIR}/cmdline.txt" "${EFIPART_DATA}/cmdline.txt"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set ORDER="A B"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_OK=1
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_TRY=0
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set ORDER="B A"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_OK=1
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_TRY=0
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -54,6 +54,12 @@ if [ "${RAUC_SLOT_CLASS}" = "boot" ]; then
     # Update
     cp -rf "${BOOT_NEW}"/* "${BOOT_MNT}/"
 
+    # If grubenv is missing, initialize with boot order which will try the right
+    # boot slot
+    if [ -d "${BOOT_NEW}"/EFI/BOOT/ -a ! -f "${BOOT_NEW}"/EFI/BOOT/grubenv ]; then
+        cp -f "${BOOT_NEW}"/EFI/BOOT/grubenv-${RAUC_SLOT_BOOTNAME} "${BOOT_NEW}"/EFI/BOOT/grubenv
+    fi
+
     # Restore boot config
     cp -f "${BOOT_TMP}"/*.txt "${BOOT_MNT}/"
 


### PR DESCRIPTION
Create GRUB env which defaults to the boot slot we are updating to. This
makes sure that the newly installed OS version will be booted on next
reboot even if installed on boot slot B.