### PR TITLE
Cleanup Yellow config.txt

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/config.txt
+++ b/buildroot-external/board/raspberrypi/yellow/config.txt
@@ -10,45 +10,9 @@ arm_64bit=1
 # uncomment to enable primary UART console
 enable_uart=1
 
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-#disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-#hdmi_group=1
-#hdmi_mode=1
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-# Uncomment to disable continous SD-card poll (for USB SSD)
-#dtparam=sd_poll_once=on
+# No HDMI on Yellow, but we can't set to 16 since we need the full firmware
+# for codecs
+gpu_mem=32
 
 # Uncomment some or all of these to enable the optional hardware interfaces
 #dtparam=i2c_arm=on
@@ -66,11 +30,6 @@ enable_uart=1
 
 # Additional overlays and parameters are documented /boot/overlays/README
 
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
 [all]
-#dtoverlay=vc4-fkms-v3d
-#max_framebuffers=2
 device_tree=bcm2711-rpi-cm4-ha-yellow.dtb
 


### PR DESCRIPTION
Yellow has no display output available, so most of the display settings are not useful.