### PR TITLE
Load container images desceding by size

### DIFF
--- a/buildroot-external/package/hassio/dind-import-containers.sh
+++ b/buildroot-external/package/hassio/dind-import-containers.sh
@@ -10,8 +10,8 @@ while ! docker version 2> /dev/null > /dev/null; do
 done
 
 # Install Supervisor, plug-ins and landing page
-echo "Loading containers..."
-for image in /build/images/*.tar; do
+echo "Loading container images..."
+for image in $(ls -S /build/images/*.tar); do
 	docker load --input "${image}"
 done
 

--- a/buildroot-external/package/hassio/dind-import-containers.sh
+++ b/buildroot-external/package/hassio/dind-import-containers.sh
@@ -11,6 +11,10 @@ done
 
 # Install Supervisor, plug-ins and landing page
 echo "Loading container images..."
+
+# Make sure to order images by size (largest first)
+# It seems docker load requires space during operation
+# shellcheck disable=SC2045
 for image in $(ls -S /build/images/*.tar); do
 	docker load --input "${image}"
 done


### PR DESCRIPTION
Loading container images using docker load seems to require more space
at load time (which gets freed after loading). Loading the largest
container first avoids running out of space.