### PR TITLE
Use anonymous Docker volume as build output

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -102,6 +102,7 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
+            -v "/build/output" \
             haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.prepare.outputs.version_dev }} ${{ matrix.board.defconfig }}
 
       - name: Upload images

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -13,7 +13,7 @@ if [ "${BUILDER_UID:-0}" -ne 0 ] && [ "${BUILDER_GID:-0}" -ne 0 ]; then
   echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
   # Make sure cache is accessible by builder
   chown "${BUILDER_UID}:${BUILDER_GID}" /cache
-  # Make sure output is accessible by builder (if ephemeral volume is used)
+  # Make sure output is accessible by builder (if anonymous volume is used)
   chown "${BUILDER_UID}:${BUILDER_GID}" /build/output || true
   USER="builder"
 fi

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -13,6 +13,8 @@ if [ "${BUILDER_UID:-0}" -ne 0 ] && [ "${BUILDER_GID:-0}" -ne 0 ]; then
   echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
   # Make sure cache is accessible by builder
   chown "${BUILDER_UID}:${BUILDER_GID}" /cache
+  # Make sure output is accessible by builder (if ephemeral volume is used)
+  chown "${BUILDER_UID}:${BUILDER_GID}" /build/output || true
   USER="builder"
 fi
 


### PR DESCRIPTION
Use anonymous/ephemeral Docker volumes as build output. This makes sure
every build is using a clean output directory.