### PR TITLE
Increase maximum socket receive and send buffer size (#1964)

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/20-network.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/20-network.conf
@@ -1,3 +1,7 @@
 # Since multicast is rather popular and we have many integrations running,
 # more than the default of 20 memberships might be required.
 net.ipv4.igmp_max_memberships = 1024
+
+# Increase maximum receive and send buffer size
+net.core.rmem_max = 4194304
+net.core.wmem_max = 4194304


### PR DESCRIPTION
Some applications try to increase the buffers for performance reason. The
QUIC Go implementation for instance tries to request a 2048 kiB buffer
size.

The kernel default depends on skubuf size (which is architecture
dependent), but it is memory size independet and typically around 200 kiB
(see [1]).

Other network tuning guides suggest 16MiB for 1GB ethernet, as well as
changing the default as well as maximum bufffer size (see [2]). This
conservatively increases the maximum buffer size to 4MiB.

[1]: https://elixir.bootlin.com/linux/v5.15.45/source/include/net/sock.h#L2742
[2]: https://nateware.com/2013/04/06/linux-network-tuning-for-2013/