### PR TITLE
Replace set-output commands with GITHUB_OUTPUT environment vars

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           version_dev="dev$(date --utc +'%Y%m%d')"
           echo "Development version \"${version_dev}\""
-          echo "::set-output name=version_dev::${version_dev}"
+          echo "version_dev=${version_dev}" >> $GITHUB_OUTPUT
       - name: Generate Development build version for PR
         if: ${{ github.event.pull_request }}
         shell: bash
@@ -34,14 +34,14 @@ jobs:
         run: |
           version_pr=$(printf "%05d" ${{ github.event.pull_request.number }})
           echo "Development build for PR #${{ github.event.pull_request.number }}"
-          echo "::set-output name=version_pr::${version_pr}"
+          echo "version_pr=${version_pr}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
       - name: Get Major/Minor version
         id: version_main
         run: |
           major=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_MAJOR | cut -d'=' -f2)
           build=$(cat ${GITHUB_WORKSPACE}/buildroot-external/meta | grep VERSION_BUILD | cut -d'=' -f2)
-          echo "::set-output name=version_main::${major}.${build}"
+          echo "version_main=${major}.${build}" >> $GITHUB_OUTPUT
       - name: Create build matrix
         uses: actions/github-script@v6
         id: generate_matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,11 @@ jobs:
             exit 1
           fi
           if [ "" != "${tag_dev}" ]; then
-            echo "Note: Release build with custom dev part: ${tag_dev}."
-            echo "::set-output name=version::${major}.${build}.${tag_dev}"
+            echo "version=${major}.${build}.${tag_dev}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=version::${major}.${build}"
+            echo "version=${major}.${build}" >> $GITHUB_OUTPUT
           fi
-          echo "::set-output name=version_dev::${tag_dev}"
+          echo "version_dev=${tag_dev}" >> $GITHUB_OUTPUT
       - name: Create build matrix
         uses: actions/github-script@v6
         id: generate_matrix


### PR DESCRIPTION
The set-output commands via stdout are deprecated. Use the GITHUB_OUTPUT environment variable as suggested by GitHub.