### PR TITLE
Include links to kernel changelogs on kernel bump

### DIFF
--- a/scripts/update-kernel-rpi.sh
+++ b/scripts/update-kernel-rpi.sh
@@ -14,7 +14,7 @@ fi
 defconfigs=(buildroot-external/configs/{rpi*,yellow}_defconfig)
 sed -i "s|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/.*\"|BR2_LINUX_KERNEL_CUSTOM_TARBALL_LOCATION=\"https://github.com/raspberrypi/linux/archive/$1.tar.gz\"|g" "${defconfigs[@]}"
 sed -i "s/| \(Raspberry Pi.*\|Home Assistant Yellow\) | .* |/| \1 | $2 |/g" Documentation/kernel.md
-git commit -m "RaspberryPi: Update kernel $2 - $1" "${defconfigs[@]}" Documentation/kernel.md
+git commit -m "RaspberryPi: Update kernel to $2 - $1" "${defconfigs[@]}" Documentation/kernel.md
 
 ./scripts/check-kernel-patches.sh
 

--- a/scripts/update-kernel-upstream.sh
+++ b/scripts/update-kernel-upstream.sh
@@ -6,9 +6,37 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# assume the version is same in all defconfigs, take ova as the reference
+current_version=$(grep 'BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE' buildroot-external/configs/ova_defconfig | cut -d '"' -f 2)
+
+# get X.Y.Z tokens of the current and new version
+IFS='.' read -r -a current_version_parts <<< "$current_version"
+IFS='.' read -r -a new_version_parts <<< "$1"
+
+
 defconfigs=(buildroot-external/configs/{generic_aarch64,generic_x86_64,ova,tinker,odroid_*,khadas_vim3,green}_defconfig)
 sed -i "s/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\".*\"/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=\"$1\"/g" "${defconfigs[@]}"
 sed -i "s/| \(Open Virtual Appliance\|Generic aarch64\|Generic x86-64\|Tinker Board\|ODROID-.*\|Khadas VIM3\|Home Assistant Green\) | .* |/| \1 | $1 |/g" Documentation/kernel.md
-git commit -m "Linux: Update kernel $1" "${defconfigs[@]}" Documentation/kernel.md
+
+commit_message="Linux: Update kernel to $1"
+
+# get links to changelog if we're only updating the Z part of the version
+if [ "${current_version_parts[0]}" == "${new_version_parts[0]}" ] && \
+   [ "${current_version_parts[1]}" == "${new_version_parts[1]}" ] && \
+   [ "${current_version_parts[2]}" -lt "${new_version_parts[2]}" ]; then
+
+    commit_message="$commit_message"$'\n\n'
+
+    # loop from the current Z + 1 to the new Z
+    for (( z = current_version_parts[2] + 1; z <= new_version_parts[2]; z++ )); do
+        next_version="${current_version_parts[0]}.${current_version_parts[1]}.$z"
+        commit_message="${commit_message}* https://cdn.kernel.org/pub/linux/kernel/v${current_version_parts[0]}.x/ChangeLog-${next_version}"$'\n'
+    done
+
+    # remove trailing newline
+    commit_message=$(echo -n "$commit_message")
+fi
+
+git commit -m "$commit_message" "${defconfigs[@]}" Documentation/kernel.md
 
 ./scripts/check-kernel-patches.sh


### PR DESCRIPTION
Generate list of changelogs if we're bumping to the next patch release. If major or minor version is bumped, the commit message contains only the title, like before.

Also fix English in the commit title of RPi bump.