### PR TITLE
Delete Bluetooth device cache regularly

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Remove Bluetooth cache entries older than one week
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'find /var/lib/bluetooth/*/cache -mindepth 1 -type f -mtime +7  -exec rm {} \;'
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateUsers=no
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@default @file-system @basic-io @system-service
+

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
@@ -3,7 +3,7 @@ Description=Remove Bluetooth cache entries older than one week
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'find /var/lib/bluetooth/*/cache -mindepth 1 -type f -mtime +7  -exec rm {} \;'
+ExecStart=/bin/sh -c 'find /var/lib/bluetooth/*/cache -mindepth 1 -type f -atime +7  -exec rm {} \;'
 PrivateDevices=yes
 PrivateNetwork=yes
 PrivateUsers=no

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.timer
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Remove Bluetooth cache entries
+ConditionPathExistsGlob=/var/lib/bluetooth/*/cache
+
+[Timer]
+OnCalendar=weekly
+AccuracySec=1h
+Persistent=true
+RandomizedDelaySec=6000
+
+[Install]
+WantedBy=timers.target
+


### PR DESCRIPTION
Delete stale Bluetooth devices from the BlueZ device cache every week. This makes sure that the overlay partition doesn't run out of inodes which has happened in real world scenarios where many new Bluetooth devices are discovered.

BlueZ maintains these files on a best effort base. So removing them while BlueZ is running should be safe. Their modification timestamp gets updated regularly (on each connect), so deleting cache entries older than 7 days essentially deletes all the entries of devices which haven't been used the last 7 days.

An alternative considered  was to lower BlueZ GATT caching (e.g. by using Cache=yes instead of always, to cache only paired devices). However, this would hurt performance and battery lifetime of Bluetooth devices due to additional unnecessary GATT attributes reads. This is in particular true for Bluetooth 5.1 devices which support the Database Hash charactristic. Caching has also helped reliability with intermittent connections (see
https://github.com/bluez/bluez/issues/191).

More importantly, besides the GATT attribute cache the same files are also used to cache the device names as well. This is independent of the above mentioned GATT cache configuration (see device_store_cached_name in BlueZ). So disabling the GATT caching alone wouldn't solve the particular problem we are facing.

See also: https://github.com/home-assistant/operating-system/issues/2752