### PR TITLE
Dockerfile: migrate to trusted.gpg.d for docker repo keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gpg \
         dirmngr \
         software-properties-common \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-    && add-apt-repository "deb https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/docker.gpg] \
+        https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
     && apt-get update && apt-get install -y --no-install-recommends \
         docker-ce \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Using apt-key for managing Debian repo keys has been deprecated for a while now. While it currently works ok, seems to be broken in bookworm. This migrates to storing keys in trusted.gpg.d as recommended by the warning messages when using apt-key. This method is still compatible with bullseye.