### PR TITLE
Fix extraction of OVA image artifact in test step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract OS image
         run: |
-          unxz haos.qcow2.xz
+          unxz haos*.qcow2.xz
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract OS image
         run: |
-          unxz haos*.qcow2.xz
+          xz -dc haos*.qcow2.xz > haos.qcow2
 
       - name: Run tests
         run: |


### PR DESCRIPTION
If the test image is obtained from an artifact instead of downloading, its name contains the version as well, in that case we still need to use wildcard expansion.