### PR TITLE
Remove rootfstype from RPi5 cmdline

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/rpi5-64/cmdline.txt
@@ -1,1 +1,1 @@
-zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty1 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=squashfs ro rauc.slot=A
+zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty1 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rauc.slot=A


### PR DESCRIPTION
Defining rootfstype is not necessary and removing it from cmdline would be more tricky than removing it from boot.scr on platforms that use UBoot if we eventually decide to switch to a different FS.