### PR TITLE
Improve handling of timeouts in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def shell_json(target, strategy) -> callable:
     strategy.transition("shell")
     shell = target.get_driver("ShellDriver")
 
-    def get_json_response(command, *, timeout=60) -> dict:
+    def get_json_response(command, *, timeout=None) -> dict:
         return json.loads("\n".join(shell.run_check(command, timeout=timeout)))
 
     return get_json_response

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+timeout_method = signal

--- a/tests/qemu-strategy.yaml
+++ b/tests/qemu-strategy.yaml
@@ -12,11 +12,12 @@ targets:
           nic: user,model=virtio-net-pci
           disk: disk-image
           bios: bios
-      - ShellDriver:
+      - CustomTimeoutShellDriver:
           login_prompt: 'homeassistant login: '
           username: 'root'
           prompt: '# '
           login_timeout: 300
+          command_timeout: 300
       - QEMUShellStrategy: {}
 
 tools:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 labgrid==23.0.3
 pytest==7.2.2
 pytest-dependency==0.5.1
+pytest-timeout==2.2.0

--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.dependency()
-@pytest.mark.timeout(450)
+@pytest.mark.timeout(600)
 def test_init(shell):
     def check_container_running(container_name):
         out = shell.run_check(

--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -8,7 +8,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.dependency()
-@pytest.mark.timeout(350)
+@pytest.mark.timeout(450)
 def test_init(shell):
     def check_container_running(container_name):
         out = shell.run_check(

--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -1,10 +1,14 @@
 import logging
 from time import sleep
 
+import pytest
+
 
 _LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.dependency()
+@pytest.mark.timeout(350)
 def test_init(shell):
     def check_container_running(container_name):
         out = shell.run_check(
@@ -13,35 +17,37 @@ def test_init(shell):
         return "running" in out
 
     # wait for important containers first
-    for _ in range(20):
+    while True:
         if check_container_running("homeassistant") and check_container_running("hassio_supervisor"):
             break
 
-        sleep(5)
+        sleep(1)
 
     # wait for system ready
-    for _ in range(20):
+    while True:
         output = "\n".join(shell.run_check("ha os info || true"))
         if "System is not ready" not in output:
             break
 
-        sleep(5)
+        sleep(1)
 
     output = shell.run_check("ha os info")
     _LOGGER.info("%s", "\n".join(output))
 
+
+@pytest.mark.dependency(depends=["test_init"])
 def test_dmesg(shell):
     output = shell.run_check("dmesg")
     _LOGGER.info("%s", "\n".join(output))
 
 
+@pytest.mark.dependency(depends=["test_init"])
 def test_supervisor_logs(shell):
     output = shell.run_check("ha su logs")
     _LOGGER.info("%s", "\n".join(output))
 
 
+@pytest.mark.dependency(depends=["test_init"])
 def test_systemctl_status(shell):
-    output = shell.run_check(
-        "systemctl --no-pager -l status -a || true", timeout=90
-    )
+    output = shell.run_check("systemctl --no-pager -l status -a || true")
     _LOGGER.info("%s", "\n".join(output))

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -16,7 +16,7 @@ def stash() -> dict:
 
 
 @pytest.mark.dependency()
-@pytest.mark.timeout(450)
+@pytest.mark.timeout(600)
 def test_start_supervisor(shell, shell_json):
     def check_container_running(container_name):
         out = shell.run_check(f"docker container inspect -f '{{{{.State.Status}}}}' {container_name} || true")

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -16,7 +16,7 @@ def stash() -> dict:
 
 
 @pytest.mark.dependency()
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(450)
 def test_start_supervisor(shell, shell_json):
     def check_container_running(container_name):
         out = shell.run_check(f"docker container inspect -f '{{{{.State.Status}}}}' {container_name} || true")

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -87,7 +87,7 @@ def test_update_supervisor(shell_json):
             sleep(1)
 
 
-@pytest.mark.dependency(depends=["test_update_supervisor"])
+@pytest.mark.dependency(depends=["test_check_supervisor"])
 def test_supervisor_is_updated(shell_json):
     supervisor_info = shell_json("ha supervisor info --no-progress --raw-json")
     data = supervisor_info.get("data")


### PR DESCRIPTION
Make timeout handling in tests more transparent. Added a custom shell driver that allows to define global timeout for commands in the config file, and replaced for/sleep constructs with infinite loops that will be eventually terminated by pytest-timeout plugin. Current timeouts taken from last runs on Github CI with some extra headroom.