### PR TITLE
Update test_offline.py

### DIFF
--- a/tests/smoke_test/test_offline.py
+++ b/tests/smoke_test/test_offline.py
@@ -43,6 +43,8 @@ def test_ha_runs_offline(shell):
             if "Supervisor" in " ".join(nm_conns):
                 break
         sleep(1)
+else:
+    raise AssertionError("supervisor network creation timed out")
 
     # To simulate situation where HAOS is not connected to internet, we need to add
     # default gateway to the supervisor connection. So we add a default route to


### PR DESCRIPTION
Problem: This loop can run indefinitely if the network or container never becomes available, leading to a hang in the test execution. It would be better to add a timeout or a maximum retry limit.
Fix: Add a retry count or a timeout to prevent infinite looping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in offline tests by adding a timeout assertion for supervisor network creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->