### PR TITLE
Fix IPv6 routing failover for Thread (#2434)

### DIFF
--- a/buildroot-external/patches/linux/0001-ipv6-add-option-to-explicitly-enable-reachability-te.patch
+++ b/buildroot-external/patches/linux/0001-ipv6-add-option-to-explicitly-enable-reachability-te.patch
@@ -1,5 +1,5 @@
-From b9182b02829b158d55acc53a0bcec1ed667b2668 Mon Sep 17 00:00:00 2001
-Message-Id: <b9182b02829b158d55acc53a0bcec1ed667b2668.1680000784.git.stefan@agner.ch>
+From 5761ca22d64773b901f2578fad418bdefeb08b93 Mon Sep 17 00:00:00 2001
+Message-ID: <5761ca22d64773b901f2578fad418bdefeb08b93.1697750485.git.stefan@agner.ch>
 From: Stefan Agner <stefan@agner.ch>
 Date: Tue, 28 Mar 2023 12:02:10 +0200
 Subject: [PATCH] ipv6: add option to explicitly enable reachability test
@@ -38,7 +38,7 @@ index 658bfed1df8b..5147fd4c93ff 100644
  	tristate "IPv6: AH transformation"
  	select XFRM_AH
 diff --git a/net/ipv6/route.c b/net/ipv6/route.c
-index 0fdb03df2287..5e1e1f02f400 100644
+index 960ab43a49c4..89922091719c 100644
 --- a/net/ipv6/route.c
 +++ b/net/ipv6/route.c
 @@ -2210,7 +2210,8 @@ struct rt6_info *ip6_pol_route(struct net *net, struct fib6_table *table,
@@ -47,10 +47,10 @@ index 0fdb03df2287..5e1e1f02f400 100644
  	strict |= flags & RT6_LOOKUP_F_IGNORE_LINKSTATE;
 -	if (net->ipv6.devconf_all->forwarding == 0)
 +	if (net->ipv6.devconf_all->forwarding == 0 ||
-+	    IS_ENABLED(IPV6_REACHABILITY_PROBE))
++	    IS_ENABLED(CONFIG_IPV6_REACHABILITY_PROBE))
  		strict |= RT6_LOOKUP_F_REACHABLE;
  
  	rcu_read_lock();
 -- 
-2.40.0
+2.42.0
 


### PR DESCRIPTION
The patch added in #2434 is not working: IS_ENABLED requires the full config symbol including CONFIG_ prefix.

Fix the patch to make automatic IPv6 route failover depening on IPv6 reachability probes actually work.