### PR TITLE
Add checkout step to bump_version job in the build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -255,6 +255,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
     - name: Initialize git
       uses: home-assistant/actions/helpers/git-init@master
       with:


### PR DESCRIPTION
It's required both for the artifact index and to run the RPi Imager bump local action.