### PR TITLE
Start OS Agent only when boot partition is mounted

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-agent.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-agent.service.d/haos.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=mnt-boot.mount


### PR DESCRIPTION
On Yellow, to read the current LED configuration correctly /mnt/boot is required. This change makes sure that the boot partition is mounted when the OS Agent starts.