### PR TITLE
Only run HA CLI interactively if stdout is a terminal

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/bin/ha
+++ b/buildroot-external/rootfs-overlay/usr/bin/ha
@@ -4,8 +4,8 @@
 # ==============================================================================
 
 if [ -t 1 ]; then
-	# stdout (fd 1) must be terminal, otherwise `docker exec -it` fails
+	# stdout (fd 1) must be terminal, otherwise `-t` causes error
 	docker exec -it hassio_cli ha "$@"
 else
-	docker exec hassio_cli ha "$@"
+	docker exec -i hassio_cli ha "$@"
 fi

--- a/buildroot-external/rootfs-overlay/usr/bin/ha
+++ b/buildroot-external/rootfs-overlay/usr/bin/ha
@@ -3,4 +3,9 @@
 # HA utility
 # ==============================================================================
 
-docker exec -it hassio_cli ha "$@"
+if [ -t 1 ]; then
+	# stdout (fd 1) must be terminal, otherwise `docker exec -it` fails
+	docker exec -it hassio_cli ha "$@"
+else
+	docker exec hassio_cli ha "$@"
+fi


### PR DESCRIPTION
Flags for running HA CLI commands in an interactive shell added in #3238 cause the command to fail if the process is not running in a terminal. This is needed for example for the fsfreeze hook, otherwise the command fails, as seen in this trace when the hook is executed:

```
+ '[' thaw '=' freeze ]
+ '[' thaw '=' thaw ]
+ echo 'File system thaw requested, thawing Home Assistant'
File system thaw requested, thawing Home Assistant
+ ha backups thaw
the input device is not a TTY
```

However, for example on Proxmox this message is not logged anywhere and the hook just fails silently (i.e. it doesn't cause the backup to fail).

Fixes #3251