### PR TITLE
Backport support for Netgear AXE3000/A8000 and Comfast CF-952AX

### DIFF
--- a/buildroot-external/patches/linux/0005-wifi-mt76-mt7921u-backport-Comfast-CF-952AX-and-Netg.patch
+++ b/buildroot-external/patches/linux/0005-wifi-mt76-mt7921u-backport-Comfast-CF-952AX-and-Netg.patch
@@ -1,0 +1,30 @@
+From 65b2dcdb79a0bdf0f3ad432dfeb267979e2bd866 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Mon, 4 Dec 2023 11:53:06 +0100
+Subject: [PATCH] wifi: mt76: mt7921u: backport Comfast CF-952AX and Netgear
+ AXE3000 support
+
+This backports support of two mt7921u WiFi cards that only use differend
+USB VID/PID but should use the standard mainline driver and firmware too.
+---
+ drivers/net/wireless/mediatek/mt76/mt7921/usb.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/net/wireless/mediatek/mt76/mt7921/usb.c b/drivers/net/wireless/mediatek/mt76/mt7921/usb.c
+index 521bcd577640..67522be28c9a 100644
+--- a/drivers/net/wireless/mediatek/mt76/mt7921/usb.c
++++ b/drivers/net/wireless/mediatek/mt76/mt7921/usb.c
+@@ -14,6 +14,10 @@
+ 
+ static const struct usb_device_id mt7921u_device_table[] = {
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x0e8d, 0x7961, 0xff, 0xff, 0xff) },
++	/* Comfast CF-952AX - e766b7fd41cad2074e43da2e88fc970a88d2c239 backport */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x3574, 0x6211, 0xff, 0xff, 0xff) },
++	/* Netgear, Inc. [A8000,AXE3000] - 03eb52dd78cab08f13925aeec8315fbdbcba3253 backport */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x0846, 0x9060, 0xff, 0xff, 0xff) },
+ 	{ },
+ };
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Current mainline contains support for two more WiFi cards in the mt7921u driver that only use a proprietary VID/PID but are compatible with the standard driver. Backport support for those via a simple driver patch.

Fixes #2926