### PR TITLE
Handle long-press system keys only

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/logind.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/logind.conf
@@ -18,9 +18,14 @@
 #KillOnlyUsers=
 #KillExcludeUsers=root
 #InhibitDelayMaxSec=5
-#HandlePowerKey=poweroff
-#HandleSuspendKey=suspend
-#HandleHibernateKey=hibernate
+HandlePowerKey=ignore
+HandlePowerKeyLongPress=poweroff
+HandleRebootKey=ignore
+HandleRebootKeyLongPress=reboot
+HandleSuspendKey=ignore
+HandleSuspendKeyLongPress=suspend
+HandleHibernateKey=ignore
+HandleHibernateKeyLongPress=hibernate
 HandleLidSwitch=ignore
 HandleLidSwitchExternalPower=ignore
 HandleLidSwitchDocked=ignore


### PR DESCRIPTION
Only handle long-press system power, reboot and sleep keys. This lowers the risk of accidentally power down the system.