### PR TITLE
Tests: update labgrid to v24.0.1

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
-labgrid==23.0.6
-pytest==7.2.2
+labgrid==24.0.1
 pytest-dependency==0.6.0
 pytest-timeout==2.3.1


### PR DESCRIPTION
Bump labgrid to latest release. None of the changes require adjustments in the tests. Remove pytest from requirements.txt, it's not needed anymore, so let pip to resolve the correct (latest) version from labgrid's dependencies. With these new dependencies, previous DeprecationWarnings on Python 3.12 are gone now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `labgrid` package to version `24.0.1`, which may enhance performance and stability in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->