### PR TITLE
Remove unnecessary kernel post-install hook for GRUB-based targets

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -19,8 +19,7 @@ hooks=install;
 
 [image.kernel]
 filename=kernel.img
-{{- $bootloader := (env "BOOTLOADER") }}
-{{- if or (eq $bootloader "grub") (eq $bootloader "tryboot") }}
+{{- if eq (env "BOOTLOADER") "tryboot" }}
 hooks=post-install;
 {{- end }}
 


### PR DESCRIPTION
The code for this hook was removed in #3457 but it wasn't removed from the manifest. Remove it to avoid unnecessary execution of the hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated conditions for bootloader and image component hooks to streamline execution logic.
	- Simplified the condition for the `[image.kernel]` section to check only for "tryboot".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->