### PR TITLE
Create builder group only if required

### DIFF
--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -6,9 +6,14 @@ USER="root"
 # Run dockerd
 dockerd -s vfs &> /dev/null &
 
-# Setup local user
-if [ "${BUILDER_UID:-0}" -ne 0 ] && [ "${BUILDER_GID:-0}" -ne 0 ]; then
+
+# Setup local group, if not existing
+if [ "${BUILDER_GID:-0}" -ne 0 ] && ! getent group "${BUILDER_GID:-0}"; then
   groupadd -g "${BUILDER_GID}" builder
+fi
+
+# Setup local user
+if [ "${BUILDER_UID:-0}" -ne 0 ]; then
   useradd -m -u "${BUILDER_UID}" -g "${BUILDER_GID}" -G docker,sudo builder
   echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
   # Make sure cache is accessible by builder


### PR DESCRIPTION
In case a group with the same id as used outside the container already exists, do not create a group inside the container.

It seems that GitHub Action runners started to use primary group id 999 which is the default group id used by the Docker daemon.