### PR TITLE
Enable 1.5MBd serial console on Green for new installs

### DIFF
--- a/buildroot-external/board/nabucasa/green/cmdline.txt
+++ b/buildroot-external/board/nabucasa/green/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty0
+console=ttyS2,1500000n8 console=tty0


### PR DESCRIPTION
With default console on HDMI (tty0), we lost the console on the serial port. It may be useful for debugging, let's enable it for new installs with the same speed as bootloader (to avoid the need for baud rate switching).