### PR TITLE
Add grub.cfg operand for headless x86_64 devices

### DIFF
--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -60,7 +60,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition nomodeset"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1


### PR DESCRIPTION
 - updated grub.cfg with nomodeset for headless boot issue resolution.