### PR TITLE
Drop uploading to the old development build server

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -200,19 +200,6 @@ jobs:
             ${{ needs.prepare.outputs.build_container_image }} \
             make BUILDDIR=/build ${{ matrix.board.defconfig }}
 
-      - name: Upload images
-        if: ${{ github.event_name != 'release' }}
-        uses: burnett01/rsync-deployments@5.2
-        with:
-          rsh: -q
-          switches: -aW
-          path: output/images/haos_*
-          remote_path: ${{ secrets.DEV_TARGET_PATH }}/${{ needs.prepare.outputs.version_full }}/
-          remote_host: ${{ secrets.DEV_HOST }}
-          remote_port: ${{ secrets.DEV_PORT }}
-          remote_user: ${{ secrets.DEV_USERNAME }}
-          remote_key: ${{ secrets.DEV_SSH_KEY }}
-
       - name: Upload artifacts
         if: ${{ github.event_name != 'release' }}
         env:


### PR DESCRIPTION
With the new development build uploads on R2 working, we no longer need to upload development builds to the old server. Drop the build step.