### PR TITLE
Add Rockchip RK3568 hardware number generator support (#2578)

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0001-arm64-dts-rockchip-Add-Hardkernel-ODROID-M1-board.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0001-arm64-dts-rockchip-Add-Hardkernel-ODROID-M1-board.patch
@@ -1,5 +1,5 @@
 From d388735d551e09b00317a509859fca51776b9826 Mon Sep 17 00:00:00 2001
-Message-Id: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Dongjin Kim <tobetter@gmail.com>
 Date: Fri, 30 Sep 2022 07:12:35 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add Hardkernel ODROID-M1 board
@@ -451,5 +451,5 @@ index 000000000000..b3016437640b
 +	status = "okay";
 +};
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0002-arm64-dts-rockchip-add-thermal-support-to-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0002-arm64-dts-rockchip-add-thermal-support-to-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From 24048c1753916bd983746542b16d19d2b399eeb7 Mon Sep 17 00:00:00 2001
-Message-Id: <24048c1753916bd983746542b16d19d2b399eeb7.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <24048c1753916bd983746542b16d19d2b399eeb7.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:36 +0200
 Subject: [PATCH] arm64: dts: rockchip: add thermal support to ODROID-M1
@@ -34,5 +34,5 @@ index b3016437640b..112c65af3f55 100644
  	status = "okay";
  };
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0003-arm64-dts-rockchip-Add-NOR-flash-to-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0003-arm64-dts-rockchip-Add-NOR-flash-to-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From 982bb2beab8e38a7c0a365770be2ad9c5221a650 Mon Sep 17 00:00:00 2001
-Message-Id: <982bb2beab8e38a7c0a365770be2ad9c5221a650.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <982bb2beab8e38a7c0a365770be2ad9c5221a650.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:37 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add NOR flash to ODROID-M1
@@ -99,5 +99,5 @@ index 112c65af3f55..94e839c9afab 100644
  	rockchip,hw-tshut-mode = <1>;
  	rockchip,hw-tshut-polarity = <0>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0004-arm64-dts-rockchip-Add-analog-audio-on-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0004-arm64-dts-rockchip-Add-analog-audio-on-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From ae25f92a09abb7dd16a9ad3b74e0c105b385f214 Mon Sep 17 00:00:00 2001
-Message-Id: <ae25f92a09abb7dd16a9ad3b74e0c105b385f214.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <ae25f92a09abb7dd16a9ad3b74e0c105b385f214.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:38 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add analog audio on ODROID-M1
@@ -98,5 +98,5 @@ index 94e839c9afab..634c1bd80b4e 100644
  
  &pmu_io_domains {
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0005-arm64-dts-rockchip-Enable-vop2-and-hdmi-tx-on-ODROID.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0005-arm64-dts-rockchip-Enable-vop2-and-hdmi-tx-on-ODROID.patch
@@ -1,7 +1,7 @@
 From 3a1be3d8719ef6335385d4e5e456371e7bf7383f Mon Sep 17 00:00:00 2001
-Message-Id: <3a1be3d8719ef6335385d4e5e456371e7bf7383f.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <3a1be3d8719ef6335385d4e5e456371e7bf7383f.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:39 +0200
 Subject: [PATCH] arm64: dts: rockchip: Enable vop2 and hdmi tx on ODROID-M1
@@ -93,5 +93,5 @@ index 634c1bd80b4e..126b893048fe 100644
 +	};
 +};
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0006-arm64-dts-rockchip-Enable-HDMI-audio-on-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0006-arm64-dts-rockchip-Enable-HDMI-audio-on-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From ded87dc761951205b8b9ba8ee4081e28a850a3db Mon Sep 17 00:00:00 2001
-Message-Id: <ded87dc761951205b8b9ba8ee4081e28a850a3db.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <ded87dc761951205b8b9ba8ee4081e28a850a3db.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:40 +0200
 Subject: [PATCH] arm64: dts: rockchip: Enable HDMI audio on ODROID-M1.
