### PR TITLE
Bump Hailo-8 firmware to 4.19.0 for RPi kernel 6.6.62

### DIFF
--- a/buildroot-external/package/hailo8-firmware/hailo8-firmware.hash
+++ b/buildroot-external/package/hailo8-firmware/hailo8-firmware.hash
@@ -1,1 +1,1 @@
-sha256  bfa576dd782359d74cabcb19e87c3a934dce03dea0785e41f86fecc9a687a92b  hailo8_fw.4.18.0.bin
+sha256  160179e523b71aca4c1fabdcbb91e19b167d9c3f0c4d789180f8fc9ee82b4c5c  hailo8_fw.4.19.0.bin

--- a/buildroot-external/package/hailo8-firmware/hailo8-firmware.mk
+++ b/buildroot-external/package/hailo8-firmware/hailo8-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HAILO8_FIRMWARE_VERSION = 4.18.0
+HAILO8_FIRMWARE_VERSION = 4.19.0
 HAILO8_FIRMWARE_LICENSE = PROPRIETARY
 HAILO8_FIRMWARE_SOURCE= hailo8_fw.$(HAILO8_FIRMWARE_VERSION).bin
 HAILO8_FIRMWARE_SITE="https://hailo-hailort.s3.eu-west-2.amazonaws.com/Hailo8/$(HAILO8_FIRMWARE_VERSION)/FW"


### PR DESCRIPTION
Kernel bump in #3715 contains update of the driver to version 4.19.0 - bump the firmware version to match it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Hailo-8 firmware to version 4.19.0, enhancing performance and stability.
  
- **Bug Fixes**
	- Resolved issues related to the previous firmware version by implementing the latest updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->