### PR TITLE
Create swapfile even when not using the multi-user.target

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-swapfile.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-swapfile.service
@@ -10,4 +10,4 @@ Type=oneshot
 ExecStart=/usr/libexec/haos-swapfile
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=swap.target


### PR DESCRIPTION
Pull in the swapfile creation service haos-swapfile.service when swap.target is reached. This makes sure the service is started even when other targets are used (e.g. rescue.target).