### PR TITLE
Suppress action-shellcheck warning from deprecated option

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Check shell scripts
       uses: ludeeus/action-shellcheck@2.0.0
       with:
-        ignore: buildroot
+        ignore_paths: buildroot
 
     - name: Check buildroot-external packages
       run: |


### PR DESCRIPTION
Use ignore_paths instead of ignore for the buildroot directory.