### PR TITLE
Fix boot on Raspberry Pi 4 32-bit (#2500)

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0001-rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
@@ -1,5 +1,5 @@
-From 135d886b4e5077c8fa96a5449a70d81ae9c1c3d0 Mon Sep 17 00:00:00 2001
-Message-Id: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From 01b4d231cbb66ca193ba422a22d25c75d21ff8ee Mon Sep 17 00:00:00 2001
+Message-Id: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Pascal Vizeli <pvizeli@syshack.ch>
 Date: Tue, 10 Dec 2019 09:48:46 +0000
 Subject: [PATCH] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
@@ -79,5 +79,5 @@ index 1d356b4b2e..6f345c790b 100644
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0002-rpi-add-NVMe-to-boot-order.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0002-rpi-add-NVMe-to-boot-order.patch
@@ -1,7 +1,7 @@
-From 191b5f4e0408e40f35379fdaab6b37a7ad93e298 Mon Sep 17 00:00:00 2001
-Message-Id: <191b5f4e0408e40f35379fdaab6b37a7ad93e298.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From 8870872f359771effddd74bcb4c7e0a4316d99f7 Mon Sep 17 00:00:00 2001
+Message-Id: <8870872f359771effddd74bcb4c7e0a4316d99f7.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 29 Dec 2020 23:34:52 +0100
 Subject: [PATCH] rpi: add NVMe to boot order
@@ -40,5 +40,5 @@ index cd8fe8b518..7257659932 100644
  	BOOT_TARGET_PXE(func) \
  	BOOT_TARGET_DHCP(func)
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0003-Revert-nvme-Correct-the-prps-per-page-calculation-me.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0003-Revert-nvme-Correct-the-prps-per-page-calculation-me.patch
@@ -1,7 +1,7 @@
-From 644bd3743aa8771ef7ecb7b7239308d6da2a5b35 Mon Sep 17 00:00:00 2001
-Message-Id: <644bd3743aa8771ef7ecb7b7239308d6da2a5b35.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From 60afc919643d212439a63908c83523879af21032 Mon Sep 17 00:00:00 2001
+Message-Id: <60afc919643d212439a63908c83523879af21032.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:43:31 +0200
 Subject: [PATCH] Revert "nvme: Correct the prps per page calculation method"
@@ -39,5 +39,5 @@ index 6d0d3f3ca2..73db80a294 100644
  
  	length -= (page_size - offset);
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0004-usb-xhci-brcm-Make-driver-compatible-with-downstream.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0004-usb-xhci-brcm-Make-driver-compatible-with-downstream.patch
@@ -1,7 +1,7 @@
-From de29ca70117fb2bfafa8b5699b34e9e94560b785 Mon Sep 17 00:00:00 2001
-Message-Id: <de29ca70117fb2bfafa8b5699b34e9e94560b785.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From cca49e815fbdcbb436f238d362b5f145471153dc Mon Sep 17 00:00:00 2001
+Message-Id: <cca49e815fbdcbb436f238d362b5f145471153dc.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 7 Oct 2021 12:02:39 +0200
 Subject: [PATCH] usb: xhci-brcm: Make driver compatible with downstream device
@@ -29,5 +29,5 @@ index fe17924028..0c6938187b 100644
  };
  
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0005-nvme-improve-readability-of-nvme_setup_prps.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0005-nvme-improve-readability-of-nvme_setup_prps.patch
@@ -1,7 +1,7 @@
-From ab2790f8ff78790ea8a9cb0b05cafc55648ebbc4 Mon Sep 17 00:00:00 2001
-Message-Id: <ab2790f8ff78790ea8a9cb0b05cafc55648ebbc4.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From 11176a6ca068e0b572abbe5da8fef1d57bd40e7a Mon Sep 17 00:00:00 2001
+Message-Id: <11176a6ca068e0b572abbe5da8fef1d57bd40e7a.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:52:44 +0200
 Subject: [PATCH] nvme: improve readability of nvme_setup_prps()
@@ -45,5 +45,5 @@ index 73db80a294..751abc3cd5 100644
  			prp_pool += page_size;
  		}
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0006-nvme-Use-pointer-for-CPU-addressed-buffers.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0006-nvme-Use-pointer-for-CPU-addressed-buffers.patch
@@ -1,7 +1,7 @@
-From 2b508d92673738d837576301866dc234d8b008c4 Mon Sep 17 00:00:00 2001
-Message-Id: <2b508d92673738d837576301866dc234d8b008c4.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From 3bccb6eb7f9e8e996cd50409eb96450c313953ec Mon Sep 17 00:00:00 2001
+Message-Id: <3bccb6eb7f9e8e996cd50409eb96450c313953ec.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Thu, 23 Sep 2021 23:58:35 +0200
 Subject: [PATCH] nvme: Use pointer for CPU addressed buffers
