### PR TITLE
Fix rauc hook to restore machine-id in new grub environment

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -34,11 +34,13 @@ install_boot() {
     else
         # Backup boot config
         cp -f "${BOOT_MNT}"/*.txt "${BOOT_TMP}/" || true
+        cp -f "${BOOT_MNT}"/EFI/BOOT/grubenv "${BOOT_TMP}/" || true
 
         cp -rf "${BOOT_NEW}"/* "${BOOT_MNT}/"
 
         # Restore boot config
         cp -f "${BOOT_TMP}"/*.txt "${BOOT_MNT}/" || true
+        cp -f "${BOOT_TMP}"/grubenv "${BOOT_MNT}"/EFI/BOOT/ || true
     fi
 }
 


### PR DESCRIPTION
Without a machine-id, the next boot will be considered as a first boot, and any external data disk will be disabled.

Fixes #3247.

<img width="416" alt="Screenshot 2024-06-29 at 12 32 46" src="https://github.com/home-assistant/operating-system/assets/11894677/c01b434e-5013-4013-8fab-bc96d8e56fa5">

After installing my raucb update bundle and a reboot:

```
Jun 29 16:34:38 homeassistant kernel: Kernel command line: BOOT_IMAGE=(hd0,gpt4)/Image root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootwait zram.enabled=1 zram.num_devices=3 systemd.machine_id=6c631b4986cb426f9b7860df4ce10629 fsck.repair=yes console=ttyS0 console=tty0 rauc.slot=B
```

The machine-id has been conserved 👍 