### PR TITLE
Support systemd ConditionFirstBoot

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -54,9 +54,13 @@ if [ "$default" -eq 99 ]; then
     fi
 fi
 
+if [ "$MACHINE_ID" == "" ]; then
+    boot_condition="systemd.condition-first-boot=true"
+fi
+
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/asus/tinker/uboot-boot.ush
+++ b/buildroot-external/board/asus/tinker/uboot-boot.ush
@@ -16,8 +16,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -18,8 +18,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -18,8 +18,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
@@ -16,8 +16,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -18,8 +18,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -20,8 +20,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -18,8 +18,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -54,9 +54,13 @@ if [ "$default" -eq 99 ]; then
     fi
 fi
 
+if [ "$MACHINE_ID" == "" ]; then
+    boot_condition="systemd.condition-first-boot=true"
+fi
+
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -17,8 +17,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -17,8 +17,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -17,8 +17,11 @@ test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
 test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3
 test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 
+# Allows ConditionFirstBoot=
+test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
+
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # Red Button pressed?
 if gpio input GPIO27; then


### PR DESCRIPTION
By default ConditionFirstBoot is ankered to the presence of /etc/machine-id. However, in our case /etc/machine-id is a bind mount, which makes the first boot condition non-working.

Since machine-id is stored by the bootloader on HAOS, use the boot loaders knowledge and pass the information to systemd.