### PR TITLE
Separate build step when loading container images

### DIFF
--- a/buildroot-external/package/hassio/hassio.mk
+++ b/buildroot-external/package/hassio/hassio.mk
@@ -16,14 +16,15 @@ HASSIO_CONTAINER_IMAGES_ARCH = supervisor dns audio cli multicast observer core
 define HASSIO_CONFIGURE_CMDS
 	# Deploy only landing page for "core" by setting version to "landingpage"
 	curl -s $(HASSIO_VERSION_URL) | jq '.core = "landingpage"' > $(@D)/stable.json
+endef
 
+define HASSIO_BUILD_CMDS
 	$(Q)mkdir -p $(@D)/images
 	$(Q)mkdir -p $(HASSIO_DL_DIR)
 	$(foreach image,$(HASSIO_CONTAINER_IMAGES_ARCH),\
 		$(BR2_EXTERNAL_HASSOS_PATH)/package/hassio/fetch-container-image.sh \
 			$(BR2_PACKAGE_HASSIO_ARCH) $(BR2_PACKAGE_HASSIO_MACHINE) $(@D)/stable.json $(image) "$(HASSIO_DL_DIR)" "$(@D)/images"
 	)
-
 endef
 
 HASSIO_INSTALL_IMAGES = YES


### PR DESCRIPTION
Separate fetching the current release and loading the container image into separate build steps. This allows to manually later the version json file for testing.