### PR TITLE
Use hosted GitHub Action runners

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,7 +11,7 @@ jobs:
   prepare:
     if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-dev-build') }}
     name: Prepare build
-    runs-on: [ "ubuntu-20.04" ]
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: read
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    runs-on: ${{ matrix.board.runner }}
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Define git reference
@@ -98,14 +98,34 @@ jobs:
           echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
           echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
 
+      - name: Free space on build drive
+        run: |
+          # Inspired by https://github.com/easimon/maximize-build-space/blob/v7/action.yml
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Make sure cache action can restore this lcoation
+          sudo mkdir /mnt/cache
+          sudo chown -R runner:runner /mnt/cache
+
+      - name: Cache downloads
+        uses: actions/cache@v3
+        with:
+          path: /mnt/cache/dl
+          key: haos-dl
+
+      - name: Cache object files
+        uses: actions/cache@v3
+        with:
+          path: /mnt/cache/cc
+          key: haos-cc-${{ matrix.board.architecture }}
+
       - name: Build
         run: |
           BUILDER_UID="$(id -u)"
           BUILDER_GID="$(id -g)"
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
-            -v "${{ matrix.board.runner }}-build-cache:/cache" \
-            -v "/build/output" \
+            -v "/mnt/cache:/cache" \
             haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.prepare.outputs.version_dev }} ${{ matrix.board.defconfig }}
 
       - name: Upload images
@@ -113,12 +133,13 @@ jobs:
         with:
           rsh: -q
           switches: -aW
-          path: release/
+          path: output/images/haos_*
           remote_path: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.prepare.outputs.version_main }}.${{ needs.prepare.outputs.version_dev }}/
           remote_host: ${{ secrets.DEV_HOST }}
           remote_port: ${{ secrets.DEV_PORT }}
           remote_user: ${{ secrets.DEV_USERNAME }}
           remote_key: ${{ secrets.DEV_SSH_KEY }}
+
 
   bump_version:
     name: Bump dev channel version

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -2,97 +2,97 @@
   {
     "id": "ova",
     "defconfig": "ova",
-    "runner": "x86-64-runner",
+    "architecture": "x86-64",
     "label": "board/ova"
   },
   {
     "id": "generic-x86-64",
     "defconfig": "generic_x86_64",
-    "runner": "x86-64-runner",
+    "architecture": "x86-64",
     "label": "board/generic-x86-64"
   },
   {
     "id": "generic-aarch64",
     "defconfig": "generic_aarch64",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/generic-aarch64"
   },
   {
     "id": "khadas-vim3",
     "defconfig": "khadas_vim3",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/khadas"
   },
   {
     "id": "odroid-c2",
     "defconfig": "odroid_c2",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/odroid"
   },
   {
     "id": "odroid-c4",
     "defconfig": "odroid_c4",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/odroid"
   },
   {
     "id": "odroid-m1",
     "defconfig": "odroid_m1",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/odroid"
   },
   {
     "id": "odroid-n2",
     "defconfig": "odroid_n2",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/odroid"
   },
   {
     "id": "odroid-xu4",
     "defconfig": "odroid_xu4",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/odroid"
   },
   {
     "id": "rpi2",
     "defconfig": "rpi2",
-    "runner": "arm-runner",
+    "architecture": "arm",
     "label": "board/raspberrypi"
   },
   {
     "id": "rpi3",
     "defconfig": "rpi3",
-    "runner": "arm-runner",
+    "architecture": "arm",
     "label": "board/raspberrypi"
   },
   {
     "id": "rpi3-64",
     "defconfig": "rpi3_64",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/raspberrypi"
   },
   {
     "id": "rpi4",
     "defconfig": "rpi4",
-    "runner": "arm-runner",
+    "architecture": "arm",
     "label": "board/raspberrypi"
   },
   {
     "id": "rpi4-64",
     "defconfig": "rpi4_64",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/raspberrypi"
   },
   {
     "id": "yellow",
     "defconfig": "yellow",
-    "runner": "aarch64-runner",
+    "architecture": "aarch64",
     "label": "board/yellow"
   },
   {
     "id": "tinker",
     "defconfig": "tinker",
-    "runner": "arm-runner",
+    "architecture": "arm",
     "label": "board/tinker"
   }
 ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate_release:
     name: Validate release
