### PR TITLE
Fix guest-agent not starting with HyperV Enlightenments enabled

### DIFF
--- a/buildroot-external/patches/systemd/0004-detect-virt-detect-hyperv-enlightened-qemu-as-qemu-n.patch
+++ b/buildroot-external/patches/systemd/0004-detect-virt-detect-hyperv-enlightened-qemu-as-qemu-n.patch
@@ -1,0 +1,59 @@
+From f42a5b49e95a8deed0b8e6f1bea6679af7e908e4 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Fri, 19 Apr 2024 13:25:55 +0200
+Subject: [PATCH] detect-virt: detect hyperv-enlightened qemu as qemu, not as
+ hyperv
+
+CPUID reporting hyperv should be taken with a grain of salt, and we
+should prefer other mechanisms then.
+
+Fixes: #28001
+---
+ src/basic/virt.c | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/src/basic/virt.c b/src/basic/virt.c
+index 88357a9..89abb53 100644
+--- a/src/basic/virt.c
++++ b/src/basic/virt.c
+@@ -446,7 +446,7 @@ static Virtualization detect_vm_zvm(void) {
+ /* Returns a short identifier for the various VM implementations */
+ Virtualization detect_vm(void) {
+         static thread_local Virtualization cached_found = _VIRTUALIZATION_INVALID;
+-        bool other = false;
++        bool other = false, hyperv = false;
+         int xen_dom0 = 0;
+         Virtualization v, dmi;
+ 
+@@ -503,7 +503,12 @@ Virtualization detect_vm(void) {
+         v = detect_vm_cpuid();
+         if (v < 0)
+                 return v;
+-        if (v == VIRTUALIZATION_VM_OTHER)
++        if (v == VIRTUALIZATION_MICROSOFT)
++                /* QEMU sets the CPUID string to hyperv's, in case it provides hyperv enlightenments. Let's
++                 * hence not return Microsoft here but just use the other mechanisms first to make a better
++                 * decision. */
++                hyperv = true;
++        else if (v == VIRTUALIZATION_VM_OTHER)
+                 other = true;
+         else if (v != VIRTUALIZATION_NONE)
+                 goto finish;
+@@ -544,8 +549,15 @@ Virtualization detect_vm(void) {
+                 return v;
+ 
+ finish:
+-        if (v == VIRTUALIZATION_NONE && other)
+-                v = VIRTUALIZATION_VM_OTHER;
++        /* None of the checks above gave us a clear answer, hence let's now use fallback logic: if hyperv
++         * enlightenments are available but the VMM wasn't recognized as anything yet, it's probably
++         * Microsoft. */
++        if (v == VIRTUALIZATION_NONE) {
++                if (hyperv)
++                        v = VIRTUALIZATION_MICROSOFT;
++                else if (other)
++                        v = VIRTUALIZATION_VM_OTHER;
++        }
+ 
+         cached_found = v;
+         log_debug("Found VM virtualization %s", virtualization_to_string(v));


### PR DESCRIPTION
Guest agent doesn't start because if HyperV Enlightenments are enabled, the virtualization gets detected incorrectly. Backport Systemd patch that fixes the detection, allowing the guest-agent service to meet its dependencies.

This patch should be no longer needed after update of Systemd to v256, or in case the patch gets eventually backported to the v254 stable branch.

Fixes #3565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced virtualization detection logic to improve accuracy in identifying Microsoft Hyper-V environments.
  
- **Bug Fixes**
	- Improved handling of cases where QEMU may misrepresent itself as Hyper-V, reducing reliance on potentially misleading information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->