### PR TITLE
Fix github build workflow when using self_signed_certs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ steps.generate_matrix.outputs.result }}
       build_container_image: ghcr.io/${{ github.repository_owner }}/haos-builder@${{ steps.build_haos_builder.outputs.digest }}
       publish_build: ${{ steps.check_publish.outputs.publish_build }}
-      self_signed_cert: ${{ steps.generate_signing_key.outputs.self_signed }}
+      self_signed_cert: ${{ steps.generate_signing_key.outputs.self_signed_cert }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
Tried to build the project via github actions, over in my own fork, but the build would fail with an (unhelpful) error in the UI:

```
[Build for generic-x86-64]
Process completed with exit code 2.
```

Digging into the raw logs, I spotted the error was due to it being unable to load the self signed certs:
```
2024-01-10T01:03:32.5571208Z >>>   Executing post-build script /build/buildroot-external/scripts/post-build.sh
2024-01-10T01:03:32.5895973Z unable to load certificate
2024-01-10T01:03:32.5900110Z Adding self-signed certificate to keyring.
2024-01-10T01:03:32.5921613Z unable to load certificate
2024-01-10T01:03:32.5930444Z make[1]: *** [Makefile:753: target-finalize] Error 1
2024-01-10T01:03:32.5949481Z make[1]: Leaving directory '/build/buildroot'
2024-01-10T01:03:32.5961366Z make: *** [Makefile:33: generic_x86_64] Error 2
2024-01-10T01:03:33.9850236Z ##[error]Process completed with exit code 2.
```

I turned on debug logging, and checked the build step which generates the self signed certs:
```
2024-01-09T23:08:38.9250537Z ##[debug]Finishing: Add release PKI certs
2024-01-09T23:08:38.9258428Z ##[debug]Evaluating condition for step: 'Get self-signed certificate from the prepare job'
2024-01-09T23:08:38.9260917Z ##[debug]Evaluating: (success() && (needs.prepare.outputs.self_signed_cert == 'true'))
2024-01-09T23:08:38.9261791Z ##[debug]Evaluating And:
2024-01-09T23:08:38.9262432Z ##[debug]..Evaluating success:
2024-01-09T23:08:38.9263006Z ##[debug]..=> true
2024-01-09T23:08:38.9263565Z ##[debug]..Evaluating Equal:
2024-01-09T23:08:38.9264429Z ##[debug]....Evaluating Index:
2024-01-09T23:08:38.9265140Z ##[debug]......Evaluating Index:
2024-01-09T23:08:38.9265768Z ##[debug]........Evaluating Index:
2024-01-09T23:08:38.9266557Z ##[debug]..........Evaluating needs:
2024-01-09T23:08:38.9267134Z ##[debug]..........=> Object
2024-01-09T23:08:38.9267726Z ##[debug]..........Evaluating String:
2024-01-09T23:08:38.9268287Z ##[debug]..........=> 'prepare'
2024-01-09T23:08:38.9268941Z ##[debug]........=> Object
2024-01-09T23:08:38.9269642Z ##[debug]........Evaluating String:
2024-01-09T23:08:38.9270319Z ##[debug]........=> 'outputs'
2024-01-09T23:08:38.9270921Z ##[debug]......=> Object
2024-01-09T23:08:38.9271533Z ##[debug]......Evaluating String:
2024-01-09T23:08:38.9272067Z ##[debug]......=> 'self_signed_cert'
2024-01-09T23:08:38.9272675Z ##[debug]....=> null
2024-01-09T23:08:38.9273152Z ##[debug]....Evaluating String:
2024-01-09T23:08:38.9273720Z ##[debug]....=> 'true'
2024-01-09T23:08:38.9274246Z ##[debug]..=> false
2024-01-09T23:08:38.9274759Z ##[debug]=> false
2024-01-09T23:08:38.9275450Z ##[debug]Expanded: (true && (null == 'true'))
```

Looks like this was caused by the ``self_signed_cert`` variable being null, caused by a typo in the build config. It's value is being set by ```steps.generate_signing_key.outputs.self_signed``` and not ```steps.generate_signing_key.outputs.self_signed_cert```

Fixing this value, does indeed rectify the issue, and the self signed certs are now being picked up correctly during build

