### PR TITLE
Add kernel options required for Atheros 12k wirelss adapters

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -172,3 +172,6 @@ CONFIG_DLN2_ADC=m
 
 CONFIG_IIO=m
 CONFIG_BMP280=m
+
+# Required for some PCIe devices such as ath12k
+CONFIG_IRQ_REMAP=y

--- a/buildroot-external/board/pc/ova/kernel.config
+++ b/buildroot-external/board/pc/ova/kernel.config
@@ -125,3 +125,6 @@ CONFIG_I6300ESB_WDT=y
 
 CONFIG_I2C=y
 CONFIG_I2C_MUX=y
+
+# Required for some PCIe devices such as ath12k
+CONFIG_IRQ_REMAP=y


### PR DESCRIPTION
Add support for interrupt remapping for IO-APIC and MSI devices as required by some ath12k devices.

Fixes: #3621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for various hardware components, including PCIe devices, SCSI, USB, and graphics.
	- Added support for EFI stub booting and LZ4 compression for the kernel.
	- Improved CPU and memory hotplugging capabilities for better resource management.

- **Bug Fixes**
	- Resolved compatibility issues with specific PCIe devices through configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->