### PR TITLE
Improve service ordering for udisks2.service

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/udisks2.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/udisks2.service.d/haos.conf
@@ -1,5 +1,7 @@
 [Unit]
 DefaultDependencies=no
+Requires=dbus.socket systemd-journald.socket
+After=dbus.socket systemd-journald.socket
 
 [Service]
 Environment="DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket"


### PR DESCRIPTION
UDisks2 requires D-Bus and the systemd-journald, hence add the two sockets as a requirement and order the service after them.