### PR TITLE
Enable experimental APIs for Bluetooth daemon

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/bluetooth/main.conf
+++ b/buildroot-external/rootfs-overlay/etc/bluetooth/main.conf
@@ -1,2 +1,5 @@
+[General]
+Experimental=true
+
 [Policy]
 AutoEnable=true


### PR DESCRIPTION
To get access to the experimental advertisement monitor api experimental mode is required. This eanbles the experimental D-Bus API by default.

See also: https://github.com/hbldh/bleak/pull/884

/cc @bdraco