### PR TITLE
Use maintained GitHub Action to upload release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,84 +75,13 @@ jobs:
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
             -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            -v "/build/output" \
             haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.validate_release.outputs.version_dev }} ${{ matrix.board.defconfig }}
 
-      - name: Upload disk image
-        if: ${{ matrix.board.id != 'ova' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload release assets
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.img.xz
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.img.xz
-          asset_content_type: application/x-xz
-
-      - name: Upload rauc update
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.raucb
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.raucb
-          asset_content_type: application/octet-stream
-
-      - name: Upload ova image
-        if: ${{ matrix.board.id == 'ova' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.ova
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.ova
-          asset_content_type: application/x-tar
-
-      - name: Upload qcow2 image
-        if: ${{ matrix.board.id == 'ova' || matrix.board.id == 'generic-aarch64' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.qcow2.xz
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.qcow2.xz
-          asset_content_type: application/x-xz
-
-      - name: Upload vdi image
-        if: ${{ matrix.board.id == 'ova' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vdi.zip
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vdi.zip
-          asset_content_type: application/zip
-
-      - name: Upload vhdx image
-        if: ${{ matrix.board.id == 'ova' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vhdx.zip
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vhdx.zip
-          asset_content_type: application/zip
-
-      - name: Upload vmdk image
-        if: ${{ matrix.board.id == 'ova' || matrix.board.id == 'generic-aarch64' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ github.workspace }}/release/haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vmdk.zip
-          asset_name: haos_${{ matrix.board.id }}-${{ needs.validate_release.outputs.version }}.vmdk.zip
-          asset_content_type: application/zip
+          asset_path: output/images/haos_*
 
   bump_version:
     name: Bump dev version to ${{ needs.validate_release.outputs.version }}


### PR DESCRIPTION
The chosen GitHub action sets MIME types correctly and allows glob uploads. Also upload directly from the output directory. This way we can remove the unnecessary copy to the release directory in the future.