### PR TITLE
Update test_supervisor.py

### DIFF
--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -33,6 +33,16 @@ def test_start_supervisor(shell, shell_json):
     )
 
     while True:
+        retries = 0
+      max_retries = 300  # example: wait for max 300 seconds
+       while retries < max_retries:
+    if check_container_running("homeassistant") and check_container_running("hassio_supervisor"):
+        break
+    retries += 1
+    sleep(1)
+else:
+    raise TimeoutError("Containers did not start in time")
+        
         try:
             if shell_json(f"curl -sSL http://{supervisor_ip}/supervisor/ping").get("result") == "ok":
                 break


### PR DESCRIPTION
The while loops in test_start_supervisor and other tests do not have timeouts, which may cause the tests to hang indefinitely if something goes wrong (e.g., the supervisor never starts or the API never returns the expected result).

Fix: Add a maximum retry count or timeout to prevent infinite looping:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of the supervisor startup tests with a new retry mechanism for container readiness.
	- Enhanced error handling to better manage timeout scenarios during container initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->