### PR TITLE
Avoid waiting for time synchronization too early

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/systemd-time-wait-sync.service.d/network-online.conf
@@ -1,4 +1,5 @@
 [Unit]
+After=network-online.target
 Wants=network-online.target
 
 [Install]


### PR DESCRIPTION
In case a system takes a bit longer to boot (e.g. due to SWAP initialization on first boot, especially on a system with lots of memory and not very fast strage, e.g. an ODROID-M1 using an SD card) we might time-out waiting for time synchronization before the time synchronization service even got started. By ordering the systemd-time-wait-sync.service after the network is online, the timeout of this service should be started much later. With that the systemd-time-wait-sync.service shouldn't timeout any longer.