### PR TITLE
Remove old code from rauc-hook and GRUB env initialization

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
+++ b/buildroot-external/board/pc/generic-x86-64/hassos-hook.sh
@@ -9,15 +9,10 @@ function hassos_pre_image() {
 
     cp "${BOARD_DIR}/../grub.cfg" "${EFIPART_DATA}/EFI/BOOT/grub.cfg"
     cp "${BOARD_DIR}/cmdline.txt" "${EFIPART_DATA}/cmdline.txt"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" create
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set ORDER="A B"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_OK=1
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_TRY=0
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" create
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set ORDER="B A"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_OK=1
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_TRY=0
-    cp "${EFIPART_DATA}/EFI/BOOT/grubenv-A" "${EFIPART_DATA}/EFI/BOOT/grubenv"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set ORDER="A B"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_OK=1
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_TRY=0
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }

--- a/buildroot-external/board/pc/ova/hassos-hook.sh
+++ b/buildroot-external/board/pc/ova/hassos-hook.sh
@@ -9,15 +9,10 @@ function hassos_pre_image() {
 
     cp "${BOARD_DIR}/../grub.cfg" "${EFIPART_DATA}/EFI/BOOT/grub.cfg"
     cp "${BOARD_DIR}/cmdline.txt" "${EFIPART_DATA}/cmdline.txt"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" create
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set ORDER="A B"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_OK=1
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-A" set A_TRY=0
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" create
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set ORDER="B A"
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_OK=1
-    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv-B" set B_TRY=0
-    cp "${EFIPART_DATA}/EFI/BOOT/grubenv-A" "${EFIPART_DATA}/EFI/BOOT/grubenv"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set ORDER="A B"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_OK=1
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_TRY=0
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -96,14 +96,6 @@ post_install_kernel() {
         systemctl start mnt-boot.mount
     fi
 
-    # OS 7 -> 8 upgrade path:
-    # If grub is installed, and the current system lacks GRUB environment
-    # manipulation tools, manually create a grubenv for the right boot slot
-    if [ -f "${BOOT_MNT}"/EFI/BOOT/grub.cfg ] && ! command -v grub-editenv > /dev/null; then
-        cp -f "${BOOT_MNT}/EFI/BOOT/grubenv-${RAUC_SLOT_BOOTNAME}" "${BOOT_MNT}"/EFI/BOOT/grubenv
-        echo "Copied default GRUB environment grubenv-${RAUC_SLOT_BOOTNAME} as grubenv."
-    fi
-
     # Copy new OS to appropriate directory
     if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-rpi5-64" ]; then
         rm -rf "${BOOT_MNT}/slot-${RAUC_SLOT_BOOTNAME}"
@@ -118,20 +110,8 @@ case "$1" in
      install-check)
          if [ "$RAUC_MF_COMPATIBLE" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              # Check if GRUB env has been corrupted. This is only problematic
-             # with OS 8, where compatible matches.
+             # with OS 8+, where compatible matches.
              check_grubenv
-             exit 0
-         fi
-         # Be compatible with hassos OS ID
-         # shellcheck disable=SC3060
-         rauc_os_compatible=${RAUC_MF_COMPATIBLE/haos-/hassos-}
-         if [ "$rauc_os_compatible" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
-             exit 0
-         fi
-         # generic-x86-64: Be compatible with intel-nuc
-         # shellcheck disable=SC3060
-         rauc_board_compatible=${rauc_os_compatible/generic-x86-64/intel-nuc}
-         if [ "${rauc_board_compatible}" = "$RAUC_SYSTEM_COMPATIBLE" ]; then
              exit 0
          fi
          echo "Compatible does not match!" 1>&2


### PR DESCRIPTION
With upgrade path enforced in standard HAOS upgrade procedure, we don't need to keep some old code anymore. This means that upgrade from some very old HAOS version (pre-8.0) to HAOS 13+ will fail in the install-check hook but this is rather desirable.