### PR TITLE
Avoid CLI restart on shutdown

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -27,7 +27,9 @@ case $? in
   143)
     # 143 graceful termination (SIGTERM). Most likely a proper shutdown.
     # Just sleep for a while until actual systemd shutdown gets invoked.
-    sleep 15
+    echo ""
+    echo "Home Assistant CLI has been terminated."
+    sleep 30
     ;;
   *)
     echo "HA CLI failed with error code: $?"


### PR DESCRIPTION
This avoids continous CLI restarts on shutdown. The chosen solution is not particularly pretty. Better would be we could inform the OS (systemd) that a shutdown is indeed in progress and act accordingly. But this would need bigger changes which is not in scope for now.