### PR TITLE
Don't fail update even if files are missing

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -17,13 +17,13 @@ install_boot() {
     mount "${RAUC_IMAGE_NAME}" "${BOOT_NEW}"
 
     # Backup boot config
-    cp -f "${BOOT_MNT}"/*.txt "${BOOT_TMP}/"
+    cp -f "${BOOT_MNT}"/*.txt "${BOOT_TMP}/" || true
 
     # Update
     cp -rf "${BOOT_NEW}"/* "${BOOT_MNT}/"
 
     # Restore boot config
-    cp -f "${BOOT_TMP}"/*.txt "${BOOT_MNT}/"
+    cp -f "${BOOT_TMP}"/*.txt "${BOOT_MNT}/" || true
 
     umount "${BOOT_NEW}"
     rm -rf "${BOOT_TMP}" "${BOOT_NEW}"


### PR DESCRIPTION
Don't fail the boot slot update even if files are missing in the current
boot directory.