### PR TITLE
Populate grubenv with RAUC data in clean aarch64 OS image

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/hassos-hook.sh
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/hassos-hook.sh
@@ -10,6 +10,9 @@ function hassos_pre_image() {
     cp "${BOARD_DIR}/grub.cfg" "${EFIPART_DATA}/EFI/BOOT/grub.cfg"
     cp "${BOARD_DIR}/cmdline.txt" "${EFIPART_DATA}/cmdline.txt"
     grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" create
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set ORDER="A B"
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_OK=1
+    grub-editenv "${EFIPART_DATA}/EFI/BOOT/grubenv" set A_TRY=0
 
     cp -r "${EFIPART_DATA}/"* "${BOOT_DATA}/"
 }
@@ -24,4 +27,3 @@ function hassos_post_image() {
 
     convert_disk_image_xz
 }
-


### PR DESCRIPTION
While not as bad as in 87a6c84, because the grubenv already exists in the image, RAUC still complains about missing ORDER on the very first boot on aarch64. Populate the environment in the same way as we do for other GRUB platforms.