### PR TITLE
Update and fix containerd v1.6.22

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/containerd/config.toml
+++ b/buildroot-external/rootfs-overlay/etc/containerd/config.toml
@@ -1,0 +1,15 @@
+version = 2
+disabled_plugins = [
+  "io.containerd.snapshotter.v1.aufs",
+  "io.containerd.snapshotter.v1.devmapper",
+  "io.containerd.snapshotter.v1.zfs",
+  "io.containerd.internal.v1.opt",
+  "io.containerd.tracing.processor.v1.otlp",
+  "io.containerd.internal.v1.tracing"
+]
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+cni_conf_dir = "/run/cni/net.d"
+
+[plugins."io.containerd.grpc.v1.cri".cni]
+conf_dir = "/run/cni/net.d"


### PR DESCRIPTION
The containerd update to v1.6.22 had to be reverted since it cause startup hangs (see #2744).

It turns out that the CRI plug-in can't write the CNI configuration to its default configuration under `/etc` since we are using squashfs. While this has been always a problem, the error hasn't caused issues until v1.6.22.

This change introduces a uses `config.toml` file to configure CNI to be stored under `/run` instead.

Note, this currently leads to an error message as well, namely:

```
failed to load cni during init, please check CRI plugin status before setting up network for pods" error="cni config load failed: no network config found in /run/cni/net.d: cni plugin not initialized: failed to load cni config
```

However, this seems to be the case on Desktop installations of Docker too, and is seemingly intended behavior.

While at it, also disable some unnecessary containerd plug-ins.