### PR TITLE
Always use NVMe datadisk on Yellow if it's present on first boot

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-data-disk-detach
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-data-disk-detach
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC1091
 
 # Find root using rdev command
 rootpart=$(rdev | cut -f 1 -d ' ')
@@ -9,15 +10,53 @@ sleep 10s
 
 datapartitions=$(blkid --match-token LABEL="hassos-data" --output device)
 
-for datapart in ${datapartitions}
-do
-	datadev=$(lsblk -no pkname "${datapart}")
+. /etc/os-release
 
-	# If major does not match our root device major, it is an external data
-	# disk. Rename to make sure it gets ignored.
-	if [ "$rootdev" != "$datadev" ]
-	then
-		echo "Found external data disk device on ${datapart}, mark it disabled..."
-		e2label "${datapart}" hassos-data-dis
-	fi
-done
+disable_data_partition() {
+    e2label "${1}" hassos-data-dis
+}
+
+if [ "$VARIANT_ID" = "yellow" ]; then
+    emmc_data_partition=""
+    nvme_data_partition=""
+
+    for datapart in ${datapartitions}; do
+        datadev=$(lsblk -no pkname "${datapart}")
+
+        case "${datadev}" in
+            mmc*)
+                # Data partition on internal eMMC
+                if [ "$rootdev" = "$datadev" ]; then
+                    emmc_data_partition="${datapart}"
+                fi
+                ;;
+            nvme0*)
+                # Data partition on first NVMe disk
+                nvme_data_partition="${datapart}"
+                ;;
+            *)
+                # Disable all other data disks as normally
+                if [ "$rootdev" != "$datadev" ]; then
+                    echo "Found extra external data disk device on ${datapart}, marking it disabled..."
+                    disable_data_partition "${datapart}"
+                fi
+                ;;
+        esac
+    done
+
+    if [ -n "${emmc_data_partition}" ] && [ -n "${nvme_data_partition}" ]; then
+        echo "Found both eMMC and NVMe data disk devices, marking eMMC as disabled"
+        disable_data_partition "${emmc_data_partition}"
+    fi
+else
+    for datapart in ${datapartitions}; do
+        datadev=$(lsblk -no pkname "${datapart}")
+
+        # If major does not match our root device major, it is an external data
+        # disk. Rename to make sure it gets ignored.
+        if [ "$rootdev" != "$datadev" ]; then
+            echo "Found external data disk device on ${datapart}, marking it disabled..."
+            disable_data_partition "${datapart}"
+        fi
+    done
+fi


### PR DESCRIPTION
If HAOS on Yellow is booted for the first time with NVMe data disk present, it should be preferred over the empty eMMC data partition. This will ease reinstall of the system and migration from CM4 to CM5. All other data disks (e.g. if a USB drive is used for them) are still treated as before, requiring manual adoption using the Supervisor repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of data partitions based on system configuration, allowing for more intelligent management.
	- Introduced conditional logic for distinguishing between internal eMMC and NVMe data partitions based on the `VARIANT_ID`.

- **Bug Fixes**
	- Enhanced functionality to ensure only one type of internal data partition is active at a time.

- **Refactor**
	- Restructured the script for better readability and maintainability by encapsulating logic into a new function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->