### PR TITLE
Fix build_haos_builder step to fetch the correct version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,8 +150,8 @@ jobs:
           context: .
           file: Dockerfile
           tags: ghcr.io/${{ github.repository_owner }}/haos-builder
-          cache-from: ghcr.io/${{ github.repository_owner }}/haos-builder:cache-${{ steps.version_main.outputs.version_main }}
-          cache-to: ghcr.io/${{ github.repository_owner }}/haos-builder:cache-${{ steps.version_main.outputs.version_main }}
+          cache-from: ghcr.io/${{ github.repository_owner }}/haos-builder:cache-${{ steps.version.outputs.version_main }}
+          cache-to: ghcr.io/${{ github.repository_owner }}/haos-builder:cache-${{ steps.version.outputs.version_main }}
           push: true
 
       - name: Generate self-signed certificate


### PR DESCRIPTION
The ```build_haos_builder``` step attempts to cache the builder to the docker repo using the value of ```steps.version_main.outputs.version_main```

https://github.com/home-assistant/operating-system/blob/c210a1a52af683b093be2c278e4c6028561d69bf/.github/workflows/build.yaml#L146-L155

However, the ```version_main``` step doesn't exist, the correct id for this step is ```version```

https://github.com/home-assistant/operating-system/blob/c210a1a52af683b093be2c278e4c6028561d69bf/.github/workflows/build.yaml#L82-L93

This is causing the builder image to not be cached correctly:

![image](https://github.com/home-assistant/operating-system/assets/629719/4efd63d0-37d4-4a55-b67c-e85117e64ec6)

![image](https://github.com/home-assistant/operating-system/assets/629719/e49715f6-c74f-455d-b8db-074868355317)
