### PR TITLE
Enable debug logging for GRUB rescue shell options

### DIFF
--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -77,9 +77,9 @@ menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
 }
 
 menuentry "Slot A (rescue shell)" {
-    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target
+    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target debug
 }
 
 menuentry "Slot B (rescue shell)" {
-    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target
+    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target debug
 }


### PR DESCRIPTION
If the system fails to boot, some kernel messages may not be shown before the system fully boots. Enable the debug option for rescue shell options to have an easy way to see those without modifying GRUB options. This will increase log verbosity and turn on debug logging for Systemd as well [1].

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.html#debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `debug` parameter to the boot configuration for both "Slot A" and "Slot B" rescue shell options to enhance troubleshooting capabilities during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->