### PR TITLE
Remove checkout twice in dev build workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/checkout@v3
       - name: Get Major/Minor version
         id: version_main
         run: |


### PR DESCRIPTION
Remove call actions/checkout twice in dev build workflow.