### PR TITLE
Fix deployment on dev branch

### DIFF
--- a/buildroot-external/meta
+++ b/buildroot-external/meta
@@ -5,4 +5,4 @@ VERSION_SUFFIX="dev0"
 HASSOS_NAME="Home Assistant OS"
 HASSOS_ID="haos"
 
-DEPLOYMENT="production"
+DEPLOYMENT="development"


### PR DESCRIPTION
The deployment on dev channel should always be development. The change came in from the main branch backmerge where the wrong merge strategy has been used (the merge strategy "ort" along with option "ours" has been used, instead of the "ours" merge strategy). And since the deployment was a separate hunk, it resolved to the release branch.