### PR TITLE
Always use environment for bump_version job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,7 +250,7 @@ jobs:
   bump_version:
     name: Bump ${{ needs.prepare.outputs.channel }} channel version
     if: ${{ github.repository == 'home-assistant/operating-system' }}
-    environment: "${{ github.event_name == 'release' && needs.prepare.outputs.channel || '' }}"
+    environment: ${{ needs.prepare.outputs.channel }}
     needs: [ build, prepare ]
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
As discussed here: https://github.com/home-assistant/operating-system/pull/2855#discussion_r1368533496