### PR TITLE
Use Docker 24 during build time

### DIFF
--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -22,7 +22,7 @@ container=$(docker run --privileged -e DOCKER_TLS_CERTDIR="" \
 	-v "${build_dir}/data/":/data \
 	-v "${build_dir}/data/docker/":/var/lib/docker \
 	-v "${build_dir}":/build \
-	-d docker:23.0-dind --storage-driver overlay2)
+	-d docker:24.0-dind --storage-driver overlay2)
 
 docker exec "${container}" sh /build/dind-import-containers.sh
 


### PR DESCRIPTION
Use the same Docker version we deploy on Home Assistant OS during build.