### PR TITLE
Fix startup by using BindTo and After (#2496)

### DIFF
--- a/buildroot-external/package/qemu-guest-agent/qemu-guest.service
+++ b/buildroot-external/package/qemu-guest-agent/qemu-guest.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=QEMU Guest Agent
-After=syslog.target network.target
 ConditionVirtualization=|kvm
 ConditionVirtualization=|qemu
 ConditionPathExists=!/dev/virtio-ports/org.linuxcontainers.lxd
+BindTo=dev-virtio\x2dports-org.qemu.guest_agent.0.device
+After=dev-virtio\x2dports-org.qemu.guest_agent.0.device
 
 [Service]
 ExecStart=/usr/libexec/qemu-ga -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0


### PR DESCRIPTION
Use BindTo and After settings from the QEMU guest agente service file present in the QEMU source tree (contrib/systemd/qemu-guest-agent.service).