### PR TITLE
Use new containerd.sock location of Docker 23.0

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -89,7 +89,7 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         --privileged --security-opt apparmor="hassio-supervisor" \
         --oom-score-adj=-300 \
         -v /run/docker.sock:/run/docker.sock:rw \
-        -v /run/docker/containerd/containerd.sock:/run/docker/containerd/containerd.sock:rw \
+        -v /run/containerd/containerd.sock:/run/containerd/containerd.sock:rw \
         -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/supervisor:/run/os:rw \


### PR DESCRIPTION
Otherwise the Supervisor service fails to start with the following error:

```
Mar 03 09:13:23 ha-yellow-desk hassos-supervisor[843]: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/run/docker/containerd/containerd.sock" to rootfs at "/run/docker/containerd/containerd.sock": mount /run/docker/containerd/containerd.sock:/run/docker/containerd/containerd.sock (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

Which ultimately leads to re-download of the Supervisor because the script assumes it crashed.

With this change, the container image will not get redownloaded. But because the script date changed, it will lead to recreation of the container (with the new bind mount location).

Note: We currently don't use this socket in Supervisor. Rather than maintain the old location, just move it to the new location also inside the Supervisor container.