### PR TITLE
Remove duplicated step uploading ova QEMU image for the test job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -276,14 +276,6 @@ jobs:
             echo "| ${f} | $(du -b output/images/$f | cut -f1) | $(du -bh output/images/$f | cut -f1) |" >> $GITHUB_STEP_SUMMARY
           done
 
-      - name: Upload ova image to artifacts for the test job
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.board.id == 'ova' }}
-        with:
-          name: ova-image
-          path: |
-            output/images/haos_ova*.qcow2.xz
-
       - name: Upload OS image artifact
         uses: actions/upload-artifact@v4
         if: ${{ github.event_name != 'release' && needs.prepare.outputs.publish_build != 'true' && matrix.board.id != 'ova' }}
@@ -310,7 +302,8 @@ jobs:
 
       - name: Upload QEMU disk image artifact
         uses: actions/upload-artifact@v4
-        if: ${{ github.event_name != 'release' && needs.prepare.outputs.publish_build != 'true' && (matrix.board.id == 'generic-aarch64' || matrix.board.id == 'ova') }}
+        # Create artifact for ova every time - it's used by the called tests workflow
+        if: ${{ matrix.board.id == 'ova' || (github.event_name != 'release' && needs.prepare.outputs.publish_build != 'true' && matrix.board.id == 'generic-aarch64') }}
         with:
           name: haos_${{ matrix.board.id }}-${{ needs.prepare.outputs.version_full }}.qcow2.xz
           path: |
@@ -344,6 +337,8 @@ jobs:
     name: Test OS image
     needs: [ build, prepare ]
     uses: ./.github/workflows/test.yaml
+    with:
+      version: ${{ needs.prepare.outputs.version_full }}
 
   update_index:
     name: Update artifacts index

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ on:
         type: boolean
         default: true
       version:
-        description: Version of HAOS to test (used in name of the qcow2 image artifact)
+        description: Version of HAOS to test (as used in the name of the qcow2 image artifact)
         required: true
         type: string
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,10 @@ on:
         required: false
         type: boolean
         default: true
+      version:
+        description: Version of HAOS to test (used in name of the qcow2 image artifact)
+        required: true
+        type: string
 
 jobs:
   test:
@@ -58,7 +62,7 @@ jobs:
         if: ${{ inputs.use-artifact }}
         uses: actions/download-artifact@v4
         with:
-          name: ova-image
+          name: haos_ova-${{ inputs.version }}.qcow2.xz
 
       - name: Extract OS image
         run: |


### PR DESCRIPTION
Instead of uploading the file twice with a fixed name, upload it in the same step that is used for unpublished builds and pass the version string to the test job.