### PR TITLE
Fix test_restore_ssl_directory with HA CLI in interactive PTY

### DIFF
--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -187,6 +187,6 @@ def test_restore_backup(shell_json, stash):
 
 @pytest.mark.dependency(depends=["test_create_backup"])
 def test_restore_ssl_directory(shell_json, stash):
-    result = shell_json(f"ha backups restore {stash.get('slug')} --folders ssl --raw-json")
+    result = shell_json(f"ha backups restore {stash.get('slug')} --folders ssl --no-progress --raw-json")
     assert result.get("result") == "ok", f"Backup restore failed: {result}"
     logger.info("Backup restore result: %s", result)


### PR DESCRIPTION
The test was missing --no-progress flag, which only manifested after merging #3238 - causing the CLI to run in an interactive pseudotty.