### PR TITLE
Add documentation and dependencies category to release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,8 +4,6 @@ version-template: "$MAJOR.$MINOR"
 categories:
   - title: 'Home Assistant Operating System'
     label: 'os'
-  - title: 'Build System'
-    label: 'build'
   - title: 'Raspberry Pi'
     label: 'board/raspberrypi'
   - title: 'Home Assistant Yellow'
@@ -24,6 +22,12 @@ categories:
     label: 'board/khadas'
   - title: 'Generic aarch64'
     label: 'board/generic-aarch64'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Build System'
+    label: 'build'
+  - title: 'Dependencies'
+    label: 'dependencies'
 filter-by-commitish: true
 template: |
   ## Changes


### PR DESCRIPTION
* add Documentation category
* add Dependencies (to easily filter them out if not needed in changelog)
* adjust the order a bit to have user-facing changes first