### PR TITLE
Add test for no failed Systemd units

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -71,3 +71,8 @@ def test_supervisor_logs(shell):
 def test_systemctl_status(shell):
     output = shell.run_check("systemctl --no-pager -l status -a || true")
     _LOGGER.info("%s", "\n".join(output))
+
+@pytest.mark.dependency(depends=["test_init"])
+def test_systemctl_check_no_failed(shell):
+    output = shell.run_check("systemctl --no-pager -l list-units --state=failed")
+    assert "0 loaded units listed." in output, f"Some units failed:\n{"\n".join(output)}"


### PR DESCRIPTION
Test that systemctl reports no failed units at the end of the basic test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced a new test to verify that there are no failed system units, enhancing the robustness of the testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->