### PR TITLE
Revert "RAUC update: Use verity bundle format (#2786)"

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -2,9 +2,6 @@
 compatible={{ env "ota_compatible" }}
 version={{ env "ota_version" }}
 
-[bundle]
-format=verity
-
 [hooks]
 filename=hook
 hooks=install-check;


### PR DESCRIPTION
This reverts commit 0ebcdcb9dc8d2471bcacf0049e93f1ad0bf12a37.

We only added verity support in HAOS 10.4. However, we currently have an issue since HAOS 10.3 where certain Realtek network cards don't work anymore (see issue #2630). For this systems, it won't be possible to upgrade, even when using the console.

Only having two HAOS releases creates a rather "narrow" upgrade path accross all boards. There could be more issues where this proves problematic.

Currently we don't use any new feature of the verity format. Therefor let's postpone the move to the new format for a couple of releases for now.