### PR TITLE
Fix CPU ID for D2xxx/N2xxx in GRUB2 loader patch

### DIFF
--- a/buildroot-external/patches/grub2/0002-loader-efi-linux-use-legacy-loader-for-broken-Intel-.patch
+++ b/buildroot-external/patches/grub2/0002-loader-efi-linux-use-legacy-loader-for-broken-Intel-.patch
@@ -89,7 +89,7 @@ index bfbd95aee..f4fc6d25c 100644
 +           * negatives) or partial CPU identification (which might lead to
 +           * false positives instead).
 +           */
-+          return (processor_id == 0xbfebfbff61060300      // D2xxx/N2xxx
++          return (processor_id == 0xbfebfbff00030661      // D2xxx/N2xxx
 +                  || processor_id == 0xbfebfbff000106ca); // D525
 +        }
 +      else


### PR DESCRIPTION
Report from @ChernyaevAN in [1] revealed it's 13829424153406670433 in decimal, which means the endianness was wrong for the CPUs I didn't have available for testing.

[1] https://github.com/home-assistant/operating-system/issues/3305#issuecomment-2288609199