@@ -44,5 +44,5 @@ index 126b893048fe..ac4e94d18feb 100644
  	rockchip,trcm-sync-tx-only;
  	status = "okay";
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0007-arm64-dts-rockchip-Enable-the-GPU-on-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0007-arm64-dts-rockchip-Enable-the-GPU-on-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From 13438a717627cae086cc3a1126552cffa2f4bd16 Mon Sep 17 00:00:00 2001
-Message-Id: <13438a717627cae086cc3a1126552cffa2f4bd16.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <13438a717627cae086cc3a1126552cffa2f4bd16.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:41 +0200
 Subject: [PATCH] arm64: dts: rockchip: Enable the GPU on ODROID-M1
@@ -33,5 +33,5 @@ index ac4e94d18feb..e4b7699d3eea 100644
  	avdd-0v9-supply = <&vdda0v9_image>;
  	avdd-1v8-supply = <&vcca1v8_image>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0008-arm64-dts-rockchip-Enable-the-USB-2.0-ports-on-ODROI.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0008-arm64-dts-rockchip-Enable-the-USB-2.0-ports-on-ODROI.patch
@@ -1,7 +1,7 @@
 From 0f0a85a289b4d0fbd5c39eb5ddbb681a37ad490c Mon Sep 17 00:00:00 2001
-Message-Id: <0f0a85a289b4d0fbd5c39eb5ddbb681a37ad490c.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <0f0a85a289b4d0fbd5c39eb5ddbb681a37ad490c.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:42 +0200
 Subject: [PATCH] arm64: dts: rockchip: Enable the USB 2.0 ports on ODROID-M1
@@ -107,5 +107,5 @@ index e4b7699d3eea..2e4cc20bd676 100644
  	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
  	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0009-arm64-dts-rockchip-Enable-the-USB-3.0-ports-on-ODROI.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0009-arm64-dts-rockchip-Enable-the-USB-3.0-ports-on-ODROI.patch
@@ -1,7 +1,7 @@
 From d8abc451c669a8fd36b31db5cb96ec49da819124 Mon Sep 17 00:00:00 2001
-Message-Id: <d8abc451c669a8fd36b31db5cb96ec49da819124.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <d8abc451c669a8fd36b31db5cb96ec49da819124.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:43 +0200
 Subject: [PATCH] arm64: dts: rockchip: Enable the USB 3.0 ports on ODROID-M1
@@ -110,5 +110,5 @@ index 2e4cc20bd676..9a84a7e76d7a 100644
  	status = "okay";
  };
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0010-arm64-dts-rockchip-Add-SATA-support-to-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0010-arm64-dts-rockchip-Add-SATA-support-to-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From 2f6d4521403932ca22cb4dabef9033f1d52232ba Mon Sep 17 00:00:00 2001
-Message-Id: <2f6d4521403932ca22cb4dabef9033f1d52232ba.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <2f6d4521403932ca22cb4dabef9033f1d52232ba.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:44 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add SATA support to ODROID-M1
@@ -44,5 +44,5 @@ index 9a84a7e76d7a..bd24ccf94e76 100644
  	bus-width = <8>;
  	max-frequency = <200000000>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0011-arm64-dts-rockchip-Add-PCIEe-v3-nodes-to-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0011-arm64-dts-rockchip-Add-PCIEe-v3-nodes-to-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From 1572a9c5d9fa9f654fbc1909528ae5940ad34aa3 Mon Sep 17 00:00:00 2001
