### PR TITLE
Don't combine GitHub action caches

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: /mnt/cache/cc
-          key: haos-cc-${{ matrix.board.architecture }}
+          key: haos-cc-${{ matrix.board.id }}
 
       - name: Build
         run: |
@@ -150,64 +150,13 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: /mnt/cache/dl
-          key: haos-dl-${{ matrix.board.id }}-${{ github.run_id }}
+          key: haos-dl-${{ github.run_id }}
 
       - name: Cache build
         uses: actions/cache/save@v3
         with:
           path: /mnt/cache/cc
           key: haos-cc-${{ matrix.board.id }}-${{ github.run_id }}
-
-  combine_cache:
-    name: Combine caches for ${{ matrix.board.id }}
-    needs: [ build, prepare ]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    runs-on: ubuntu-22.04
-    concurrency: ${{ github.run_id }}
-
-    steps:
-      - name: Prepare /mnt
-        run: |
-          sudo mkdir /mnt/cache
-          sudo chown -R runner:runner /mnt/cache
-
-      - name: Restore global downloads cache
-        uses: actions/cache/restore@v3
-        with:
-          path: /mnt/cache/dl
-          key: haos-dl-${{ github.run_id }}
-      - name: Restore board specific downloads cache
-        id: cache-dl-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: /mnt/cache/dl
-          key: haos-dl-${{ matrix.board.id }}-${{ github.run_id }}
-      - name: Upload new global downloads cache
-        if: ${{ steps.cache-dl-restore.outputs.cache-hit == 'true' }}
-        uses: actions/cache/save@v3
-        with:
-          path: /mnt/cache/dl
-          key: haos-dl-${{ github.run_id }}-with-${{ matrix.board.id }}
-
-      - name: Restore global build cache
-        uses: actions/cache/restore@v3
-        with:
-          path: /mnt/cache/cc
-          key: haos-cc-${{ matrix.board.architecture }}-${{ github.run_id }}
-      - name: Restore board specific build cache
-        id: cache-cc-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: /mnt/cache/cc
-          key: haos-cc-${{ matrix.board.id }}-${{ github.run_id }}
-      - name: Upload new global build cache
-        if: ${{ steps.cache-cc-restore.outputs.cache-hit == 'true' }}
-        uses: actions/cache/save@v3
-        with:
-          path: /mnt/cache/cc
-          key: haos-cc-${{ matrix.board.architecture }}-${{ github.run_id }}-with-${{ matrix.board.id }}
 
   bump_version:
     name: Bump dev channel version


### PR DESCRIPTION
It turns out that the way concurrency works in GitHub action doesn't allow to queue up multiple pending jobs. As soon as a second job gets pending, the previous pending jobs get cancelled. So this does not allow to sequentially run all cache combine jobs as we hoped for.

Let's use a single download cache and per board build cache for now.