### PR TITLE
Fix fsfreeze support on OVA

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/qemu-guest.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/qemu-guest.service.d/haos.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/libexec/qemu-ga -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0 --fsfreeze-hook /usr/libexec/haos-freeze-hook
+ExecStart=/usr/libexec/qemu-ga -m virtio-serial -p /dev/virtio-ports/org.qemu.guest_agent.0 --fsfreeze-hook=/usr/libexec/haos-freeze-hook


### PR DESCRIPTION
Pass the script argument properly to make sure the script gets actually called from the QEMU guest agent.