### PR TITLE
Create empty overlays/README to fix DTB overlay loading on RPi 5

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/config.txt
+++ b/buildroot-external/board/raspberrypi/rpi5-64/config.txt
@@ -10,9 +10,6 @@
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
-# Additional overlays and parameters are documented
-# /boot/firmware/overlays/README
-
 # Automatically load overlays for detected cameras
 camera_auto_detect=1
 

--- a/buildroot-external/board/raspberrypi/rpi5-64/hassos-hook.sh
+++ b/buildroot-external/board/raspberrypi/rpi5-64/hassos-hook.sh
@@ -9,6 +9,10 @@ function hassos_pre_image() {
     gzip --stdout "${BINARIES_DIR}"/Image > "${BOOT_DATA}/slot-A/kernel_2712.img"
     cp -r "${BINARIES_DIR}/overlays/" "${BOOT_DATA}/slot-A/"
     cp "${BINARIES_DIR}"/*.dtbo "${BOOT_DATA}/slot-A/overlays/" 2>/dev/null || true
+    # README needs to be present, otherwise os_prefix is not
+    # prepended implicitly to the overlays' path, see:
+    # https://www.raspberrypi.com/documentation/computers/config_txt.html#overlay_prefix
+    touch "${BOOT_DATA}/slot-A/overlays/README" 2>/dev/null || true
     cp "${BOARD_DIR}/config.txt" "${BOOT_DATA}/config.txt"
     cp "${BOARD_DIR}/cmdline.txt" "${BOOT_DATA}/cmdline.txt"
 }


### PR DESCRIPTION
Since we're using a custom os_prefix for dual boot on RPi 5, overlays can be also present in different directories. Raspberry Pi's bootloader has a strange feature that it only respects os_prefix if the directory with overlays contains a README file:
https://www.raspberrypi.com/documentation/computers/config_txt.html#overlay_prefix

While rpi-firmware package touches the file when copying overlays to the destination directory, for RPi 5 we are using BR2_LINUX_KERNEL_INSTALL_INTREE_OVERLAYS option which does not copy or create it. Ensure it is present (no matter if we're using intree on rpi-firmware overlays) in the hassos-hook.

Fixes #3079

(also removed invalid mention about the README from config.txt)