### PR TITLE
RAUC update: Use verity bundle format

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -2,6 +2,9 @@
 compatible={{ env "ota_compatible" }}
 version={{ env "ota_version" }}
 
+[bundle]
+format=verity
+
 [hooks]
 filename=hook
 hooks=install-check;


### PR DESCRIPTION
Move from the current plain format to the new verity bundle format. This requires at least HAOS 10.4 to work. The Supervisor will make sure to update to the latest minor release of the previous major release, so updating will work in the regular use case.