### PR TITLE
Enable watchdog control in systemd

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system.conf.d/watchdog.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system.conf.d/watchdog.conf
@@ -1,0 +1,3 @@
+[Manager]
+RuntimeWatchdogSec=default
+WatchdogDevice=/dev/watchdog


### PR DESCRIPTION
This is a follow-up to #2627 to enable the systemd configuration for dealing with watchdogs. As mentioned in the comments of the last PR this should also enable watchdog handling on RPi where the watchdog driver is already enabled.
