### PR TITLE
ODROID-M1: Fix environment read from SD card (#2822)

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
@@ -1,5 +1,5 @@
-
 part start mmc ${devnum} hassos-bootstate mmc_env
+mmc dev ${devnum}
 
 setenv loadbootstate " \
     echo 'loading env...'; \


### PR DESCRIPTION
Make sure the environment can be read and written to SD card as well. This makes sure that first boot detection works properly too when booting from SD card.