### PR TITLE
Add access to containerd for Supervisor

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -82,6 +82,7 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         --privileged --security-opt apparmor="hassio-supervisor" \
         --oom-score-adj=-300 \
         -v /run/docker.sock:/run/docker.sock:rw \
+        -v /run/docker/containerd/containerd.sock:/run/docker/containerd/containerd.sock:rw \
         -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/supervisor:/run/os:rw \


### PR DESCRIPTION
Add direct access to Docker's containerd instance by passing in its GRCP
socket. This can be useful to talk to the containerd GRPC API directly,
which exposes more information than the Docker API (e.g. OOM kill
events).