### PR TITLE
Decrease network size of Docker default bridge (#2135)

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -7,5 +7,6 @@
         "tag": "{{.Name}}"
     },
     "data-root": "/mnt/data/docker",
-    "deprecated-key-path": "/mnt/overlay/etc/docker/key.json"
+    "deprecated-key-path": "/mnt/overlay/etc/docker/key.json",
+    "bip": "172.17.232.1/23"
 }


### PR DESCRIPTION
Instead of allocating `172.17.0.0/16` as the default network bridge use a much smaller range. This helps folks which have hosts in that network range.

Ideally, we should make the default as well as the hassio bridge configurable.