### PR TITLE
Print object cache statistics before upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -221,18 +221,18 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: output/images/haos_*
 
+      - name: Print cache stats
+        run: |
+          echo "Cache size: $(du -sh /mnt/cache/cc)"
+          echo "Files total: $(find /mnt/cache/cc -mindepth 1 -type f | wc -l)"
+          echo "Old files: $(find /mnt/cache/cc -mindepth 1 -type f -not -anewer output/Makefile | wc -l)"
+
       - name: "Save cache: object files"
         if: github.ref == 'refs/heads/dev'
         uses: actions/cache/save@v3
         with:
           path: /mnt/cache/cc
           key: haos-cc-${{ matrix.board.id }}-${{ github.run_id }}
-
-      - name: Print cache stats
-        run: |
-          echo "Cache size: $(du -sh /mnt/cache/cc)"
-          echo "Files total: $(find /mnt/cache/cc -mindepth 1 -type f | wc -l)"
-          echo "Old files: $(find /mnt/cache/cc -mindepth 1 -type f -not -anewer output/Makefile | wc -l)"
 
       - name: Upload ova image to artifacts for test job
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Print the object cache statistics before uploading them to the action cache. The action cache accesses all files, this makes the statistics of files used during build not useful.