### PR TITLE
Sync Yellow's DTS with plain CM5 device tree

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0017-ARM-dts-bcm2712-yellow-Sync-sdio1-and-sd_io_1v8_reg-.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0017-ARM-dts-bcm2712-yellow-Sync-sdio1-and-sd_io_1v8_reg-.patch
@@ -1,0 +1,50 @@
+From e29e2cfad33afa692f2f727f492dab02d5ff3948 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Thu, 21 Nov 2024 14:26:20 +0100
+Subject: [PATCH] ARM: dts: bcm2712: yellow: Sync sdio1 and sd_io_1v8_reg nodes
+ with CM5 DTS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+SDIO1 and its 1V8 regulator have been changed in vanilla CM5 device tree,
+reflect those changes in Yellow's DTS.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ .../boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts  | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+index 4b130f42b2358..c85d608da2043 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+@@ -78,17 +78,11 @@ led_act: led-act {
+ 	};
+ 
+ 	sd_io_1v8_reg: sd_io_1v8_reg {
+-		compatible = "regulator-gpio";
++		compatible = "regulator-fixed";
+ 		regulator-name = "vdd-sd-io";
+ 		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <3300000>;
+-		regulator-boot-on;
++		regulator-max-microvolt = <1800000>;
+ 		regulator-always-on;
+-		regulator-settling-time-us = <5000>;
+-		gpios = <&gio_aon 3 GPIO_ACTIVE_HIGH>;
+-		states = <1800000 0x1
+-			  3300000 0x0>;
+-		status = "okay";
+ 	};
+ 
+ 	sd_vcc_reg: sd_vcc_reg {
+@@ -355,6 +349,8 @@ &sdio1 {
+ 	sd-uhs-ddr50;
+ 	sd-uhs-sdr104;
+ 	mmc-hs200-1_8v;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
+ 	broken-cd;
+ 	supports-cqe;
+ 	status = "okay";


### PR DESCRIPTION
Sync the DTS with changes added in newer commits merged after the initial Yellow/CM5 DTS was written. The sdio1 node now has HS400 mode enabled and sd_io_1v8_reg has been changed to regulator-fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced SDIO interface capabilities with support for additional modes.
- **Bug Fixes**
	- Improved power management for the SDIO1 regulator, ensuring consistent voltage levels.
- **Refactor**
	- Simplified regulator configuration by removing unnecessary properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->