### PR TITLE
Upload artifacts index even on partial builds

### DIFF
--- a/.github/workflows/artifacts-index.yaml
+++ b/.github/workflows/artifacts-index.yaml
@@ -89,5 +89,6 @@ jobs:
             -H "Content-Type: application/json" \
             --data '{"files": [
               "https://os-artifacts.home-assistant.io/index.html",
-              "https://os-artifacts.home-assistant.io/index.json"
+              "https://os-artifacts.home-assistant.io/index.json",
+              "https://os-artifacts.home-assistant.io/indexes/${{ github.event.inputs.version }}.json"
             ] }'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,7 +243,7 @@ jobs:
 
   update_index:
     name: Update artifacts index
-    if: ${{ github.event_name != 'release' }}
+    if: ${{ github.event_name != 'release' && (always() && steps.prepare.outcome == 'success') }}
     needs: [ build, prepare ]
     uses: home-assistant/operating-system/.github/workflows/artifacts-index.yaml@dev
     with:


### PR DESCRIPTION
Make sure that the artifacts index always gets updated. This allows to use builds even when not all of them are available.