### PR TITLE
Use latest Network device naming scheme

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -60,7 +60,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/asus/tinker/uboot-boot.ush
+++ b/buildroot-external/board/asus/tinker/uboot-boot.ush
@@ -20,7 +20,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -22,7 +22,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -22,7 +22,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
@@ -20,7 +20,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -22,7 +22,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-xu4/uboot-boot.ush
@@ -24,7 +24,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -22,7 +22,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=squashfs ro rootwait"

--- a/buildroot-external/board/nabucasa/green/uboot-boot.ush
+++ b/buildroot-external/board/nabucasa/green/uboot-boot.ush
@@ -25,7 +25,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -60,7 +60,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 net.naming-scheme=v250 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -21,7 +21,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -21,7 +21,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HassOS system A/B
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro"

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -21,7 +21,7 @@ test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3
 test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=true"
 
 # HassOS bootargs
-setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait net.naming-scheme=v250 systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
+setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # Red Button pressed?
 if gpio input GPIO27; then


### PR DESCRIPTION
This essentially reverts #2380, making sure that Home Assistant OS uses systemd's latest network naming scheme.

We stick to a certain naming scheme to make sure NetworkManager still applies the network configuration (which is matched by network interface name by default).

With Supervisor [PR #4476](https://github.com/home-assistant/supervisor/pull/4476) NetworkManager uses udev path by default. With this we can safely enable the new interface naming and NetworkManager will still apply the configuration based on udev path correctly.