### PR TITLE
ODROID-N2/C2/C4: Force 40MHz instead of 24MHz as eMMC clock

### DIFF
--- a/buildroot-external/board/hardkernel/patches/uboot/0001-HACK-mmc-meson-gx-limit-to-40MHz.patch
+++ b/buildroot-external/board/hardkernel/patches/uboot/0001-HACK-mmc-meson-gx-limit-to-40MHz.patch
@@ -1,15 +1,18 @@
-From 11f015e13ef0442b6d2bb734954291abde415f73 Mon Sep 17 00:00:00 2001
-From: Neil Armstrong <narmstrong@baylibre.com>
-Date: Mon, 2 Sep 2019 15:42:04 +0200
-Subject: [PATCH] HACK: mmc: meson-gx: limit to 24MHz
+From 820e6f6e3745e988246a1acca4aaacdd759b778f Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 18 Apr 2024 18:01:54 +0200
+Subject: [PATCH] HACK: mmc: meson-gx: limit to 40MHz
 
-Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+This is the limit used by downstream U-Boot for ODROID-N2(+) (odroidg12
+branch).
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
  drivers/mmc/meson_gx_mmc.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
-index fcf4f03d1e..6ded4b619b 100644
+index fcf4f03d1e..c578ac0f74 100644
 --- a/drivers/mmc/meson_gx_mmc.c
 +++ b/drivers/mmc/meson_gx_mmc.c
 @@ -279,7 +279,7 @@ static int meson_mmc_probe(struct udevice *dev)
@@ -17,10 +20,10 @@ index fcf4f03d1e..6ded4b619b 100644
  			MMC_MODE_HS_52MHz | MMC_MODE_HS;
  	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
 -	cfg->f_max = 100000000; /* 100 MHz */
-+	cfg->f_max = SD_EMMC_CLKSRC_24M;
++	cfg->f_max = 40000000; /* 40 MHz */
  	cfg->b_max = 511; /* max 512 - 1 blocks */
  	cfg->name = dev->name;
  
 -- 
-2.43.0
+2.44.0
 


### PR DESCRIPTION
It seems that forcing 24MHz clocks is problematic for newer 32GB Kingston based eMMC modules on ODROID-N2(+). Use what downstream U-Boot is using as f_max, which is 40MHz.

Fixes: #3227