### PR TITLE
Fix delaying systemd-timesyncd start

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
@@ -2,4 +2,5 @@
 Wants=network-online.target
 
 [Install]
+WantedBy=
 WantedBy=time-sync.target

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
@@ -3,4 +3,5 @@ RequiresMountsFor=/var/lib/systemd
 After=network-online.target
 
 [Install]
+WantedBy=
 WantedBy=time-sync.target

--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-timesyncd.service.d/hassos.conf
@@ -1,6 +1,8 @@
 [Unit]
 RequiresMountsFor=/var/lib/systemd
 After=network-online.target
+Before=
+Before=time-set.target shutdown.target
 
 [Install]
 WantedBy=


### PR DESCRIPTION
Setting WantedBy=time-sync.target in a service.d config file does not
clear previous assignments of WantedBy. This caused the services to still
be pulled in by the sysinit.target, causing a ordering cycle and the
system to not start essential services.

Fixes: #2068