### PR TITLE
Fix Hailo-8 firmware path expected since driver v4.19.0

### DIFF
--- a/buildroot-external/package/hailo8-firmware/hailo8-firmware.mk
+++ b/buildroot-external/package/hailo8-firmware/hailo8-firmware.mk
@@ -13,13 +13,9 @@ define HAILO8_FIRMWARE_EXTRACT_CMDS
 	cp $(HAILO8_FIRMWARE_DL_DIR)/$(HAILO8_FIRMWARE_SOURCE) $(@D)
 endef
 
-define HAILO8_FIRMWARE_BUILD_CMDS
-	cp $(@D)/$(HAILO8_FIRMWARE_SOURCE) $(@D)/hailo8_fw.bin
-endef
-
 define HAILO8_FIRMWARE_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/lib/firmware/hailo
-	$(INSTALL) -m 0644 $(@D)/hailo8_fw.bin $(TARGET_DIR)/lib/firmware/hailo/
+	$(INSTALL) -m 0644 $(@D)/$(HAILO8_FIRMWARE_SOURCE) $(TARGET_DIR)/lib/firmware/hailo/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
The new driver now expects the firmware file to contain version number, adjust the path and remove unnecessary makefile step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined firmware build process for Hailo-8 by removing unnecessary commands.
	- Installation command now directly references the source filename for improved consistency.

- **Bug Fixes**
	- Corrected installation command to ensure proper firmware installation without referencing outdated filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->