### PR TITLE
Remove kernel HCI driver if no WiFi/Bluetooth module present (#2944)

### DIFF
--- a/buildroot-external/package/pi-bluetooth/hcidisable.service
+++ b/buildroot-external/package/pi-bluetooth/hcidisable.service
@@ -4,7 +4,7 @@ ConditionPathExists=!/sys/bus/sdio/devices/mmc1:0001:1
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/rmmod hci_uart
+ExecStart=/usr/sbin/modprobe -r hci_uart
 
 [Install]
 WantedBy=hassos-hardware.target

--- a/buildroot-external/package/pi-bluetooth/hcidisable.service
+++ b/buildroot-external/package/pi-bluetooth/hcidisable.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remove HCI kernel driver if WiFi/Bluetooth module is not present
+ConditionPathExists=!/sys/bus/sdio/devices/mmc1:0001:1
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/rmmod hci_uart
+
+[Install]
+WantedBy=hassos-hardware.target

--- a/buildroot-external/package/pi-bluetooth/pi-bluetooth.mk
+++ b/buildroot-external/package/pi-bluetooth/pi-bluetooth.mk
@@ -12,6 +12,7 @@ PI_BLUETOOTH_LICENSE_FILES = debian/copyright
 define PI_BLUETOOTH_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/etc/systemd/system/hassos-hardware.target.wants
 	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/hciuart.service $(TARGET_DIR)/usr/lib/systemd/system/
+	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/hcidisable.service $(TARGET_DIR)/usr/lib/systemd/system/
 	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/bthelper@.service $(TARGET_DIR)/usr/lib/systemd/system/
 
 	$(INSTALL) -d $(TARGET_DIR)/usr/bin


### PR DESCRIPTION
If the WiFi/Bluetooth module is not present on the SDIO bus, remove the HCI driver. This avoids hci0 interface to be present. Current Home Assistant Core versions show a Bluetooth device as soon as a hci device is present. With this change there won't be a Bluetooth device shown.