### PR TITLE
Ignore non-existing CP15 barrier instructions emulation

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/sysctl.d/30-cp15barrier.conf
+++ b/buildroot-external/rootfs-overlay/etc/sysctl.d/30-cp15barrier.conf
@@ -1,3 +1,3 @@
 # disable "deprecated CP15 Barrier instruction" warnings
 # https://www.kernel.org/doc/Documentation/arm64/legacy_instructions.txt
-abi.cp15_barrier = 2
+-abi.cp15_barrier = 2


### PR DESCRIPTION
CP15 barrier instruction emulation only exists on arm64 architecture. Avoid sysctl writing an error to the journal when the setting doesn't exist by prepending a dash.