### PR TITLE
Don't kill ssh connection on OOM

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/hassos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/dropbear.service.d/hassos.conf
@@ -9,3 +9,4 @@ ExecStartPre=
 ExecStart=
 ExecStart=-/usr/sbin/dropbear -R -E -p 22222 -s
 KillMode=mixed
+OOMPolicy=continue


### PR DESCRIPTION
By default systemd kills the service which causes an OOM. That make sense for a typical service, however, for SSH we don't want this behavior: The connection should continue, just the command which caused OOM should be killed.