### PR TITLE
Increase block size of kernel squashfs image to 128K

### DIFF
--- a/buildroot-external/genimage/images-os.cfg
+++ b/buildroot-external/genimage/images-os.cfg
@@ -4,6 +4,7 @@ image kernel.img {
 
 	squashfs {
 		compression = "lzo"
+		block-size = 131072
 	}
 }
 


### PR DESCRIPTION
While mksquashfs uses this value by default, Genimage's default is 4K. This is far too low value and results in slower kernel load, especially on embedded boards with a flash drive. Explicitly set it to 128K to generate same images as in pre-genimage builds.