### PR TITLE
Allow dev builds in forks

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -143,7 +143,7 @@ jobs:
 
   bump_version:
     name: Bump dev channel version
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'home-assistant/operating-system' }}
     needs: [ build, prepare ]
     runs-on: [ "ubuntu-20.04" ]
 


### PR DESCRIPTION
Do not try to bump Home Assistant OS dev channel version in forks. This allows to use the dev pipeline in forks.