### PR TITLE
add optional rpi-rf-mod dtoverlay block

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/config.txt
+++ b/buildroot-external/board/raspberrypi/rpi5-64/config.txt
@@ -43,6 +43,12 @@ arm_boost=1
 os_prefix=slot-A/
 cmdline=/cmdline.txt
 
+# Uncomment this to enable GPIO support for RPI-RF-MOD/HM-MOD-RPI-PCB
+#enable_uart=1
+#dtparam=i2c_arm=on
+#dtoverlay=miniuart-bt
+#dtoverlay=rpi-rf-mod
+
 [cm4]
 # Enable host mode on the 2711 built-in XHCI USB controller.
 # This line should be removed if the legacy DWC2 controller is required

--- a/buildroot-external/board/raspberrypi/rpi5-64/config.txt
+++ b/buildroot-external/board/raspberrypi/rpi5-64/config.txt
@@ -46,7 +46,6 @@ cmdline=/cmdline.txt
 # Uncomment this to enable GPIO support for RPI-RF-MOD/HM-MOD-RPI-PCB
 #enable_uart=1
 #dtparam=i2c_arm=on
-#dtoverlay=miniuart-bt
 #dtoverlay=rpi-rf-mod
 
 [cm4]


### PR DESCRIPTION
This PR adds the "usual" dtoverlay block for optionally enabling the `rpi-rf-mod.dtbo` device tree overlay to support the `RPI-RF-MOD` HAT hardware for HomeMatic(IP) support.

Please note that, while this PR will allow users to more easily enable support for this special dtoverlay, due to #3079 it is currently not correctly loaded and would require an additional `overlay_prefix` line which I intentionally omitted here until #3079 is fixed.