### PR TITLE
Remove image name from journald tag/identifier

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -4,7 +4,7 @@
     "experimental": true,
     "ip6tables": true,
     "log-opts": {
-        "tag": "{{.ImageName}}/{{.Name}}"
+        "tag": "{{.Name}}"
     },
     "data-root": "/mnt/data/docker",
     "deprecated-key-path": "/mnt/overlay/etc/docker/key.json"


### PR DESCRIPTION
The image name is stored in a separate field IMAGE_NAME as well. This allows to use the container name (e.g. `hassio_supervisor`) to get logs of all Supervisors independent of the image name (which differs for every version).