### PR TITLE
Fix network.md ha cli network wifi example

### DIFF
--- a/Documentation/network.md
+++ b/Documentation/network.md
@@ -133,7 +133,7 @@ Home Assistant OS will recreate the default connection profile during boot.
 WiFi is discouraged for reliability reasons. However if you're still like to use WiFi, you can us the `ha network` command to set up WiFi (example for a Raspberry Pi 4, check `ha network info` to check if your board supports WiFi and the name of the WiFi device):
 
 ```bash
-ha network update wlan0 --enabled --ipv4-method auto --wifi-auth wpa-psk --wifi-mode infrastructure --wifi-ssid MY-SSID --wifi-psk MY_PASS
+ha network update wlan0 --ipv4-method auto --wifi-auth wpa-psk --wifi-mode infrastructure --wifi-ssid MY-SSID --wifi-psk MY_PASS
 ````
 
 ### Powersave


### PR DESCRIPTION
Removing `--enabled` option from ha cli network update example as it is not supported