### PR TITLE
Increase net.core.optmem_max for OTBR

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/60-otbr-ancillary-buffer.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/60-otbr-ancillary-buffer.conf
@@ -1,0 +1,3 @@
+# Increase ancillary buffer size to allow for a larger number of multicast groups
+# Required for NdProxyManager::JoinSolicitedNodeMulticastGroup
+net.core.optmem_max=65536


### PR DESCRIPTION
The OTBR install scripts by default increases the net.core.optmem_max ancillary buffer size to 64KiB to allow for a larger number of multicast groups. Arch Linux as well recommends this size for high speed network links.