### PR TITLE
Start dropbear SSH server earlier

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/docker.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/docker.conf
@@ -1,3 +1,0 @@
-[Unit]
-Requires=docker.service
-After=docker.service


### PR DESCRIPTION
This can be helpful when debugging HAOS issues. Dropbear is only started
if the user actually enabled it by configuring a SSH key, so this change
won't have an effect for most people.