### PR TITLE
Revert "Remove git submodules before git checkout (#1611)"

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -77,10 +77,6 @@ jobs:
               return { "ref": context.ref }
             return { "ref": context.payload.pull_request.head.sha }
 
-      # Make sure directories of potentially removed submodules are cleaned correctly
-      - name: Cleanup git submodules
-        run: find . -name .git -type f -exec rm {} \;
-
       - name: Checkout source
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,6 @@ jobs:
     runs-on: ${{ matrix.board.runner }}
 
     steps:
-      # Make sure directories of potentially removed submodules are cleaned correctly
-      - name: Cleanup git submodules
-        run: find . -name .git -type f -exec rm {} \;
-
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This reverts commit ff07728fa3bb6b06e2c05a8134213a5830244259.

Removing the .git file from the git submodule is problematic when
updating buildroot: Files deleted stay present in the buildroot
directory (since their origin is no longer known).

The workaround has been introduced to allow building non-git submodule
releases (rel-6) on the same runners. Since rel-7 uses git submodule and
we stay with git submodule for the forseeable future, remove this work
around.