### PR TITLE
Avoid custom GPT location

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -41,7 +41,7 @@ install_spl() {
     fi
 
     if [ "${PART_LABEL}" = "gpt" ]; then
-        dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=512 seek=2 skip=2
+        dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=512 seek=64 skip=64
     else
         dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=1 count=440
         dd if="${RAUC_IMAGE_NAME}" of="${DEVICE_ROOT}" conv=notrunc ${FLAGS} bs=512 seek=1 skip=1


### PR DESCRIPTION
Currently the only board supporting GPT partition table and SPL is the ASUS Tinker board. Its Rockchip boot loader is stored at LBA 0x40 (64) which is well past the last LBA of a regular GPT partition table which is at LBA 33). Therefor a custom GPT main partition table location (via sgdisk -j, --adjust-main-table=sector) is not necessary.

Technically we could copy anything after LBA 34 from the SPL image, but since we don't support a board which needs that space for its SPL let's stick with the well aligned Rockchip start at LBA 64.

Note: To preserve the layout we still add the SPL size to the regular offset. Technically we could start the boot partition at LBA 16384, but this would mean a different partition table compared to before and different offset of subsequent partitions compared to other GPT platforms.