### PR TITLE
Update grub.cfg to blank console

### DIFF
--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -60,7 +60,7 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER MACHINE_ID
 
-default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition"
+default_cmdline="rootwait zram.enabled=1 zram.num_devices=3 systemd.machine_id=$MACHINE_ID fsck.repair=yes $boot_condition consoleblank=120"
 file_env -f ($root)/cmdline.txt cmdline
 
 # root is a full HDD/partition definition in GRUB format like hd0,gpt1


### PR DESCRIPTION
To safe energy an allow usage of Surface tablets with integrated screen, switch off the backlight after 120sec