### PR TITLE
Synchronize network time quicker on bootup

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/timesyncd.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/timesyncd.conf
@@ -1,2 +1,4 @@
 [Time]
 FallbackNTP=time.cloudflare.com
+# Speed-up boot as first attempt is done before network is up
+ConnectionRetrySec=10


### PR DESCRIPTION
Currently systemd-timesyncd tries to connect to the NTP server quite
early at boot-up. At this time the network connection has not been
established yet. This causes resolving the NTP server to fail and 
a rate limit kicks in which makes systemd-timesyncd wait for 30s until
the next attempt.

Lowering the retry attempt to 10s makes systemd-timesyncd connecting
shortly after.

Note: The rate limit is 10 attempts per 10s. Because the attempts are
immediately exhausted lowering connection retry attempt below 10s
adds no benefit.

See also: https://github.com/systemd/systemd/issues/24298