@@ -260,5 +260,5 @@ index 2cdf8ce320..8ff823cd81 100644
  /**
   * nvme_scan_namespace - scan all namespaces attached to NVMe controllers
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0007-nvme-translate-virtual-addresses-into-the-bus-s-addr.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0007-nvme-translate-virtual-addresses-into-the-bus-s-addr.patch
@@ -1,7 +1,7 @@
-From c70926d8b8ad11b8e489e92a8ca9ca93fb201595 Mon Sep 17 00:00:00 2001
-Message-Id: <c70926d8b8ad11b8e489e92a8ca9ca93fb201595.1668448794.git.stefan@agner.ch>
-In-Reply-To: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
-References: <135d886b4e5077c8fa96a5449a70d81ae9c1c3d0.1668448794.git.stefan@agner.ch>
+From ca73fb28fa86b7de243b6713d2756dee445c5f56 Mon Sep 17 00:00:00 2001
+Message-Id: <ca73fb28fa86b7de243b6713d2756dee445c5f56.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Fri, 24 Sep 2021 00:27:39 +0200
 Subject: [PATCH] nvme: translate virtual addresses into the bus's address
@@ -172,5 +172,5 @@ index bc1d612dde..f52103c009 100644
 +
  #endif /* __DRIVER_NVME_H__ */
 -- 
-2.38.1
+2.40.0
 

--- a/buildroot-external/board/raspberrypi/patches/uboot/0008-Revert-pci-Check-region-ranges-are-addressable.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0008-Revert-pci-Check-region-ranges-are-addressable.patch
@@ -1,0 +1,50 @@
+From 89df39ccb71062a06f4548c11fba9101dfd82445 Mon Sep 17 00:00:00 2001
+Message-Id: <89df39ccb71062a06f4548c11fba9101dfd82445.1682350496.git.stefan@agner.ch>
+In-Reply-To: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+References: <01b4d231cbb66ca193ba422a22d25c75d21ff8ee.1682350496.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 24 Apr 2023 15:44:15 +0200
+Subject: [PATCH] Revert "pci: Check region ranges are addressable"
+
+This reverts commit ec8eba8c2d4e10e77699c56918d2078210aa1339.
+
+This commit seems to cause boot hangs when USB via XHCI is enabled on
+Raspberry Pi 4 32-bit. Reverting the commit fixes USB device detection
+and makes the devices boot again.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/pci/pci-uclass.c | 17 +----------------
+ 1 file changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/drivers/pci/pci-uclass.c b/drivers/pci/pci-uclass.c
+index 9343cfc62a..ac2a8c8aa0 100644
+--- a/drivers/pci/pci-uclass.c
++++ b/drivers/pci/pci-uclass.c
+@@ -1027,22 +1027,7 @@ static int decode_regions(struct pci_controller *hose, ofnode parent_node,
+ 
+ 		if (!IS_ENABLED(CONFIG_SYS_PCI_64BIT) &&
+ 		    type == PCI_REGION_MEM && upper_32_bits(pci_addr)) {
+-			debug(" - pci_addr beyond the 32-bit boundary, ignoring\n");
+-			continue;
+-		}
+-
+-		if (!IS_ENABLED(CONFIG_PHYS_64BIT) && upper_32_bits(addr)) {
+-			debug(" - addr beyond the 32-bit boundary, ignoring\n");
+-			continue;
+-		}
+-
+-		if (~((pci_addr_t)0) - pci_addr < size) {
+-			debug(" - PCI range exceeds max address, ignoring\n");
+-			continue;
+-		}
+-
+-		if (~((phys_addr_t)0) - addr < size) {
+-			debug(" - phys range exceeds max address, ignoring\n");
++			debug(" - beyond the 32-bit boundary, ignoring\n");
+ 			continue;
+ 		}
+ 
+-- 
+2.40.0
+


### PR DESCRIPTION
With U-Boot 2023.01 booting on Raspberry Pi 4 32-bit (at least with 4 or 8GB of memory) freezes when trying to enumerate USB devices. It seems that the PCIe initialization partially fails, which causes the USB XHCI initialization to fail.

It seems that a new restriction on viable addresses for PCIe initialization causes the problem. Revert the offending commit to make U-Boot properly detect USB devices again.