### PR TITLE
Enable KVM for running tests in GH Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,9 +28,6 @@ jobs:
   test:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
-    env:
-      NO_KVM: 1
-
     name: Test in QEMU
     runs-on: ubuntu-22.04
     steps:
@@ -68,6 +65,12 @@ jobs:
         run: |
           xz -dc haos*.qcow2.xz > tests/haos.qcow2
           rm haos*.qcow2.xz
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Run tests
         run: |


### PR DESCRIPTION
It was not possible on free runners previously, but it should be now: https://github.com/actions/runner-images/discussions/7191#discussioncomment-9018826