### PR TITLE
Add udev rule to rpi-rf-mod package 

### DIFF
--- a/buildroot-external/package/rpi-rf-mod/82-rpi-rf-mod-leds.rules
+++ b/buildroot-external/package/rpi-rf-mod/82-rpi-rf-mod-leds.rules
@@ -1,0 +1,4 @@
+# make sure all rpi-rf-mod led nodes in /sys are generated with permissions so that addons
+# can access it (e.g. raspberrymatic)
+SUBSYSTEM=="leds", ACTION=="add", KERNEL=="rpi_rf_mod:*", RUN+="/bin/chmod -R g=u,o=u /sys%p"
+SUBSYSTEM=="leds", ACTION=="change", KERNEL=="rpi_rf_mod:*", ENV{TRIGGER}!="none", RUN+="/bin/chmod -R g=u,o=u /sys%p"

--- a/buildroot-external/package/rpi-rf-mod/rpi-rf-mod.mk
+++ b/buildroot-external/package/rpi-rf-mod/rpi-rf-mod.mk
@@ -57,6 +57,7 @@ define RPI_RF_MOD_INSTALL_TARGET_CMDS
 	if [[ -n "$(RPI_RF_MOD_DTS_FILE_ALT)" ]]; then \
 		$(INSTALL) -D -m 0644 $(@D)/buildroot-external/package/rpi-rf-mod/dts/$(RPI_RF_MOD_DTS_FILE_ALT).dtbo $(BINARIES_DIR)/; \
 	fi
+	$(INSTALL) -D -m 644 $(RPI_RF_MOD_PKGDIR)/82-rpi-rf-mod-leds.rules $(TARGET_DIR)/lib/udev/rules.d/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
This PR adds an udev rule to set write permissions for the led device nodes for the RPI-RF-MOD hardware (HomeMatic RF module) so that newer versions of addons (e.g. raspberrymatic) using dedicated users to access these leds nodes can still modify these leds during runtime.
