### PR TITLE
Fix boot slot A marked as bad on the very first boot

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
+++ b/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
@@ -17,6 +17,7 @@ function hassos_pre_image() {
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set ORDER="B A"
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_OK=1
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_TRY=0
+    cp "${EFIPART_DATA}/EFI/BOOT/grubenv-A" "${EFIPART_DATA}/EFI/BOOT/grubenv"
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }

--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -17,6 +17,7 @@ function hassos_pre_image() {
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set ORDER="B A"
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_OK=1
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_TRY=0
+    cp "${EFIPART_DATA}/EFI/BOOT/grubenv-A" "${EFIPART_DATA}/EFI/BOOT/grubenv"
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }

--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -36,6 +36,14 @@ def test_init(shell):
 
 
 @pytest.mark.dependency(depends=["test_init"])
+def test_rauc_status(shell):
+    output = shell.run_check("rauc status --output-format=shell")
+    # RAUC_BOOT_PRIMARY won't be set if correct grub env is missing
+    assert "RAUC_BOOT_PRIMARY='kernel.0'" in output
+    assert "rauc-WARNING" not in "\n".join(output)
+
+
+@pytest.mark.dependency(depends=["test_init"])
 def test_dmesg(shell):
     output = shell.run_check("dmesg")
     _LOGGER.info("%s", "\n".join(output))


### PR DESCRIPTION
On the very first boot, grubenv doesn't exist and loading and saving it silently fails. However, it is later created by the hassos-persists script and the missing information are added by grub.cfg on the next boot. As the consequence, when RAUC tries to get information from grubenv on the first boot, ORDER variable is missing and the slot is reported as bad.

Fixes #3376