### PR TITLE
Add HA Yellow image to RPi Imager index update action

### DIFF
--- a/.github/actions/bump-rpi-imager-version/action.yml
+++ b/.github/actions/bump-rpi-imager-version/action.yml
@@ -83,6 +83,7 @@ runs:
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi3-64" "RPi 3"
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi4-64" "RPi 4/400"
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi5-64" "RPi 5"
+        bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "yellow" "HA Yellow"
 
     - shell: bash
       env:

--- a/.github/actions/bump-rpi-imager-version/action.yml
+++ b/.github/actions/bump-rpi-imager-version/action.yml
@@ -83,7 +83,7 @@ runs:
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi3-64" "RPi 3"
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi4-64" "RPi 4/400"
         bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "rpi5-64" "RPi 5"
-        bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "yellow" "HA Yellow"
+        bump_entry /tmp/version/rpi-imager-haos.json "$INPUTS_VERSION" "${{ steps.validate-input.outputs.date }}" "yellow" "Yellow"
 
     - shell: bash
       env:


### PR DESCRIPTION
Update the action to also bump HA Yellow image added in home-assistant/version#402.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded version bump functionality to include support for the "HA Yellow" hardware target in the RPi Imager workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->