### PR TITLE
Revert "Upload artifacts index even on partial builds (#2901)"

### DIFF
--- a/.github/workflows/artifacts-index.yaml
+++ b/.github/workflows/artifacts-index.yaml
@@ -89,6 +89,5 @@ jobs:
             -H "Content-Type: application/json" \
             --data '{"files": [
               "https://os-artifacts.home-assistant.io/index.html",
-              "https://os-artifacts.home-assistant.io/index.json",
-              "https://os-artifacts.home-assistant.io/indexes/${{ github.event.inputs.version }}.json"
+              "https://os-artifacts.home-assistant.io/index.json"
             ] }'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -245,7 +245,7 @@ jobs:
 
   update_index:
     name: Update artifacts index
-    if: ${{ github.event_name != 'release' && (always() && steps.prepare.outcome == 'success') }}
+    if: ${{ github.event_name != 'release' }}
     needs: [ build, prepare ]
     uses: home-assistant/operating-system/.github/workflows/artifacts-index.yaml@dev
     with:


### PR DESCRIPTION
This reverts commit 49f26c3d2e685e3f7e9135f8e10efaa6a40526df.

The steps is not valid in that context. Let's revert the commit to get a green build first.