### PR TITLE
Yellow: Rely on device tree alias for serial port numbering

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0013-Revert-amba_pl011-Don-t-use-DT-aliases-for-numbering.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0013-Revert-amba_pl011-Don-t-use-DT-aliases-for-numbering.patch
@@ -1,0 +1,56 @@
+From e223dcd78da4356a2aebb2d99412229978ee4c12 Mon Sep 17 00:00:00 2001
+Message-Id: <e223dcd78da4356a2aebb2d99412229978ee4c12.1685522257.git.stefan@agner.ch>
+In-Reply-To: <f0292972b38d512fce48384ebbb72b2da46f03bd.1685522257.git.stefan@agner.ch>
+References: <f0292972b38d512fce48384ebbb72b2da46f03bd.1685522257.git.stefan@agner.ch>
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Thu, 23 Feb 2023 09:34:12 +0000
+Subject: [PATCH] Revert "amba_pl011: Don't use DT aliases for numbering"
+
+This reverts commit c2fa32a8dae4c4b2638c9f4de5e398e98460e693.
+
+Consistent, logical UART numbering is desirable, so remove the
+effective revert.
+
+See: https://forums.raspberrypi.com/viewtopic.php?t=347868
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/tty/serial/amba-pl011.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/drivers/tty/serial/amba-pl011.c b/drivers/tty/serial/amba-pl011.c
+index 6f92f581e18c..d301253e26b1 100644
+--- a/drivers/tty/serial/amba-pl011.c
++++ b/drivers/tty/serial/amba-pl011.c
+@@ -2671,7 +2671,6 @@ static struct uart_driver amba_reg = {
+ 	.cons			= AMBA_CONSOLE,
+ };
+ 
+-#if 0
+ static int pl011_probe_dt_alias(int index, struct device *dev)
+ {
+ 	struct device_node *np;
+@@ -2703,7 +2702,6 @@ static int pl011_probe_dt_alias(int index, struct device *dev)
+ 
+ 	return ret;
+ }
+-#endif
+ 
+ /* unregisters the driver also if no more ports are left */
+ static void pl011_unregister_port(struct uart_amba_port *uap)
+@@ -2755,12 +2753,7 @@ static int pl011_setup_port(struct device *dev, struct uart_amba_port *uap,
+ 	if (IS_ERR(base))
+ 		return PTR_ERR(base);
+ 
+-	/* Don't use DT serial<n> aliases - it causes the device to
+-	   be renumbered to ttyAMA1 if it is the second serial port in the
+-	   system, even though the other one is ttyS0. The 8250 driver
+-	   doesn't use this logic, so always remains ttyS0.
+ 	index = pl011_probe_dt_alias(index, dev);
+-	*/
+ 
+ 	uap->port.dev = dev;
+ 	uap->port.mapbase = mmiobase->start;
+-- 
+2.40.1
+

--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0014-ARM-dts-bcm2711-yellow-use-serial-alias-to-enumerate.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0014-ARM-dts-bcm2711-yellow-use-serial-alias-to-enumerate.patch
@@ -1,0 +1,46 @@
+From 60e2cd5b6747992f47feef0ee36e2d0d80706c18 Mon Sep 17 00:00:00 2001
+Message-Id: <60e2cd5b6747992f47feef0ee36e2d0d80706c18.1685523528.git.stefan@agner.ch>
+In-Reply-To: <f0292972b38d512fce48384ebbb72b2da46f03bd.1685523528.git.stefan@agner.ch>
+References: <f0292972b38d512fce48384ebbb72b2da46f03bd.1685523528.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 31 May 2023 10:57:43 +0200
+Subject: [PATCH] ARM: dts: bcm2711: yellow: use serial alias to enumerate
+ ttyAMA
+
+Now that the driver actually uses the index from the serial aliases,
+make sure to correctly enumerate the serial aliases.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm/boot/dts/bcm2711-rpi-cm4-ha-yellow.dts | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-yellow.dts b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-yellow.dts
+index f7fdf8bbb395..b8f0bc2df062 100644
+--- a/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-yellow.dts
++++ b/arch/arm/boot/dts/bcm2711-rpi-cm4-ha-yellow.dts
+@@ -17,11 +17,6 @@ / {
+ 	compatible = "raspberrypi,4-compute-module-ha-yellow", "raspberrypi,4-compute-module", "brcm,bcm2711";
+ 	model = "Raspberry Pi Compute Module 4 on Home Assistant Yellow";
+ 
+-	aliases {
+-		serial4 = &uart4;
+-		serial5 = &uart5;
+-	};
+-
+ 	chosen {
+ 		/* 8250 auxiliary UART instead of pl011 */
+ 		stdout-path = "serial1:115200n8";
+@@ -324,7 +319,8 @@ chosen {
+ 
+ 	aliases {
+ 		serial0 = &uart1;
+-		serial1 = &uart0;
++		serial1 = &uart4;
++		serial2 = &uart5;
+ 		mmc0 = &emmc2;
+ 		mmc1 = &mmcnr;
+ 		mmc2 = &sdhost;
+-- 
+2.40.1
+


### PR DESCRIPTION
Use the device tree alias to enumerate the ttyAMA serial ports.