### PR TITLE
Generate self-signed certificate in the prepare step and archive it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.result }}
       build_container_image: ghcr.io/${{ github.repository_owner }}/haos-builder@${{ steps.build_haos_builder.outputs.digest }}
       publish_build: ${{ steps.check_publish.outputs.publish_build }}
+      self_signed_cert: ${{ steps.generate_signing_key.outputs.self_signed }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -153,6 +154,26 @@ jobs:
           cache-to: ghcr.io/${{ github.repository_owner }}/haos-builder:cache-${{ steps.version_main.outputs.version_main }}
           push: true
 
+      - name: Generate self-signed certificate
+        id: generate_signing_key
+        env:
+          RAUC_CERTIFICATE: ${{ secrets.RAUC_CERTIFICATE }}
+          RAUC_PRIVATE_KEY: ${{ secrets.RAUC_PRIVATE_KEY }}
+        if: env.RAUC_CERTIFICATE == '' || env.RAUC_PRIVATE_KEY == ''
+        run: |
+          echo "::warning:: RAUC certificate or key is missing in the repository secrets. Building with a public self-signed certificate!"
+          buildroot-external/scripts/generate-signing-key.sh cert.pem key.pem
+          echo "self_signed_cert=true" >> $GITHUB_OUTPUT
+
+      - name: Create signing key
+        uses: actions/upload-artifact@v4
+        if: steps.generate_signing_key.outcome == 'success'
+        with:
+          name: signing-key
+          path: |
+            cert.pem
+            key.pem
+
   build:
     name: Build for ${{ matrix.board.id }}
     permissions:
@@ -188,16 +209,19 @@ jobs:
           sed -i -E "s/(^VERSION_SUFFIX=\").*(\"$)/\1${VERSION_DEV}\2/" buildroot-external/meta
 
       - name: 'Add release PKI certs'
+        if: ${{ needs.prepare.outputs.self_signed_cert != 'true' }}
         env:
           RAUC_CERTIFICATE: ${{ secrets.RAUC_CERTIFICATE }}
           RAUC_PRIVATE_KEY: ${{ secrets.RAUC_PRIVATE_KEY }}
         run: |
-          if [ -z "${RAUC_CERTIFICATE}" ] || [ -z "${RAUC_PRIVATE_KEY}" ]; then
-              echo "::warning:: RAUC certificate or key is missing. Building with a self-signed certificate!"
-          else
-              echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
-              echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
-          fi
+          echo -e "-----BEGIN CERTIFICATE-----\n${RAUC_CERTIFICATE}\n-----END CERTIFICATE-----" > cert.pem
+          echo -e "-----BEGIN PRIVATE KEY-----\n${RAUC_PRIVATE_KEY}\n-----END PRIVATE KEY-----" > key.pem
+
+      - name: Get self-signed certificate from the prepare job
+        if: ${{ needs.prepare.outputs.self_signed_cert == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: signing-key
 
       - name: Free space on build drive
         run: |

--- a/buildroot-external/scripts/generate-signing-key.sh
+++ b/buildroot-external/scripts/generate-signing-key.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <cert_path> <key_path>"
+    exit 1
+fi
+
+cert=$1
+key=$2
+
+openssl req -x509 -newkey rsa:4096 -keyout "${key}" \
+                -out "${cert}" -days 3650 -nodes \
+                -subj "/O=HassOS/CN=HassOS Self-signed Development Certificate"

--- a/buildroot-external/scripts/rauc.sh
+++ b/buildroot-external/scripts/rauc.sh
@@ -8,9 +8,7 @@ function prepare_rauc_signing() {
 
     if [ ! -f "${key}" ]; then
         echo "Generating a self-signed certificate for development"
-        openssl req -x509 -newkey rsa:4096 -keyout "${key}" \
-                -out "${cert}" -days 3650 -nodes \
-                -subj "/O=HassOS/CN=HassOS Self-signed Development Certificate"
+        "${BR2_EXTERNAL_HASSOS_PATH}"/scripts/generate-signing-key.sh "${cert}" "${key}"
     fi
 }
 


### PR DESCRIPTION
Generate the certificate only once and make it available. The preferred option that doesn't generate warnings would be to use secrets in the repository config, in that case no certificate is generated or archived.