### PR TITLE
Merge Yellow's RAUC post-install hook with the install hook

### DIFF
--- a/buildroot-external/ota/manifest.raucm.gtpl
+++ b/buildroot-external/ota/manifest.raucm.gtpl
@@ -11,11 +11,7 @@ hooks=install-check;
 
 [image.boot]
 filename=boot.vfat
-{{- if eq (env "ota_compatible") "haos-yellow" }}
-hooks=install;post-install;
-{{- else }}
 hooks=install;
-{{- end }}
 
 [image.kernel]
 filename=kernel.img

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -42,6 +42,16 @@ install_boot() {
         cp -f "${BOOT_TMP}"/*.txt "${BOOT_MNT}/" || true
         cp -f "${BOOT_TMP}"/grubenv "${BOOT_MNT}"/EFI/BOOT/ || true
     fi
+
+    # Add CM5 support for Yellow. Can be removed in HAOS 15.
+    if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-yellow" ]; then
+        if ! grep -q "\[cm5\]" "${BOOT_MNT}/config.txt"; then
+            echo "Adding CM5 config to config.txt"
+
+            # Remove old single device_tree config and add CM-specific ones
+            sed -i '/device_tree=bcm2711-rpi-cm4-ha-yellow.dtb/d; s/\[all\]/\[cm4\]\ndevice_tree=bcm2711-rpi-cm4-ha-yellow.dtb\n\n\[cm5\]\ndevice_tree=bcm2712-rpi-cm5-ha-yellow.dtb\n\n\[all\]/' "${BOOT_MNT}/config.txt"
+        fi
+    fi
 }
 
 install_spl() {
@@ -84,25 +94,6 @@ check_grubenv() {
         if ! grub-editenv "${BOOT_MNT}/EFI/BOOT/grubenv" list > /dev/null; then
             echo "GRUB environment seems to be corrupted. Recreating a new environment."
             grub-editenv "${BOOT_MNT}"/EFI/BOOT/grubenv create
-        fi
-    fi
-}
-
-post_install_boot() {
-    BOOT_MNT=/mnt/boot
-
-    # Add CM5 support for Yellow. Can be removed in HAOS 15. Make sure manifest.raucm.gtpl is updated.
-    if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-yellow" ]; then
-        # Mount boot
-        if ! systemctl -q is-active mnt-boot.mount; then
-            systemctl start mnt-boot.mount
-        fi
-
-        if ! grep -q "\[cm5\]" "${BOOT_MNT}/config.txt"; then
-            echo "Adding CM5 config to config.txt"
-
-            # Remove old single device_tree config and add CM-specific ones
-            sed -i '/device_tree=bcm2711-rpi-cm4-ha-yellow.dtb/d; s/\[all\]/\[cm4\]\ndevice_tree=bcm2711-rpi-cm4-ha-yellow.dtb\n\n\[cm5\]\ndevice_tree=bcm2712-rpi-cm5-ha-yellow.dtb\n\n\[all\]/' "${BOOT_MNT}/config.txt"
         fi
     fi
 }


### PR DESCRIPTION
As stated in the docs [1], post-install hook is not executed if the slot already has an install hook defined. Merge the post-install hook with the install hook to fix CM5 migration for Yellow.

[1] https://rauc.readthedocs.io/en/latest/using.html#slot-hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the "CM5" configuration in the boot installation process for "haos-yellow" systems.
  
- **Bug Fixes**
	- Streamlined the boot image installation process by simplifying the hook configuration.

- **Refactor**
	- Consolidated CM5 support logic into the main installation function, removing the need for a separate post-install function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->