### PR TITLE
Do not start hciuart.service if krnbt is used

### DIFF
--- a/buildroot-external/package/pi-bluetooth/hciuart.service
+++ b/buildroot-external/package/pi-bluetooth/hciuart.service
@@ -5,6 +5,7 @@ After=dev-serial1.device
 
 [Service]
 Type=forking
+ExecCondition=/bin/sh -c "if [ "$(cat /proc/device-tree/$(cat /proc/device-tree/aliases/bluetooth)/bluetooth/status)" == "okay" ]; then exit 1; fi"
 ExecStart=/usr/bin/btuart
 
 [Install]


### PR DESCRIPTION
Avoid starting (and failing to start) hciuart.service if krnbt is used. This avoid unnecessary failed services showing up.