### PR TITLE
Set GRUB2 bootloader timeout to 1s

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -1,5 +1,5 @@
 set default=99
-set timeout=5
+set timeout=1
 
 set ORDER="A B"
 set A_OK=0

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -1,5 +1,5 @@
 set default=99
-set timeout=5
+set timeout=1
 
 set ORDER="A B"
 set A_OK=0


### PR DESCRIPTION
This aligns with what we used to have in Barebox. Most of the time the
user is not expected to make a choice, so keeping the timeout short is
sensible.