### PR TITLE
Use verity bundle format for RAUC updates

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -2,6 +2,9 @@
 compatible={{ env "ota_compatible" }}
 version={{ env "ota_version" }}
 
+[bundle]
+format=verity
+
 [hooks]
 filename=hook
 hooks=install-check;


### PR DESCRIPTION
We originally enabled it in 0ebcdcb9dc8d2471bcacf0049e93f1ad0bf12a37 but later reverted the patch in 5b927389b8562b14de5bc35a26f425ad041d0712 because of backward compatibility issues. Since we're going to 12.0, there is now hopefully enough room for seamless transition.