### PR TITLE
Improve Bluetooth cache cleanup command

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-bt-cache.service
@@ -3,7 +3,7 @@ Description=Remove Bluetooth cache entries older than one week
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'find /var/lib/bluetooth/*/cache -mindepth 1 -type f -atime +7  -exec rm {} \;'
+ExecStart=/bin/sh -c 'find /var/lib/bluetooth/*/cache -mindepth 1 -type f -atime +7 -delete'
 PrivateDevices=yes
 PrivateNetwork=yes
 PrivateUsers=no


### PR DESCRIPTION
Use the find's delete flag to delete the files instead of spanning a shell for each file.