### PR TITLE
Use GitHub Container Registry for Supervisor (#2005)

### DIFF
--- a/buildroot-external/package/hassio/dind-import-containers.sh
+++ b/buildroot-external/package/hassio/dind-import-containers.sh
@@ -18,7 +18,7 @@ done
 # Tag the Supervisor how the OS expects it to be tagged
 supervisor=$(docker images --filter "label=io.hass.type=supervisor" --quiet)
 arch=$(docker inspect --format '{{ index .Config.Labels "io.hass.arch" }}' "${supervisor}")
-docker tag "${supervisor}" "homeassistant/${arch}-hassio-supervisor:latest"
+docker tag "${supervisor}" "ghcr.io/homeassistant/${arch}-hassio-supervisor:latest"
 
 # Setup AppArmor
 mkdir -p "/data/supervisor/apparmor"

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -12,7 +12,7 @@ set -e
 SUPERVISOR_DATA=/mnt/data/supervisor
 SUPERVISOR_STARTUP_MARKER="/run/supervisor/startup-marker"
 SUPERVISOR_STARTSCRIPT_VERSION="/mnt/data/.hassos-supervisor-version"
-SUPERVISOR_IMAGE="homeassistant/${SUPERVISOR_ARCH}-hassio-supervisor"
+SUPERVISOR_IMAGE="ghcr.io/homeassistant/${SUPERVISOR_ARCH}-hassio-supervisor"
 
 SUPERVISOR_IMAGE_ID=$(docker images --no-trunc --filter "reference=${SUPERVISOR_IMAGE}:latest" --format "{{.ID}}" || echo "")
 SUPERVISOR_CONTAINER_ID=$(docker inspect --format='{{.Image}}' hassio_supervisor || echo "")


### PR DESCRIPTION
Use GitHub Container Registry for Supervisor by default.