### PR TITLE
Use same class B network for Docker as Supervisor (#2246)

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -8,5 +8,5 @@
     },
     "data-root": "/mnt/data/docker",
     "deprecated-key-path": "/mnt/overlay/etc/docker/key.json",
-    "bip": "172.17.232.1/23"
+    "bip": "172.30.232.1/23"
 }


### PR DESCRIPTION
Use a subnet in the same class B network for the Docker default bridge is using. This avoids conflicting with more than one class B network.