### PR TITLE
Start HA CLI interactively and with a tty allocated

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/bin/ha
+++ b/buildroot-external/rootfs-overlay/usr/bin/ha
@@ -3,4 +3,4 @@
 # HA utility
 # ==============================================================================
 
-docker exec hassio_cli ha "$@"
+docker exec -it hassio_cli ha "$@"


### PR DESCRIPTION
Use -i (--interactive) and -t (--tty) to start the HA CLI interactively. This is required by some commands like the new device wipe command added with https://github.com/home-assistant/cli/pull/464.