### PR TITLE
Add Home Assistant Green to GitHub infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,7 @@ body:
         - rpi4-64  (Raspberry Pi 4/400 64-bit OS)
         - tinker (ASUS Tinker Board/Tinker Board S)
         - yellow (Home Assistant Yellow)
+        - green (Home Assistant Green)
       description: >
         Can be found in [Settings -> System -> Repairs -> System Information](https://my.home-assistant.io/redirect/system_health/). It is listed as the `Board` value.
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,8 @@ categories:
     label: 'board/raspberrypi'
   - title: 'Home Assistant Yellow'
     label: 'board/yellow'
+  - title: 'Home Assistant Green'
+    label: 'board/green'
   - title: 'Open Virtual Appliance'
     label: 'board/ova'
   - title: 'Generic x86-64'


### PR DESCRIPTION
Add Home Assistant Green to the issue template and release drafter configuration.