### PR TITLE
Set bind propagation for supervisor data

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -95,7 +95,7 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         -v /run/supervisor:/run/os:rw \
         -v /run/udev:/run/udev:ro \
         -v /etc/machine-id:/etc/machine-id:ro \
-        -v ${SUPERVISOR_DATA}:/data:rw \
+        -v ${SUPERVISOR_DATA}:/data:rw,slave \
         -e SUPERVISOR_SHARE=${SUPERVISOR_DATA} \
         -e SUPERVISOR_NAME=hassio_supervisor \
         -e SUPERVISOR_MACHINE=${SUPERVISOR_MACHINE} \


### PR DESCRIPTION
Supervisor cannot see network mounts currently without a rebuild of the container since bind propagation is set to `rprivate` for its data mount. We need to change the propagation mode so supervisor can see network mounts as they are added by users without a restart.