### PR TITLE
Fix ARCH/SRCARCH for aarch64 in linux-check-dotconfig

### DIFF
--- a/buildroot-external/external.mk
+++ b/buildroot-external/external.mk
@@ -3,8 +3,8 @@ include $(sort $(wildcard $(BR2_EXTERNAL_HASSOS_PATH)/package/*/*.mk))
 .PHONY: linux-check-dotconfig
 linux-check-dotconfig: linux-check-configuration-done
 	CC=$(TARGET_CC) LD=$(TARGET_LD) srctree=$(LINUX_SRCDIR) \
-	ARCH=$(if $(BR2_x86_64),x86,$(if $(BR2_arm)$(BR2_aarch64),arm,$(ARCH))) \
-	SRCARCH=$(if $(BR2_x86_64),x86,$(if $(BR2_arm)$(BR2_aarch64),arm,$(ARCH))) \
+	ARCH=$(if $(BR2_x86_64),x86,$(if $(BR2_aarch64),arm64,$(ARCH))) \
+	SRCARCH=$(if $(BR2_x86_64),x86,$(if $(BR2_aarch64),arm64,$(ARCH))) \
 	 $(BR2_EXTERNAL_HASSOS_PATH)/scripts/check-dotconfig.py \
 		$(BR2_CHECK_DOTCONFIG_OPTS) \
 		--src-kconfig $(LINUX_SRCDIR)Kconfig \


### PR DESCRIPTION
Wrong arch for arm64 produces few false check results resulting from some symbols in arm64 tree not being loaded. We can use raw $(ARCH) variable for arm, only need to translate aarch64 -> arm64.