### PR TITLE
Drop unused cgroup_enable=memory kernel parameter

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -56,7 +56,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID cgroup_enable=memory fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID fsck.repair=yes"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/asus/tinker/uboot-boot.ush
+++ b/buildroot-external/board/asus/tinker/uboot-boot.ush
@@ -17,7 +17,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -21,7 +21,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -56,7 +56,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID cgroup_enable=memory fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID fsck.repair=yes"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1


### PR DESCRIPTION
The cgroup_enable parameter is a Raspberry Pi kernel specific kernel parameter. Upstream based kernel do not have the parameter, and hence do not do anything.

This gets rid of the following message during boot: 

```
Unknown kernel command line parameters "cgroup_enable=memory", will be passed to user space.
```