### PR TITLE
Bump Raspberry Pi firmware to latest stable version

### DIFF
--- a/scripts/update-kernel-rpi.sh
+++ b/scripts/update-kernel-rpi.sh
@@ -17,3 +17,9 @@ sed -i "s/| \(Raspberry Pi.*\|Home Assistant Yellow\) | .* |/| \1 | $2 |/g" Docu
 git commit -m "RaspberryPi: Update kernel $2 - $1" "${defconfigs[@]}" Documentation/kernel.md
 
 ./scripts/check-kernel-patches.sh
+
+echo
+echo "WARNING: bumping RPi kernel usually requires bump of rpi-firmware"
+echo "package to version from the corresponding branch in raspberrypi/firmware"
+echo "repository (which is usually the stable branch), namely because the DT"
+echo "overlays are copied from this repository"


### PR DESCRIPTION
Also added a little warning to the RPi kernel bump script, so the future me/us don't do the same mistake as I did.

* buildroot 20ea6bedda...a48cc458e7 (1):
  > package/rpi-firmware: bump to version for stable_20231030 kernel