### PR TITLE
Generate self-signed certificates for development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -166,8 +166,12 @@ jobs:
           RAUC_CERTIFICATE: ${{ secrets.RAUC_CERTIFICATE }}
           RAUC_PRIVATE_KEY: ${{ secrets.RAUC_PRIVATE_KEY }}
         run: |
-          echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
-          echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
+          if [ -z "${RAUC_CERTIFICATE}" ] || [ -z "${RAUC_KEY}" ]; then
+              echo "::warning:: RAUC certificate or key is missing. Building with a self-signed certificate!"
+          else
+              echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
+              echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
+          fi
 
       - name: Free space on build drive
         run: |

--- a/buildroot-external/scripts/post-build.sh
+++ b/buildroot-external/scripts/post-build.sh
@@ -41,6 +41,7 @@ install_tini_docker
 
 
 # Setup RAUC
+prepare_rauc_signing
 write_rauc_config
 install_rauc_certs
 install_bootloader_config

--- a/buildroot-external/scripts/rauc.sh
+++ b/buildroot-external/scripts/rauc.sh
@@ -35,16 +35,17 @@ function install_rauc_certs() {
     local cert="/build/cert.pem"
 
     if [ "${DEPLOYMENT}" == "development" ]; then
+        # Contains development and release certificate
         cp "${BR2_EXTERNAL_HASSOS_PATH}/ota/dev-ca.pem" "${TARGET_DIR}/etc/rauc/keyring.pem"
-
-        # Add local self-signed certificate (if not trusted by chain it is a
-        # self-signed certificate)
-        if ! openssl verify -CAfile "${BR2_EXTERNAL_HASSOS_PATH}/ota/dev-ca.pem" -no-CApath "${cert}"; then
-            echo "Adding self-signed certificate to keyring."
-            openssl x509 -in "${cert}" -text >> "${TARGET_DIR}/etc/rauc/keyring.pem"
-        fi
     else
         cp "${BR2_EXTERNAL_HASSOS_PATH}/ota/rel-ca.pem" "${TARGET_DIR}/etc/rauc/keyring.pem"
+    fi
+
+    # Add local self-signed certificate (if not trusted by the dev or release
+    # certificate it is a self-signed certificate, dev-ca.pem contains both)
+    if ! openssl verify -CAfile "${BR2_EXTERNAL_HASSOS_PATH}/ota/dev-ca.pem" -no-CApath "${cert}"; then
+        echo "Adding self-signed certificate to keyring."
+        openssl x509 -in "${cert}" -text >> "${TARGET_DIR}/etc/rauc/keyring.pem"
     fi
 }
 


### PR DESCRIPTION
To simplify development generate a self-signed certificate on first build. Also make sure that the self-signed certificate is being added the RAUC keyring so that manual updates can be performed.