### PR TITLE
Reduce timeout for network time synchronization to 15 seconds

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/systemd-time-wait-sync.service.d/timeout.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/systemd-time-wait-sync.service.d/timeout.conf
@@ -1,2 +1,2 @@
 [Service]
-TimeoutStartSec=90s
+TimeoutStartSec=15s


### PR DESCRIPTION
The timeout of 90s was introduced before it was ensured that the timesync systemd unit starts after network is online. Now with that, it makes less sense to wait that long - if network is unreachable at the point the time synchronization starts, and the server fails to reply on the first sync, the polling interval is exponentially increased and the benefit of waiting for more attempts is doubtful.

Since another synchronization attempt is done after network changes its state, we should rely on that instead of having the 90 seconds interval as a waiting period for plugging the network cable. Worst case, there are other mechanisms that should set the time to a reasonably accurate value, making the NTP sync less importart for most of the cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reduced the startup timeout for the time synchronization service from 90 seconds to 15 seconds, improving overall system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->