-    runs-on: [ "ubuntu-20.04" ]
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.version_check.outputs.version }}
       version_dev: ${{ steps.version_check.outputs.version_dev }}
@@ -49,11 +49,11 @@ jobs:
     needs: validate_release
     strategy:
       matrix: ${{ fromJson(needs.validate_release.outputs.matrix) }}
-    runs-on: ${{ matrix.board.runner }}
+    runs-on: ubuntu-22.04
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - name: Checkout source
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -68,13 +68,34 @@ jobs:
           echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
           echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
 
+      - name: Free space on build drive
+        run: |
+          # Inspired by https://github.com/easimon/maximize-build-space/blob/v7/action.yml
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          # Make sure cache action can restore this lcoation
+          sudo mkdir /mnt/cache
+          sudo chown -R runner:runner /mnt/cache
+
+      - name: Cache downloads
+        uses: actions/cache@v3
+        with:
+          path: /mnt/cache/dl
+          key: haos-dl
+
+      - name: Cache object files
+        uses: actions/cache@v3
+        with:
+          path: /mnt/cache/cc
+          key: haos-cc-${{ matrix.board.architecture }}
+
       - name: Build
         run: |
           BUILDER_UID="$(id -u)"
           BUILDER_GID="$(id -g)"
           docker run --rm --privileged -v "${GITHUB_WORKSPACE}:/build" \
             -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
-            -v "${{ matrix.board.runner }}-build-cache:/cache" \
+            -v "/mnt/cache:/cache" \
             haos-builder make BUILDDIR=/build VERSION_DEV=${{ needs.validate_release.outputs.version_dev }} ${{ matrix.board.defconfig }}
 
       - name: Upload release assets

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 BUILDDIR:=$(shell pwd)
-RELEASE_DIR = $(BUILDDIR)/release
 
 BUILDROOT=$(BUILDDIR)/buildroot
 BUILDROOT_EXTERNAL=$(BUILDDIR)/buildroot-external
@@ -23,9 +22,6 @@ endif
 
 all: $(TARGETS)
 
-$(RELEASE_DIR):
-	mkdir -p $(RELEASE_DIR)
-
 savedefconfig:
 	@echo "config $*"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "savedefconfig"
@@ -34,10 +30,9 @@ $(TARGETS_CONFIG): %-config:
 	@echo "config $*"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$*_defconfig"
 
-$(TARGETS): %: $(RELEASE_DIR) %-config
+$(TARGETS): %: %-config
 	@echo "build $@"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) VERSION_DEV=$(VERSION_DEV)
-	cp -f $(O)/images/haos_* $(RELEASE_DIR)/
 
 	# Do not clean when building for one target
 ifneq ($(words $(filter $(TARGETS),$(MAKECMDGOALS))), 1)


### PR DESCRIPTION
Instead of using self-hosted runners use the hosted GitHub Action
runners. Officially the GitHub Action runners have a maximum of 14GB
free space available. However, a single Home Assistant OS build requires
up to 23GB (the ova board seems to require most because of the various
output image formats).

This PR adds some tricks to make use of the GitHub hosted GitHub Action
runners still, namely:
- Build and download cache is stored on /mnt which offers an additional
  10GB of disk space
- Some tools/SDKs on the runner get removed from the root disk to free
  up some disk space.

Other than that building on the hosted GitHub Action runners seems
straight forward. The build time is significantly longer (from ~30
minutes on the current AMD Ryzen 7950X build machine to 1 hours 30
minutes even with cache). But since we can build all boards in parallel
now, the overall build time will likely be shorted.
