### PR TITLE
Fix path to cmdline after successful RPi 5 tryboot

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
+++ b/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
@@ -67,7 +67,7 @@ case "$1" in
         else
             rm -f "${boot_dir}/slot-${slot_bootname}/.good"
             exit 0
-	fi
+        fi
 
         # It seems we call set-state in any case. Use this to "commit" tryboot
         # state...
@@ -76,13 +76,15 @@ case "$1" in
         if ! cmp -s -n 4 /proc/device-tree/chosen/bootloader/tryboot /dev/zero; then
             cmdline_tryboot=$(head -n1 "${boot_dir}/cmdline-tryboot.txt")
             tryboot_slot=$(get_value rauc.slot "${cmdline_tryboot}")
-	    if [ "${tryboot_slot}" != "${slot_bootname}" ]; then
+            if [ "${tryboot_slot}" != "${slot_bootname}" ]; then
                 echo "tryboot doesn't reflect the expected boot slot, not committing." >&2
                 exit 1
             fi
             echo "Committing tryboot state to primary boot" >&2
-            mv "${boot_dir}/tryboot.txt" "${boot_dir}/config.txt"
+            sed -e "s/^\(cmdline=\).*$/\1\/cmdline.txt/" \
+                "${boot_dir}/tryboot.txt" > "${boot_dir}/config.txt"
             mv "${boot_dir}/cmdline-tryboot.txt" "${boot_dir}/cmdline.txt"
+            rm "${boot_dir}/tryboot.txt"
         fi
         ;;
 


### PR DESCRIPTION
Path to cmdline is set in tryboot.txt to cmdline-tryboot.txt before attempting A/B boot. After successful boot, tryboot.txt is relocated to config.txt, yet the config path of cmdline is not changed and remains set to cmdline-tryboot.txt which doesn't exist anymore at that point, causing following reboots to fail.

Fixes #3065