### PR TITLE
Fix remote tracking branch for Buildroot submodule (#2287)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "buildroot"]
 	path = buildroot
 	url = https://github.com/home-assistant/buildroot.git
-	branch = 2021.02.x-haos
+	branch = 2022.02.x-haos


### PR DESCRIPTION
Set 2022.02-haos as the default remote tracking branch. This should not influence regular submodule updates/inits as they reference the git hash tracked by the operating-system repository directly.