### PR TITLE
Drop "default kernel tree" line from docs

### DIFF
--- a/Documentation/kernel.md
+++ b/Documentation/kernel.md
@@ -1,8 +1,6 @@
 
 # Kernel Version
 
-Default Kernel tree: 6.1
-
 | Board | Version |
 |-------|---------|
 | Open Virtual Appliance | 6.6.44 |


### PR DESCRIPTION
The following table is self-explanatory and unlike this, is kept up-to-date automatically.