### PR TITLE
Add fsfreeze support for QEMU/KVM/Proxmox installations

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/qemu-guest.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/qemu-guest.service.d/haos.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/libexec/qemu-ga -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0 --fsfreeze-hook /usr/libexec/haos-freeze-hook

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-freeze-hook
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-freeze-hook
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+action="$1"
+
+if [ "${action}" == "freeze" ]; then
+	echo "File system freeze requested, freezing Home Assistant"
+	ha backups freeze
+elif [ "${action}" == "thaw" ]; then
+	echo "File system thaw requested, thawing Home Assistant"
+	ha backups thaw
+else
+	echo "Unknown action ${action}"
+fi
+

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-freeze-hook
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-freeze-hook
@@ -3,10 +3,10 @@ set -e
 
 action="$1"
 
-if [ "${action}" == "freeze" ]; then
+if [ "${action}" = "freeze" ]; then
 	echo "File system freeze requested, freezing Home Assistant"
 	ha backups freeze
-elif [ "${action}" == "thaw" ]; then
+elif [ "${action}" = "thaw" ]; then
 	echo "File system thaw requested, thawing Home Assistant"
 	ha backups thaw
 else


### PR DESCRIPTION
Add fsfreeze scripts which calls the new Supervisor API to freeze Home Assistant Core and add-ons which support the backup freeze scripts (`backup_pre` and `backup_post`).

This allows to create safe snapshots with databases running.