### PR TITLE
Avoid moving data to same device

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-data
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-data
@@ -37,7 +37,7 @@ echo "[INFO] Moving data from ${OLD_DEVICE_CHILD} to ${NEW_DEVICE_CHILD}"
 if ! e2image -ra -p "${OLD_DEVICE_CHILD}" "${NEW_DEVICE_CHILD}"; then
     echo "[ERROR] Copying data partition to external device failed!"
     # Rename partition to make sure HAOS does not try to mount a failed copy attempt.
-    e2label "${NEW_DEVICE_CHILD}" hassos-data-failed || true
+    e2label "${NEW_DEVICE_CHILD}" hassos-data-fail || true
     exit 1
 fi
 

--- a/buildroot-external/rootfs-overlay/usr/libexec/hassos-data
+++ b/buildroot-external/rootfs-overlay/usr/libexec/hassos-data
@@ -20,10 +20,16 @@ fi
 # Rely on systemd-udev symlinks to find external data partition by partlabel
 NEW_DEVICE_CHILD="$(readlink -f "/dev/disk/by-partlabel/hassos-data-external")"
 
+# Check if target device is the current device
+if [ "${NEW_DEVICE_CHILD}" = "${OLD_DEVICE_CHILD}" ]; then
+    echo "[ERROR] Home Assitant OS is already using this external data device!"
+    exit 1
+fi
+
 NEW_DEVICE_PART_SIZE=$(cat "/sys/class/block/$(basename "${NEW_DEVICE_CHILD}")/size")
 OLD_DEVICE_PART_SIZE=$(cat "/sys/class/block/$(basename "${OLD_DEVICE_CHILD}")/size")
 if [ "${NEW_DEVICE_PART_SIZE}" -lt "${OLD_DEVICE_PART_SIZE}" ]; then
-    echo "[INFO] Target device too small!"
+    echo "[ERROR] Target device too small!"
     exit 1
 fi
 


### PR DESCRIPTION
When a data disk move is triggered when the data disk is already in use the script currently renames that only data disk, rendering the system unusable.

Don't continue if source and destination happens to be the same device.