### PR TITLE
Remove Raspberry Pi 1/Zero from docs

### DIFF
--- a/Documentation/boards/README.md
+++ b/Documentation/boards/README.md
@@ -9,8 +9,6 @@ The following boards/devices are supported:
   - Pi 4 Model B ([1 GB](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/?variant=raspberry-pi-4-model-b-1gb), [2 GB](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/?variant=raspberry-pi-4-model-b-2gb), [4 GB](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/?variant=raspberry-pi-4-model-b-4gb) and [8 GB](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/?variant=raspberry-pi-4-model-b-8gb) model) 32-bit or 64-bit (recommended)
   - [Pi 3 Model B](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) and [B+](https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/) 32-bit or 64-bit (recommended)
   - [Pi 2](https://www.raspberrypi.com/products/raspberry-pi-2-model-b/) (not recommended)
-  - [Pi Zero-W](https://www.raspberrypi.com/products/raspberry-pi-zero-w/) (not recommended)
-  - [Pi](https://www.raspberrypi.com/products/raspberry-pi-1-model-b-plus/) (not recommended)
 - Hardkernel
   - [ODROID-C2](https://www.hardkernel.com/shop/odroid-c2/) (discontinued)
   - [ODROID-C4](https://www.hardkernel.com/shop/odroid-c4/)

--- a/Documentation/boards/raspberrypi/README.md
+++ b/Documentation/boards/raspberrypi/README.md
@@ -4,7 +4,6 @@
 
 | Device              | Release Date  | Support         | Config             |
 |---------------------|---------------|-----------------|--------------------|
-| Raspberry Pi B/B+/A+|2012/2014/2014 | not recommended | [rpi](../../../buildroot-external/configs/rpi_defconfig)              |
 | Raspberry Pi 2 B    |2015           | not recommended | [rpi2](../../../buildroot-external/configs/rpi2_defconfig)             |
 | Raspberry Pi 3 B/B+ |2016/2018      | yes             | [rpi3](../../../buildroot-external/configs/rpi3_defconfig) / [rpi3_64](../../../buildroot-external/configs/rpi3_64_defconfig) |
 | Raspberry Pi 4 B    |2019           | yes             | [rpi4](../../../buildroot-external/configs/rpi4_defconfig) / [rpi4_64](../../../buildroot-external/configs/rpi4_64_defconfig) |


### PR DESCRIPTION
Its support has been removed 2 years ago.