### PR TITLE
fix: disable uas for wavlink adaptor

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u
+dwc_otg.lpm_enable=0 console=tty1 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u


### PR DESCRIPTION
this adaptor doesn't work and the hard disk is not able to work correctly. Need to disable UAS to fallback to the usb-storage module