### PR TITLE
Delay systemd-timesyncd start after network is deemed online

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
@@ -1,0 +1,5 @@
+[Unit]
+Wants=network-online.target
+
+[Install]
+WantedBy=time-sync.target

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
@@ -1,2 +1,6 @@
 [Unit]
 RequiresMountsFor=/var/lib/systemd
+After=network-online.target
+
+[Install]
+WantedBy=time-sync.target


### PR DESCRIPTION
With commit 2d3119ef2201 ("Delay Supervisor start until time has been
sychronized (#1360)") systemd-time-wait-sync.service got enabled, which
waits until systemd-timesyncd synchronizes time with a NTP server.

By default systemd-timesyncd.service and systemd-time-wait-sync.service
are pulled in by sysinit.target. This starts the services before full
network connectivity is established. The first sychronization fails and
systemd-timesyncd only retries after a ratelimit mechanism times out.
This causes a dealy of 30s during startup. While systemd-timesyncd has
a mechanism to (re)try time synchronization when network becomes
online, it seems that those only work properly when systemd-networkd
is used, see also https://github.com/systemd/systemd/issues/24298.

Simply reordering systemd-timesyncd.service after network-online.target
does not work as it causes circular dependencies (NetworkManager itself
depends ultimately on the sysinit.target).

With this change, the services are only pulled in by time-sync.target.
That allows to order the service after network-online.target. With that
the first synchronization succeeds.

This mechanism also works when a NTP server is provided through DHCP.
In that case, a the systemd-timesyncd service is started by the dispatch
script /usr/lib/NetworkManager/dispatcher.d/10-ntp before the systemd
even considers starting the service. Tests show that the default
fallback NTP is not contacted, only the DHCP provided service.