### PR TITLE
Add ASMedia based devices to UAS block list (#1743)

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u
+dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u


### PR DESCRIPTION
This ASMedia Technology chip seems to cause problem with the UAS driver. The chip is used in UGreen S-ATA to USB 3.0 adapters.