### PR TITLE
Update conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,9 @@ def shell_json(target, strategy) -> callable:
     strategy.transition("shell")
     shell = target.get_driver("ShellDriver")
 
-    def get_json_response(command, *, timeout=None) -> dict:
-        return json.loads("\n".join(shell.run_check(command, timeout=timeout)))
-
-    return get_json_response
+   def get_json_response(command, *, timeout=None) -> dict:
+    # Check if the output is a list and join if necessary
+    output = shell.run_check(command, timeout=timeout)
+    if isinstance(output, list):
+        output = "\n".join(output)
+    return json.loads(output)


### PR DESCRIPTION
The shell.run_check() method likely returns a list of strings (lines from the command output). However, the current implementation assumes it's a single string, using "\n".join(shell.run_check(...)). This could lead to unintended behavior if the output is already a single string or not formatted as expected.

Fix: You can simplify this by directly parsing the result without joining the lines, as json.loads can handle strings with line breaks. If the output is indeed a list, join them properly.