### PR TITLE
Connectivity check interval to 10 minutes

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -16,6 +16,7 @@ connection.llmnr=2
 
 [connectivity]
 uri=http://checkonline.home-assistant.io/online.txt
+interval=600
 
 [device]
 wifi.scan-rand-mac-address=no


### PR DESCRIPTION
Supervisor now relies on Network Manager to do connectivity checks in the background instead of forcing it to do one every 10 minutes. Since supervisor's interval for this was 10 minutes it seems like we should set Network Manager to that. It uses 300 seconds by default.