### PR TITLE
Fix Docker key.json corruption check

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/docker-failure
+++ b/buildroot-external/rootfs-overlay/usr/libexec/docker-failure
@@ -4,7 +4,7 @@ if [ "$SERVICE_RESULT" = "exit-code" ] && [ "$EXIT_STATUS" = "1" ]; then
     echo "Docker exited with exit status 1, this might be caused by corrupted key.json."
     size=$(stat -c %s "/mnt/overlay/etc/docker/key.json")
     echo "key.json: ${size} bytes"
-    if ! jq < "/mnt/overlay/etc/docker/key.json" > /dev/null || [ "${size}" -eq 0 ]; then
+    if ! jq -e < "/mnt/overlay/etc/docker/key.json" > /dev/null || [ "${size}" -eq 0 ]; then
         echo "key.json appears to be corrupted, it is not parsable. Removing it."
         rm -f "/mnt/overlay/etc/docker/key.json"
     fi

--- a/buildroot-external/rootfs-overlay/usr/libexec/docker-failure
+++ b/buildroot-external/rootfs-overlay/usr/libexec/docker-failure
@@ -2,10 +2,10 @@
 
 if [ "$SERVICE_RESULT" = "exit-code" ] && [ "$EXIT_STATUS" = "1" ]; then
     echo "Docker exited with exit status 1, this might be caused by corrupted key.json."
-    size=$(stat -c %s "/etc/docker/key.json")
+    size=$(stat -c %s "/mnt/overlay/etc/docker/key.json")
     echo "key.json: ${size} bytes"
-    if ! jq < "/etc/docker/key.json" > /dev/null || [ "${size}" -eq 0 ]; then
+    if ! jq < "/mnt/overlay/etc/docker/key.json" > /dev/null || [ "${size}" -eq 0 ]; then
         echo "key.json appears to be corrupted, it is not parsable. Removing it."
-        rm -f "/etc/docker/key.json"
+        rm -f "/mnt/overlay/etc/docker/key.json"
     fi
 fi


### PR DESCRIPTION
Since /etc/docker does not get bind mounted anymore (see #2116), key.json from the overlay partition is used directly.