### PR TITLE
Revert NetworkManager bridge support

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -5,7 +5,7 @@ autoconnect-retries-default=0
 rc-manager=file
 
 [keyfile]
-unmanaged-devices=type:tun;driver:veth;interface-name:docker*;interface-name:hassio
+unmanaged-devices=type:bridge;type:tun;driver:veth
 
 [logging]
 backend=journal


### PR DESCRIPTION
The bridge support is not complete and causes issues in Supervisor. Supervisor first needs proper support for it before we can deploy it in Operating System.

See also: https://github.com/home-assistant/supervisor/pull/4133