### PR TITLE
Use Network device naming scheme v250

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -56,7 +56,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/asus/tinker/uboot-boot.ush
+++ b/buildroot-external/board/asus/tinker/uboot-boot.ush
@@ -17,7 +17,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -21,7 +21,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -19,7 +19,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -56,7 +56,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor systemd.machine_id=$MACHINE_ID fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -18,7 +18,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -18,7 +18,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -18,7 +18,7 @@ test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 apparmor=1 security=apparmor rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
 
 # Red Button pressed?
 if gpio input GPIO27; then


### PR DESCRIPTION
The new systemd version v252 brings a new naming scheme, in particular it seems that on device tree based systems (e.g. Raspberry Pis) the Ethernet device name changes from eth0 to end0.

This breaks a previously made configuration.

Even worse, it seems that the default NetworkManager behavior is to only configure a network device if there is no profile. But since profiles are configured on a typical installation, NetworkManager doesn't bring up any of the network interface, leaving the user stranded on an unconnected system.

Ideally, we should have a plan how to migrate from one naming scheme to the next. For now, just stick with the naming scheme HAOS 9.x has been using.