### PR TITLE
Also check kernel custom config file in linux-check-dotconfig

### DIFF
--- a/buildroot-external/external.mk
+++ b/buildroot-external/external.mk
@@ -9,4 +9,4 @@ linux-check-dotconfig: linux-check-configuration-done
 		$(BR2_CHECK_DOTCONFIG_OPTS) \
 		--src-kconfig $(LINUX_SRCDIR)Kconfig \
 		--actual-config $(LINUX_SRCDIR).config \
-		$(shell echo $(BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES))
+		$(shell echo $(BR2_LINUX_KERNEL_CUSTOM_CONFIG_FILE) $(BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES))


### PR DESCRIPTION
If BR2_LINUX_KERNEL_CUSTOM_CONFIG_FILE is set, it should be also checked by the script for checking that all kernel options are applied.