### PR TITLE
Set containerd root explicitly (#2476)

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/containerd/config.toml
+++ b/buildroot-external/rootfs-overlay/etc/containerd/config.toml
@@ -1,4 +1,7 @@
 version = 2
+
+root = "/mnt/data/docker/containerd/daemon"
+
 disabled_plugins = [
   "io.containerd.internal.v1.opt",
   "io.containerd.tracing.processor.v1.otlp",


### PR DESCRIPTION
With the move to Docker 23 containerd stores its metadata no longer undernath the Docker data directory but at its default location at /var/lib/containerd. Previously Docker passed a containerd configuration toml file which explicitly set the metadata root underneath Docker's data directory.

On Home Assistant OS, the new location /var/lib/containerd is on a tmpfs file system. For unknown reasons, it seems that if containerd's root directory is on a tmpfs this leads to significantly more syscalls and hence CPU load.

Change the metadata location to be on the data partition again. Since containerd is treated separately from Docker these days, use a new root directory under /mnt/data for containerd as well. With this, the CPU load of containerd is back to normal.