### PR TITLE
Make container fetching more reliable

### DIFF
--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+set -o pipefail
+
 arch=$1
 machine=$2
 version_json=$3
 image_json_name=$4
 dl_dir=$5
 dst_dir=$6
-
-set -e
 
 image_name=$(jq -e -r --arg image_json_name "${image_json_name}" \
 	--arg arch "${arch}" --arg machine "${machine}" \
@@ -17,7 +19,7 @@ image_tag=$(jq -e -r --arg image_json_name "${image_json_name}" \
 	'.[$image_json_name]' < "${version_json}")
 full_image_name="${image_name}:${image_tag}"
 
-image_digest=$(skopeo inspect "docker://${full_image_name}" | jq -r '.Digest')
+image_digest=$(skopeo inspect --retry-times=5 "docker://${full_image_name}" | jq -r '.Digest')
 
 # Cleanup image name file name use
 image_file_name="${full_image_name//[:\/]/_}@${image_digest//[:\/]/_}"


### PR DESCRIPTION
It seems that the GitHub container registry sometimes returns 503
service unavailable temporarily ("Error fetching tags list: invalid status
code from registry 503"). Use skopeo's retry mechanism to try up to 5
times before failing.