### PR TITLE
Improve resiliency of skopeo operations in hassio package

### DIFF
--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -11,6 +11,26 @@ image_json_name=$4
 dl_dir=$5
 dst_dir=$6
 
+retry() {
+	local retries="$1"
+	local cmd=$2
+
+	local output
+	output=$(eval "$cmd")
+	local rc=$?
+
+	# shellcheck disable=SC2086
+	if [ $rc -ne 0 ] && [ $retries -gt 0 ]; then
+		echo "Retrying \"$cmd\" $retries more times..." >&2
+		sleep 3s
+		# shellcheck disable=SC2004
+		retry $(($retries - 1)) "$cmd"
+	else
+		echo "$output"
+		return $rc
+	fi
+}
+
 image_name=$(jq -e -r --arg image_json_name "${image_json_name}" \
 	--arg arch "${arch}" --arg machine "${machine}" \
 	'.images[$image_json_name] | sub("{arch}"; $arch) | sub("{machine}"; $machine)' \
@@ -19,7 +39,7 @@ image_tag=$(jq -e -r --arg image_json_name "${image_json_name}" \
 	'.[$image_json_name]' < "${version_json}")
 full_image_name="${image_name}:${image_tag}"
 
-image_digest=$(skopeo inspect --retry-times=5 "docker://${full_image_name}" | jq -r '.Digest')
+image_digest=$(retry 3 "skopeo inspect 'docker://${full_image_name}' | jq -r '.Digest'")
 
 # Cleanup image name file name use
 image_file_name="${full_image_name//[:\/]/_}@${image_digest//[:\/]/_}"
@@ -32,7 +52,7 @@ dst_image_file_path="${dst_dir}/${image_file_name}.tar"
 	if [ ! -f "${image_file_path}" ]
 	then
 		echo "Fetching image: ${full_image_name} (digest ${image_digest})"
-		skopeo copy "docker://${image_name}@${image_digest}" "docker-archive:${image_file_path}:${full_image_name}"
+		retry 3 "skopeo copy 'docker://${image_name}@${image_digest}' 'docker-archive:${image_file_path}:${full_image_name}'"
 	else
 		echo "Skipping download of existing image: ${full_image_name} (digest ${image_digest})"
 	fi


### PR DESCRIPTION
We still face occasional build errors when fetching from the Docker registry fails and is not retried with the Skopeo's built-in retry mechanism that was enabled in #1866. This happens on some network failures, or when premature EOF is returned when fetching the HTTP data. Seems we're not the only ones having such issues [1].

To workaround this, add a generic retry shell function that simply retries when the command ends with a non-zero status, no matter what was the actual cause of the error.

[1] https://www.github.com/containers/common/issues/654