### PR TITLE
Clarify M1S flashing and recovery docs

### DIFF
--- a/Documentation/boards/hardkernel/odroid-m1s.md
+++ b/Documentation/boards/hardkernel/odroid-m1s.md
@@ -4,19 +4,26 @@ Home Assistant OS 12 and newer support the ODROID-M1S board.
 
 ## SD-card
 
-SD-card boot is supported only if you have erased Petitboot from eMMC.
+ODROID-M1S can boot HAOS directly from an SD card, as it has higher priority than the system on the eMMC. Simply flash the image to the SD card using your favorite tool and insert it to the micro SD slot on the board. This works even when the eMMC is wiped, or when it contains the factory-default U-Boot SPL loader, which is still able to load U-Boot provided in the HAOS image. In the second case, however, if the SD card fails to probe (e.g. due to a hardware failure), the system on the eMMC may be booted instead of HAOS.
 
 ## eMMC
 
-To install to eMMC via on-board Petitboot bootloader:
+HAOS can be installed directly to the eMMC using a special boot image, to do that:
 
 1. Download [`ODROID-M1S_EMMC2UMS.img`][1]
 2. Use balenaEtcher or another tool to flash the UMS utility onto an SD card.
 3. Plug-in that SD card to your ODROID-M1S and boot it. Connect your PC to the Micro USB OTG port.
 4. The eMMC will show as a drive on your PC and you can directly flash the HAOS image with balenaEther.
 
-Installing HAOS erases Petitboot, if you wish to return to any official Hardkernel images then short the maskRom pads near
-the 40pin connector while booting from a [Hardkernel recovery image][2].
+Installing HAOS replaces the firmware and SPL on the eMMC with the mainline version provided by HAOS. As a result, it is not possible to use the SD card with the EMMC2UMS image anymore, because the mainline SPL is not compatible with U-Boot in the EMMC2UMS image at this time (February 2024). This does not pose any problem for standard use, just makes it more complicated in case you want to return to the Hardkernel-provided OS.
+
+A reliable way of reflashing the eMMC in this case is to use HAOS booted from an SD card. To do that, insert the SD card with HAOS to the micro SD slot and plug the board in. Once the device boots to the HA CLI, enter `login` to enter the root shell and use `curl` to download an image and `dd` it to the eMMC block device:
+
+```sh
+curl https://dn.odroid.com/RK3566/ODROID-M1S/Installer/ODROID-M1S_EMMC2UMS.img | dd of=/dev/mmcblk0
+```
+
+This way the device will start in the UMS mode on the next boot with the SD card removed. Alternatively you can use the [Hardkernel installer image][2] directly instead of the EMMC2UMS image.
 
 ## NVMe
 
@@ -24,7 +31,7 @@ Booting directly from NVMe is not supported. The NVMe card can be used as a data
 
 ## Technical notes on boot flow
 
-The Home Assistant OS image is bootable by the SoC directly. This means that no help from the Hardkernel provided and pre-installed bootloader Petitboot is necessary. Petitboot is stored on the eMMC and will be erased when installing HAOS.
+The Home Assistant OS image is bootable by the SoC directly. Refer to the [boot sequence documentation][3] for the details on what part of the boot is executed from the eMMC and what from the SD card. The steps documented above should however cover all scenarios that a standard user may encounter during usage.
 
 ## Console
 
@@ -37,7 +44,7 @@ to the `cmdline.txt` file on the boot partition (e.g. `console=tty0`).
 
 ## GPIO
 
-Odroid-M1S introduces a new 14pin expansion header. Refer to [the odroid wiki][3].
+Odroid-M1S introduces a new 14pin expansion header. Refer to [the ODROID wiki][4].
 At this point not all functionality is supported by the upstream kernel used by Home Assistant OS.  
 Supported modules include:
 - UPS
@@ -46,5 +53,6 @@ Supported modules include:
 
 
 [1]: https://dn.odroid.com/RK3566/ODROID-M1S/Installer/ODROID-M1S_EMMC2UMS.img
-[2]: https://wiki.odroid.com/odroid-m1s/getting_started/os_installation_guide
-[3]: https://wiki.odroid.com/odroid-m1s/hardware/expansion_connectors
+[2]: https://wiki.odroid.com/odroid-m1s/getting_started/os_installation_guide#user_installer
+[3]: https://wiki.odroid.com/odroid-m1s/board_support/boot_sequence
+[4]: https://wiki.odroid.com/odroid-m1s/hardware/expansion_connectors


### PR DESCRIPTION
Remove the mentions of petitboot, as it's not normally used on M1S. Document possibility to use SD card boot and alternative method of reflashing the eMMC from an OS running from an SD card.