### PR TITLE
Set file descriptors limit of Docker to pre-OS 10 default

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/containerd.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/containerd.service.d/haos.conf
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=1048576


### PR DESCRIPTION
With the bump to Docker 23.0 a new maximum number of file descriptors got set (LimitNOFILE=infinity in the Docker service files). This reintroduces the old default.

Related to: #2438