### PR TITLE
Increase Supervisor start rate limit

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -4,8 +4,8 @@ Requires=docker.service rauc.service dbus.service
 Wants=network-online.target hassos-apparmor.service time-sync.target systemd-journal-gatewayd.socket
 After=docker.service rauc.service dbus.service network-online.target hassos-apparmor.service time-sync.target systemd-journal-gatewayd.socket
 RequiresMountsFor=/mnt/data /mnt/boot /mnt/overlay
-StartLimitIntervalSec=60
-StartLimitBurst=5
+StartLimitIntervalSec=30m
+StartLimitBurst=3
 ConditionPathExists=/run/dbus/system_bus_socket
 ConditionPathExists=/run/docker.sock
 


### PR DESCRIPTION
A faster restart policy is unlikely to help. Increasing the limit makes
it less likely to run into cloud service rate limits (e.g. container
registry).