### PR TITLE
Remove existing rauc.db from a data disk on the first boot

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/raucdb-first-boot.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/raucdb-first-boot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Remove adopted rauc.db on first boot
+After=rauc.service
+Before=raucdb-update.service
+RequiresMountsFor=/mnt/data
+ConditionFirstBoot=yes
+ConditionFileNotEmpty=/mnt/data/rauc.db
+
+[Service]
+Type=oneshot
+ExecStart=/bin/rm -f /mnt/data/rauc.db
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If data disk is adopted on Yellow using the mechanism added in #3686, it contains RAUC version information that is very likely invalid. In such case, remove the file on first boot and have it recreated by the raucdb-update service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new systemd service for one-time operations during the first boot of the system.
  
- **Bug Fixes**
	- Ensures the removal of the specified file on first boot if it exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->