### PR TITLE
Add USB storage quirks for Raspberry Pi by default (#1743)

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1
+dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u


### PR DESCRIPTION
Add VID/PID of some known problematic USB SSD controllers to USB storage
quirk list. This should make most USB SSD's work with Home Assistant OS
out-of-the box.