-Message-Id: <1572a9c5d9fa9f654fbc1909528ae5940ad34aa3.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <1572a9c5d9fa9f654fbc1909528ae5940ad34aa3.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:45 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add PCIEe v3 nodes to ODROID-M1
@@ -76,5 +76,5 @@ index bd24ccf94e76..2f685c606bb9 100644
  		pmic_int_l: pmic-int-l {
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0012-arm64-dts-rockchip-Add-IR-receiver-node-to-ODROID-M1.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0012-arm64-dts-rockchip-Add-IR-receiver-node-to-ODROID-M1.patch
@@ -1,7 +1,7 @@
 From b2eae73eeb32dd9383571de6af18fc8bd39aac3a Mon Sep 17 00:00:00 2001
-Message-Id: <b2eae73eeb32dd9383571de6af18fc8bd39aac3a.1678107917.git.stefan@agner.ch>
-In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
-References: <d388735d551e09b00317a509859fca51776b9826.1678107917.git.stefan@agner.ch>
+Message-ID: <b2eae73eeb32dd9383571de6af18fc8bd39aac3a.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
 From: Aurelien Jarno <aurelien@aurel32.net>
 Date: Fri, 30 Sep 2022 07:12:46 +0200
 Subject: [PATCH] arm64: dts: rockchip: Add IR receiver node to ODROID-M1
@@ -50,5 +50,5 @@ index 2f685c606bb9..59ecf868dbd0 100644
  		led_power_pin: led-power-pin {
  			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 -- 
-2.39.2
+2.41.0
 

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0013-hwrng-add-Rockchip-SoC-hwrng-driver.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0013-hwrng-add-Rockchip-SoC-hwrng-driver.patch
@@ -1,0 +1,323 @@
+From 08264b26ac568035ff04bcccc5c47d4a5d50f93b Mon Sep 17 00:00:00 2001
+Message-ID: <08264b26ac568035ff04bcccc5c47d4a5d50f93b.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+From: Aurelien Jarno <aurelien@aurel32.net>
+Date: Mon, 28 Nov 2022 19:47:17 +0100
+Subject: [PATCH] hwrng: add Rockchip SoC hwrng driver
+
+Rockchip SoCs used to have a random number generator as part of their
+crypto device, and support for it has to be added to the corresponding
+driver. However newer Rockchip SoCs like the RK356x have an independent
+True Random Number Generator device. This patch adds a driver for it,
+greatly inspired from the downstream driver.
+
+The TRNG device does not seem to have a signal conditionner and the FIPS
+140-2 test returns a lot of failures. They can be reduced by increasing
+RK_RNG_SAMPLE_CNT, in a tradeoff between quality and speed. This value
+has been adjusted to get ~90% of successes and the quality value has
+been set accordingly.
+
+Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+[conservatively estimate quality as per review feedback]
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/char/hw_random/Kconfig        |  14 ++
+ drivers/char/hw_random/Makefile       |   1 +
+ drivers/char/hw_random/rockchip-rng.c | 250 ++++++++++++++++++++++++++
+ 3 files changed, 265 insertions(+)
+ create mode 100644 drivers/char/hw_random/rockchip-rng.c
+
+diff --git a/drivers/char/hw_random/Kconfig b/drivers/char/hw_random/Kconfig
+index 3da8e85f8aae..8e5c88504f72 100644
+--- a/drivers/char/hw_random/Kconfig
++++ b/drivers/char/hw_random/Kconfig
+@@ -549,6 +549,20 @@ config HW_RANDOM_CN10K
+ 	 To compile this driver as a module, choose M here.
+ 	 The module will be called cn10k_rng. If unsure, say Y.
+ 
++config HW_RANDOM_ROCKCHIP
++        tristate "Rockchip True Random Number Generator"
++        depends on HW_RANDOM && (ARCH_ROCKCHIP || COMPILE_TEST)
++        depends on HAS_IOMEM
++        default HW_RANDOM
++        help
++          This driver provides kernel-side support for the True Random Number
++          Generator hardware found on some Rockchip SoC like RK3566 or RK3568.
++
++          To compile this driver as a module, choose M here: the
++          module will be called rockchip-rng.
++
++          If unsure, say Y.
++
+ endif # HW_RANDOM
+ 
+ config UML_RANDOM
+diff --git a/drivers/char/hw_random/Makefile b/drivers/char/hw_random/Makefile
+index 3e948cf04476..b7e989535fd6 100644
+--- a/drivers/char/hw_random/Makefile
++++ b/drivers/char/hw_random/Makefile
+@@ -47,3 +47,4 @@ obj-$(CONFIG_HW_RANDOM_XIPHERA) += xiphera-trng.o
+ obj-$(CONFIG_HW_RANDOM_ARM_SMCCC_TRNG) += arm_smccc_trng.o
+ obj-$(CONFIG_HW_RANDOM_CN10K) += cn10k-rng.o
+ obj-$(CONFIG_HW_RANDOM_POLARFIRE_SOC) += mpfs-rng.o
++obj-$(CONFIG_HW_RANDOM_ROCKCHIP) += rockchip-rng.o
+diff --git a/drivers/char/hw_random/rockchip-rng.c b/drivers/char/hw_random/rockchip-rng.c
+new file mode 100644
+index 000000000000..9b7b334d6410
+--- /dev/null
++++ b/drivers/char/hw_random/rockchip-rng.c
+@@ -0,0 +1,250 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * rockchip-rng.c True Random Number Generator driver for Rockchip SoCs
++ *
++ * Copyright (c) 2018, Fuzhou Rockchip Electronics Co., Ltd.
++ * Copyright (c) 2022, Aurelien Jarno
++ * Authors:
++ *  Lin Jinhan <troy.lin@rock-chips.com>
++ *  Aurelien Jarno <aurelien@aurel32.net>
++ */
++#include <linux/clk.h>
++#include <linux/hw_random.h>
++#include <linux/io.h>
++#include <linux/iopoll.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/of_platform.h>
++#include <linux/pm_runtime.h>
++#include <linux/reset.h>
++#include <linux/slab.h>
++
++#define RK_RNG_AUTOSUSPEND_DELAY	100
++#define RK_RNG_MAX_BYTE			32
++#define RK_RNG_POLL_PERIOD_US		100
++#define RK_RNG_POLL_TIMEOUT_US		10000
++
++/*
++ * TRNG collects osc ring output bit every RK_RNG_SAMPLE_CNT time. The value is
++ * a tradeoff between speed and quality and has been adjusted to get a quality
++ * of ~900 (~90% of FIPS 140-2 successes).
++ */
++#define RK_RNG_SAMPLE_CNT		1000
++
++/* TRNG registers from RK3568 TRM-Part2, section 5.4.1 */
++#define TRNG_RST_CTL			0x0004
++#define TRNG_RNG_CTL			0x0400
++#define TRNG_RNG_CTL_LEN_64_BIT		(0x00 << 4)
++#define TRNG_RNG_CTL_LEN_128_BIT	(0x01 << 4)
++#define TRNG_RNG_CTL_LEN_192_BIT	(0x02 << 4)
++#define TRNG_RNG_CTL_LEN_256_BIT	(0x03 << 4)
++#define TRNG_RNG_CTL_OSC_RING_SPEED_0	(0x00 << 2)
++#define TRNG_RNG_CTL_OSC_RING_SPEED_1	(0x01 << 2)
++#define TRNG_RNG_CTL_OSC_RING_SPEED_2	(0x02 << 2)
++#define TRNG_RNG_CTL_OSC_RING_SPEED_3	(0x03 << 2)
++#define TRNG_RNG_CTL_ENABLE		BIT(1)
++#define TRNG_RNG_CTL_START		BIT(0)
++#define TRNG_RNG_SAMPLE_CNT		0x0404
++#define TRNG_RNG_DOUT_0			0x0410
++#define TRNG_RNG_DOUT_1			0x0414
++#define TRNG_RNG_DOUT_2			0x0418
++#define TRNG_RNG_DOUT_3			0x041c
++#define TRNG_RNG_DOUT_4			0x0420
++#define TRNG_RNG_DOUT_5			0x0424
++#define TRNG_RNG_DOUT_6			0x0428
++#define TRNG_RNG_DOUT_7			0x042c
++
++struct rk_rng {
++	struct hwrng rng;
++	void __iomem *base;
++	struct reset_control *rst;
++	int clk_num;
++	struct clk_bulk_data *clk_bulks;
++};
++
++/* The mask determine the bits that are updated */
++static void rk_rng_write_ctl(struct rk_rng *rng, u32 val, u32 mask)
++{
++	writel_relaxed((mask << 16) | val, rng->base + TRNG_RNG_CTL);
++}
++
++static int rk_rng_init(struct hwrng *rng)
++{
++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
++	u32 reg;
++	int ret;
++
++	/* start clocks */
++	ret = clk_bulk_prepare_enable(rk_rng->clk_num, rk_rng->clk_bulks);
++	if (ret < 0) {
++		dev_err((struct device *) rk_rng->rng.priv,
++			"Failed to enable clks %d\n", ret);
++		return ret;
++	}
++
++	/* set the sample period */
++	writel(RK_RNG_SAMPLE_CNT, rk_rng->base + TRNG_RNG_SAMPLE_CNT);
++
++	/* set osc ring speed and enable it */
++	reg = TRNG_RNG_CTL_LEN_256_BIT |
++		   TRNG_RNG_CTL_OSC_RING_SPEED_0 |
++		   TRNG_RNG_CTL_ENABLE;
++	rk_rng_write_ctl(rk_rng, reg, 0xffff);
++
++	return 0;
++}
++
++static void rk_rng_cleanup(struct hwrng *rng)
++{
++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
++	u32 reg;
++
++	/* stop TRNG */
++	reg = 0;
++	rk_rng_write_ctl(rk_rng, reg, 0xffff);
++
++	/* stop clocks */
++	clk_bulk_disable_unprepare(rk_rng->clk_num, rk_rng->clk_bulks);
++}
++
++static int rk_rng_read(struct hwrng *rng, void *buf, size_t max, bool wait)
++{
++	struct rk_rng *rk_rng = container_of(rng, struct rk_rng, rng);
++	u32 reg;
++	int ret = 0;
++	int i;
++
++	pm_runtime_get_sync((struct device *) rk_rng->rng.priv);
++
++	/* Start collecting random data */
++	reg = TRNG_RNG_CTL_START;
++	rk_rng_write_ctl(rk_rng, reg, reg);
++
++	ret = readl_poll_timeout(rk_rng->base + TRNG_RNG_CTL, reg,
++				 !(reg & TRNG_RNG_CTL_START),
++				 RK_RNG_POLL_PERIOD_US,
++				 RK_RNG_POLL_TIMEOUT_US);
++	if (ret < 0)
++		goto out;
++
++	/* Read random data stored in the registers */
++	ret = min_t(size_t, max, RK_RNG_MAX_BYTE);
++	for (i = 0; i < ret; i += 4) {
++		*(u32 *)(buf + i) = readl_relaxed(rk_rng->base + TRNG_RNG_DOUT_0 + i);
++	}
++
++out:
++	pm_runtime_mark_last_busy((struct device *) rk_rng->rng.priv);
++	pm_runtime_put_sync_autosuspend((struct device *) rk_rng->rng.priv);
++
++	return ret;
++}
++
++static int rk_rng_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct rk_rng *rk_rng;
++	int ret;
++
++	rk_rng = devm_kzalloc(dev, sizeof(struct rk_rng), GFP_KERNEL);
++	if (!rk_rng)
++		return -ENOMEM;
++
++	rk_rng->base = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(rk_rng->base))
++		return PTR_ERR(rk_rng->base);
++
++	rk_rng->clk_num = devm_clk_bulk_get_all(dev, &rk_rng->clk_bulks);
++	if (rk_rng->clk_num < 0)
++		return dev_err_probe(dev, rk_rng->clk_num,
++				     "Failed to get clks property\n");
++
++	rk_rng->rst = devm_reset_control_array_get(&pdev->dev, false, false);
++	if (IS_ERR(rk_rng->rst))
++		return dev_err_probe(dev, PTR_ERR(rk_rng->rst),
++				     "Failed to get reset property\n");
++
++	reset_control_assert(rk_rng->rst);
++	udelay(2);
++	reset_control_deassert(rk_rng->rst);
++
++	platform_set_drvdata(pdev, rk_rng);
++
++	rk_rng->rng.name = dev_driver_string(dev);
++#ifndef CONFIG_PM
++	rk_rng->rng.init = rk_rng_init;
++	rk_rng->rng.cleanup = rk_rng_cleanup;
++#endif
++	rk_rng->rng.read = rk_rng_read;
++	rk_rng->rng.priv = (unsigned long) dev;
++	rk_rng->rng.quality = 512;
++
++	pm_runtime_set_autosuspend_delay(dev, RK_RNG_AUTOSUSPEND_DELAY);
++	pm_runtime_use_autosuspend(dev);
++	pm_runtime_enable(dev);
++
++	ret = devm_hwrng_register(dev, &rk_rng->rng);
++	if (ret)
++		return dev_err_probe(&pdev->dev, ret, "Failed to register Rockchip hwrng\n");
++
++	dev_info(&pdev->dev, "Registered Rockchip hwrng\n");
++
++	return 0;
++}
++
++static int rk_rng_remove(struct platform_device *pdev)
++{
++	pm_runtime_disable(&pdev->dev);
++
++	return 0;
++}
++
++#ifdef CONFIG_PM
++static int rk_rng_runtime_suspend(struct device *dev)
++{
++	struct rk_rng *rk_rng = dev_get_drvdata(dev);
++
++	rk_rng_cleanup(&rk_rng->rng);
++
++	return 0;
++}
++
++static int rk_rng_runtime_resume(struct device *dev)
++{
++	struct rk_rng *rk_rng = dev_get_drvdata(dev);
++
++	return rk_rng_init(&rk_rng->rng);
++}
++#endif
++
++static const struct dev_pm_ops rk_rng_pm_ops = {
++	SET_RUNTIME_PM_OPS(rk_rng_runtime_suspend,
++				rk_rng_runtime_resume, NULL)
++	SET_SYSTEM_SLEEP_PM_OPS(pm_runtime_force_suspend,
++				pm_runtime_force_resume)
++};
++
++static const struct of_device_id rk_rng_dt_match[] = {
++	{
++		.compatible = "rockchip,rk3568-rng",
++	},
++	{},
++};
++
++MODULE_DEVICE_TABLE(of, rk_rng_dt_match);
++
++static struct platform_driver rk_rng_driver = {
++	.driver	= {
++		.name	= "rockchip-rng",
++		.pm	= &rk_rng_pm_ops,
++		.of_match_table = rk_rng_dt_match,
++	},
++	.probe	= rk_rng_probe,
++	.remove = rk_rng_remove,
++};
++
++module_platform_driver(rk_rng_driver);
++
++MODULE_DESCRIPTION("Rockchip True Random Number Generator driver");
++MODULE_AUTHOR("Lin Jinhan <troy.lin@rock-chips.com>, Aurelien Jarno <aurelien@aurel32.net>");
++MODULE_LICENSE("GPL v2");
+-- 
+2.41.0
+

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0014-arm64-dts-rockchip-add-DT-entry-for-RNG-to-RK356x.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0014-arm64-dts-rockchip-add-DT-entry-for-RNG-to-RK356x.patch
@@ -1,0 +1,38 @@
+From 8bb36ab21d6c44a8a0d690b3c9df3d5efe2f3685 Mon Sep 17 00:00:00 2001
+Message-ID: <8bb36ab21d6c44a8a0d690b3c9df3d5efe2f3685.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+From: Aurelien Jarno <aurelien@aurel32.net>
+Date: Mon, 28 Nov 2022 19:47:18 +0100
+Subject: [PATCH] arm64: dts: rockchip: add DT entry for RNG to RK356x
+
+Enable the just added Rockchip RNG driver for RK356x SoCs.
+
+Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+---
+ arch/arm64/boot/dts/rockchip/rk356x.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+index 164708f1eb67..4be94ff45180 100644
+--- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+@@ -1770,6 +1770,15 @@ usb2phy1_otg: otg-port {
+ 		};
+ 	};
+ 
++	rng: rng@fe388000 {
++		compatible = "rockchip,rk3568-rng";
++		reg = <0x0 0xfe388000 0x0 0x4000>;
++		clocks = <&cru CLK_TRNG_NS>, <&cru HCLK_TRNG_NS>;
++		clock-names = "trng_clk", "trng_hclk";
++		resets = <&cru SRST_TRNG_NS>;
++		reset-names = "reset";
++	};
++
+ 	pinctrl: pinctrl {
+ 		compatible = "rockchip,rk3568-pinctrl";
+ 		rockchip,grf = <&grf>;
+-- 
+2.41.0
+

--- a/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0015-dt-bindings-RNG-Add-Rockchip-RNG-bindings.patch
+++ b/buildroot-external/board/hardkernel/odroid-m1/patches/linux/0015-dt-bindings-RNG-Add-Rockchip-RNG-bindings.patch
@@ -1,0 +1,85 @@
+From 1ad5bd5a1d8e83728745e3e12e620061f8281f19 Mon Sep 17 00:00:00 2001
+Message-ID: <1ad5bd5a1d8e83728745e3e12e620061f8281f19.1688490481.git.stefan@agner.ch>
+In-Reply-To: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+References: <d388735d551e09b00317a509859fca51776b9826.1688490481.git.stefan@agner.ch>
+From: Aurelien Jarno <aurelien@aurel32.net>
+Date: Mon, 28 Nov 2022 19:47:16 +0100
+Subject: [PATCH] dt-bindings: RNG: Add Rockchip RNG bindings
+
+Add the RNG bindings for the RK3568 SoC from Rockchip
+
+Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+---
+ .../bindings/rng/rockchip,rk3568-rng.yaml     | 60 +++++++++++++++++++
+ 1 file changed, 60 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/rng/rockchip,rk3568-rng.yaml
+
+diff --git a/Documentation/devicetree/bindings/rng/rockchip,rk3568-rng.yaml b/Documentation/devicetree/bindings/rng/rockchip,rk3568-rng.yaml
+new file mode 100644
+index 000000000000..c2f5ef69cf07
+--- /dev/null
++++ b/Documentation/devicetree/bindings/rng/rockchip,rk3568-rng.yaml
+@@ -0,0 +1,60 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/rng/rockchip,rk3568-rng.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Rockchip TRNG
++
++description: True Random Number Generator for some Rockchip SoCs
++
++maintainers:
++  - Aurelien Jarno <aurelien@aurel32.net>
++
++properties:
++  compatible:
++    enum:
++      - rockchip,rk3568-rng
++
++  reg:
++    maxItems: 1
++
++  clocks:
++    items:
++      - description: TRNG clock
++      - description: TRNG AHB clock
++
++  clock-names:
++    items:
++      - const: trng_clk
++      - const: trng_hclk
++
++  resets:
++    maxItems: 1
++
++required:
++  - compatible
++  - reg
++  - clocks
++  - clock-names
++  - resets
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/clock/rk3568-cru.h>
++    bus {
++      #address-cells = <2>;
++      #size-cells = <2>;
++
++      rng@fe388000 {
++        compatible = "rockchip,rk3568-rng";
++        reg = <0x0 0xfe388000 0x0 0x4000>;
++        clocks = <&cru CLK_TRNG_NS>, <&cru HCLK_TRNG_NS>;
++        clock-names = "trng_clk", "trng_hclk";
++        resets = <&cru SRST_TRNG_NS>;
++      };
++    };
++
++...
+-- 
+2.41.0
+


### PR DESCRIPTION
Add patches for the hardware random number generator part of the Rockchip RK3568. This avoids dbus-broker startup failure seen on some Hardkernel ODROID-M1 devices due to lack of entropy.