### PR TITLE
Reduce log spam from Docker health checks

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/system/run-docker-.mount.d/10-reduce-verbosity.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/system/run-docker-.mount.d/10-reduce-verbosity.conf
@@ -1,0 +1,2 @@
+[Mount]
+LogLevelMax=notice


### PR DESCRIPTION
Reduce verbosity from deactivated Docker mounts, triggered by the Docker healthcheck. These messages do not carry any value for us and logs supplied by users are often spammed mostly with these. Moreover, they sometimes cause confusion that something is wrong, see for example #3021.

Unfortunately, it's not possible to use LogFilterPatterns= here, because it's not applied to these messages, as explicitly said in the docs:

>  Filtering is based on the unit for which LogFilterPatterns= is defined, 
meaning log messages coming from systemd(1) about the unit are not taken into account.

runc 1.2.0 supposedly should fix this, but it's unclear when it would be available, so let's stick to this solution (reducing verbosity from debug to notice for all units `run-docker-*.mount`) for the time being.