### PR TITLE
Bump commit interval to 30s

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
@@ -12,6 +12,7 @@ Wants=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2ddata.service systemd-growfs@mn
 What=/dev/disk/by-label/hassos-data
 Where=/mnt/data
 Type=ext4
+Options=commit=30
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
A higher file system commit interval can help to decrease the amount of
writes. In tests, a commit interval of higher than 30s seems not to help
much in practice. Settle with 30s for now.

Some tests about this change can be found here:
https://community.home-assistant.io/t/researching-i-o-write-improvements/456227