### PR TITLE
Change RPi bootargs order to keep cgroup memory controller enabled

### DIFF
--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -42,7 +42,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:2 ${kernel_addr_r} zImage; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_a} rauc.slot=A"
       fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
@@ -50,7 +50,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:4 ${kernel_addr_r} zImage; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_b} rauc.slot=B"
       fi
     fi
   fi

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -42,7 +42,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:2 ${kernel_addr_r} Image; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_a} rauc.slot=A"
       fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
@@ -50,7 +50,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:4 ${kernel_addr_r} Image; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_b} rauc.slot=B"
       fi
     fi
   fi

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -68,7 +68,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:2 ${kernel_addr_r} Image; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_a} rauc.slot=A"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_a} rauc.slot=A"
       fi
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
@@ -76,7 +76,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
       if load ${devtype} ${devnum}:4 ${kernel_addr_r} Image; then
-          setenv bootargs "${bootargs_hassos} ${bootargs_rpi} ${bootargs_b} rauc.slot=B"
+          setenv bootargs "${bootargs_rpi} ${bootargs_hassos} ${bootargs_b} rauc.slot=B"
       fi
     fi
   fi


### PR DESCRIPTION
With "cgroup: Use kernel command line to disable memory cgroup" merged to RPi kernel as 86099de [1], the device tree now contains "cgroup_disable=memory" parameter. The parameters are parsed in the order defined in the cmdline and with the previous order, the memory CG ends up disabled. Switching the order fixes that and makes the order similar to what we get with standard bootloader and parameters in cmdline.txt only.

The possible downside is that it won't be possible to override parameters from hardcoded bootargs_hassos using cmdline.txt anymore, however, it's unlikely any of these parameters will need to be adjusted by users.

Fixes #3765 

[1] https://github.com/raspberrypi/linux/commit/86099deff5abf5f63643eecaedb4c11ae77474ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Updated boot script for Raspberry Pi devices to modify the order of boot arguments concatenation
	- Adjusted the sequence of `bootargs` variables to potentially change kernel parameter precedence
	- Changes apply to multiple Raspberry Pi board configurations (standard and Yellow models)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->