### PR TITLE
Enable release drafter on dev branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,5 @@
-name-template: Home Assistant OS $NEXT_MINOR_VERSION
+name-template: Home Assistant OS $RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
 version-template: "$MAJOR.$MINOR"
 categories:
   - title: 'Home Assistant Operating System'
@@ -26,3 +27,8 @@ template: |
   ## Changes
 
   $CHANGES
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  default: minor

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
+      - dev
       - rel-*
 
 jobs:


### PR DESCRIPTION
Properly configure the release drafter to create draft releases for the next major and minor release.

To let the release drafter know that `dev` is a new major release one of the PR need to be labeled with the `major` label (ideally there should be a version bump PR with the label).

Note that with the current approach of cherry-picking commits back to `rel-x` branches the drafts for minor release do not contain a changelog. Ideally PRs should be used, possible created automatically by a GitHub Action.