### PR TITLE
Disable CM5's RTC to make Yellow's on-board RTC the primary one

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0020-ARM-dts-bcm2712-yellow-Disable-rpi_rtc.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0020-ARM-dts-bcm2712-yellow-Disable-rpi_rtc.patch
@@ -1,0 +1,32 @@
+From fc558b6a7174e2b5c37936dd8c13ca29e9273472 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Mon, 2 Dec 2024 17:22:04 +0100
+Subject: [PATCH] ARM: dts: bcm2712: yellow: Disable rpi_rtc
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Yellow has its own I2C RTC and there is no way to power the new peripheral on
+CM5.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+index 469d0fdc971a8..ebdeef5f89881 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+@@ -927,6 +927,11 @@ &i2c1 {
+ 	clock-frequency = <100000>;
+ };
+ 
++/* No way to power CM5's VBAT pin on Yellow, disable its RTC. */
++&rpi_rtc {
++	status = "disabled";
++};
++
+ /* Board-level I2C (RTC and I2S audio) */
+ &rp1_i2c3 {
+ 	pinctrl-names = "default";


### PR DESCRIPTION
With both RTCs enabled, the rpi_rtc is probed as the first one, making the on-board RTC unused by default. Since the CM5's RTC peripheral can't be used on Yellow, as the VBAT pin is not connected, disable it completely to fix RTC.