### PR TITLE
Fix S-ATA on ODROID-HC1 (#2153)

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-xu4/patches/linux/0001-Revert-usb-dwc3-disable-USB-core-PHY-management.patch
+++ b/buildroot-external/board/hardkernel/odroid-xu4/patches/linux/0001-Revert-usb-dwc3-disable-USB-core-PHY-management.patch
@@ -1,0 +1,44 @@
+From aba15462589340e5dce525e5eeae77bdcd0e06c3 Mon Sep 17 00:00:00 2001
+Message-Id: <aba15462589340e5dce525e5eeae77bdcd0e06c3.1666039333.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 17 Oct 2022 22:41:03 +0200
+Subject: [PATCH] Revert "usb: dwc3: disable USB core PHY management"
+
+This reverts commit 55d328924347dfb315fe096efdb59567a9a7a362.
+---
+ drivers/usb/dwc3/host.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/drivers/usb/dwc3/host.c b/drivers/usb/dwc3/host.c
+index 85165a972076..2078e9d70292 100644
+--- a/drivers/usb/dwc3/host.c
++++ b/drivers/usb/dwc3/host.c
+@@ -10,13 +10,8 @@
+ #include <linux/acpi.h>
+ #include <linux/platform_device.h>
+ 
+-#include "../host/xhci-plat.h"
+ #include "core.h"
+ 
+-static const struct xhci_plat_priv dwc3_xhci_plat_priv = {
+-	.quirks = XHCI_SKIP_PHY_INIT,
+-};
+-
+ static int dwc3_host_get_irq(struct dwc3 *dwc)
+ {
+ 	struct platform_device	*dwc3_pdev = to_platform_device(dwc->dev);
+@@ -92,11 +87,6 @@ int dwc3_host_init(struct dwc3 *dwc)
+ 		goto err;
+ 	}
+ 
+-	ret = platform_device_add_data(xhci, &dwc3_xhci_plat_priv,
+-					sizeof(dwc3_xhci_plat_priv));
+-	if (ret)
+-		goto err;
+-
+ 	memset(props, 0, sizeof(struct property_entry) * ARRAY_SIZE(props));
+ 
+ 	if (dwc->usb3_lpm_capable)
+-- 
+2.38.0
+


### PR DESCRIPTION
The ODROID-XU4 is largely compatible with the ODROID-HC1. It seems that the image used to work until recently, where a stable kernel update broke access to the S-ATA disk.

Revert the offending stable kernel patch to fix S-ATA disk on ODROID-HC1.