### PR TITLE
Add Makefile variable for Supervisor channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUILDDIR:=$(shell pwd)
 BUILDROOT=$(BUILDDIR)/buildroot
 BUILDROOT_EXTERNAL=$(BUILDDIR)/buildroot-external
 DEFCONFIG_DIR = $(BUILDROOT_EXTERNAL)/configs
+CHANNEL ?= stable
 
 TARGETS := $(notdir $(patsubst %_defconfig,%,$(wildcard $(DEFCONFIG_DIR)/*_defconfig)))
 TARGETS_CONFIG := $(notdir $(patsubst %_defconfig,%-config,$(wildcard $(DEFCONFIG_DIR)/*_defconfig)))
@@ -30,7 +31,8 @@ $(TARGETS_CONFIG): %-config:
 
 $(TARGETS): %: %-config
 	@echo "build $@"
-	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL)
+	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) \
+		BR2_PACKAGE_HASSIO_CHANNEL=$(CHANNEL)
 
 	# Do not clean when building for one target
 ifneq ($(words $(filter $(TARGETS),$(MAKECMDGOALS))), 1)

--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -3,6 +3,7 @@ set -e
 
 build_dir=$1
 dst_dir=$2
+channel=$3
 
 data_img="${dst_dir}/data.ext4"
 
@@ -24,7 +25,7 @@ container=$(docker run --privileged -e DOCKER_TLS_CERTDIR="" \
 	-v "${build_dir}":/build \
 	-d docker:27.2-dind --storage-driver overlay2)
 
-docker exec "${container}" sh /build/dind-import-containers.sh
+docker exec "${container}" sh /build/dind-import-containers.sh "${channel}"
 
 docker stop "${container}"
 

--- a/buildroot-external/package/hassio/dind-import-containers.sh
+++ b/buildroot-external/package/hassio/dind-import-containers.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+channel=$1
+
 APPARMOR_URL="https://version.home-assistant.io/apparmor.txt"
 
 # Make sure we can talk to the Docker daemon
@@ -27,3 +29,5 @@ docker tag "${supervisor}" "ghcr.io/home-assistant/${arch}-hassio-supervisor:lat
 # Setup AppArmor
 mkdir -p "/data/supervisor/apparmor"
 wget -O "/data/supervisor/apparmor/hassio-supervisor" "${APPARMOR_URL}"
+
+echo "{ \"channel\": \"${channel}\" }" > /data/supervisor/updater.json

--- a/buildroot-external/package/hassio/hassio.mk
+++ b/buildroot-external/package/hassio/hassio.mk
@@ -9,7 +9,7 @@ HASSIO_LICENSE = Apache License 2.0
 # HASSIO_LICENSE_FILES = $(BR2_EXTERNAL_HASSOS_PATH)/../LICENSE
 HASSIO_SITE = $(BR2_EXTERNAL_HASSOS_PATH)/package/hassio
 HASSIO_SITE_METHOD = local
-HASSIO_VERSION_URL = "https://version.home-assistant.io/stable.json"
+HASSIO_VERSION_URL = "https://version.home-assistant.io/$(BR2_PACKAGE_HASSIO_CHANNEL).json"
 
 HASSIO_CONTAINER_IMAGES_ARCH = supervisor dns audio cli multicast observer core
 
@@ -30,7 +30,7 @@ endef
 HASSIO_INSTALL_IMAGES = YES
 
 define HASSIO_INSTALL_IMAGES_CMDS
-	$(BR2_EXTERNAL_HASSOS_PATH)/package/hassio/create-data-partition.sh "$(@D)" "$(BINARIES_DIR)"
+	$(BR2_EXTERNAL_HASSOS_PATH)/package/hassio/create-data-partition.sh "$(@D)" "$(BINARIES_DIR)" "$(BR2_PACKAGE_HASSIO_CHANNEL)"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Allow to set the release channel pre-installed Home Assistant components like Supervisor and add-on are fetched from. This channel is then also used at runtime.