### PR TITLE
Enable IPv6 forwarding by default

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/60-otbr-ip-forward.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/60-otbr-ip-forward.conf
@@ -1,0 +1,1 @@
+net.ipv6.conf.all.forwarding = 1


### PR DESCRIPTION
Enable IPv6 forwarding by default which is useful to run IPv6 based
OpenThread Border Router.

Currently Docker enables IPv4 forwarding by default. Enabling IPv6
support will enable IPv6 routing as well, but we are not ready yet to
enable IPv6 support for Docker at this point.

Enabling IPv6 forwarding should be harmless as there are no IPv6
addresses configured internally and Home Assistant OS is not typically
dual-homed. In cases where it is dual-homed (e.g. VPN), routing is
often used and firewalling is setup as part of that add-on.