### PR TITLE
Fix Yellow's post-install hook for config.txt migration

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -11,7 +11,11 @@ hooks=install-check;
 
 [image.boot]
 filename=boot.vfat
+{{- if eq (env "ota_compatible") "haos-yellow" }}
+hooks=install;post-install;
+{{- else }}
 hooks=install;
+{{- end }}
 
 [image.kernel]
 filename=kernel.img

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -91,7 +91,7 @@ check_grubenv() {
 post_install_boot() {
     BOOT_MNT=/mnt/boot
 
-    # Add CM5 support for Yellow. Can be removed in HAOS 15.
+    # Add CM5 support for Yellow. Can be removed in HAOS 15. Make sure manifest.raucm.gtpl is updated.
     if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-yellow" ]; then
         # Mount boot
         if ! systemctl -q is-active mnt-boot.mount; then


### PR DESCRIPTION
The hook was missing in the manifest, enable it conditionally for Yellow and add reminder to remove it once it's not needed.