### PR TITLE
RFC: Remove all hardcoded ASMedia UAS quirk 174c:55aa:u

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:55aa:u
+dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u


### PR DESCRIPTION
ASMedia offers many USB<->SATA chipsets which share the same
USB ID (174c:55aa:u). Some of these chipsets have broken UAS support
while other (newer) chipsets work just fine.

I have a StarTech.com USB312SAT3CB adapter with a ASM235CM chipset which
works fine with UAS. This works fine with UAS, but the default quirks here disable
UAS mode.

The kernel already has built-in quirks for `174c:55aa:u` which aim to auto-detect
the actual chipset in use based on some other characteristics in [uas-detect.h].

[uas-detect.h]: https://github.com/raspberrypi/linux/blob/6f921e98008589258f97243fb6658d09750f0a2f/drivers/usb/storage/uas-detect.h#L74

With this PR, I propose to remove the hardcoded quirks in favor of the more nuanced
autodetection already in the kernel.

The risk here is that this commit might break cases where the in-kernel logic does
not work. The reward is higher performance on supported chipsets.

For reference, performance with quirks disabled (based on [Storage.sh]):

[Storage.sh]: https://github.com/TheRemote/PiBenchmarks/blob/master/Storage.sh

```
     Category                  Test                      Result
HDParm                    Disk Read                 331.30 MB/s
HDParm                    Cached Disk Read          303.42 MB/s
DD                        Disk Write                106 MB/s
FIO                       4k random read            19673 IOPS (78693 KB/s)
FIO                       4k random write           9766 IOPS (39065 KB/s)
IOZone                    4k read                   27829 KB/s
IOZone                    4k write                  21581 KB/s
IOZone                    4k random read            17897 KB/s
IOZone                    4k random write           27525 KB/s

                          Score: 6811
```

Performance with quirks enabled:

```

     Category                  Test                      Result
HDParm                    Disk Read                 242.42 MB/s
HDParm                    Cached Disk Read          229.75 MB/s
DD                        Disk Write                83.5 MB/s
FIO                       4k random read            4714 IOPS (18858 KB/s)
FIO                       4k random write           4651 IOPS (18605 KB/s)
IOZone                    4k read                   20751 KB/s
IOZone                    4k write                  15927 KB/s
IOZone                    4k random read            14937 KB/s
IOZone                    4k random write           19667 KB/s

                          Score: 4439
```