### PR TITLE
rpi4: Enable arm_boost=1 to unlock 1.8Ghz CPU 

### DIFF
--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -75,6 +75,8 @@ dtparam=audio=on
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
+# Enable boost from 1.5Ghz to 1.8Ghz on compatible models
+arm_boost=1
 
 [all]
 #dtoverlay=vc4-fkms-v3d

--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -75,7 +75,7 @@ dtparam=audio=on
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
-# Enable boost from 1.5Ghz to 1.8Ghz on compatible models
+# Enable boost from 1.5GHz to 1.8GHz on compatible models
 arm_boost=1
 
 [all]

--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -75,7 +75,7 @@ dtparam=audio=on
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
-# Enable boost from 1.5GHz to 1.8GHz on compatible models
+# Enable boost from 1.5Ghz to 1.8Ghz on compatible models
 arm_boost=1
 
 [all]

--- a/buildroot-external/board/raspberrypi/yellow/config.txt
+++ b/buildroot-external/board/raspberrypi/yellow/config.txt
@@ -31,8 +31,6 @@ gpu_mem=32
 
 # Additional overlays and parameters are documented /boot/overlays/README
 
-[cm4]
+[all]
 device_tree=bcm2711-rpi-cm4-ha-yellow.dtb
-# Enable boost from 1.5GHz to 1.8GHz on compatible models
-arm_boost=1
 

--- a/buildroot-external/board/raspberrypi/yellow/config.txt
+++ b/buildroot-external/board/raspberrypi/yellow/config.txt
@@ -31,6 +31,8 @@ gpu_mem=32
 
 # Additional overlays and parameters are documented /boot/overlays/README
 
-[all]
+[cm4]
 device_tree=bcm2711-rpi-cm4-ha-yellow.dtb
+# Enable boost from 1.5GHz to 1.8GHz on compatible models
+arm_boost=1
 


### PR DESCRIPTION
The official Raspberry Pi OS enables a "boosted" 1.8GHz mode since their Debian bullseye based release [source]. This commit brings this feature to HASS OS.

See the official [documentation on arm_boost], which states the following:

> This change should be safe for all such boards [...]
>  New Raspberry Pi OS images from Bullseye onwards come with this setting by default.

[source]: https://www.raspberrypi.com/news/bullseye-bonus-1-8ghz-raspberry-pi-4/
[documentation on arm_boost]: https://www.raspberrypi.com/documentation/computers/config_txt.html#arm_boost-raspberry-pi-4-only