### PR TITLE
Allow boot from USB and NVMe on Khadas VIM3

### DIFF
--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -1,17 +1,17 @@
 
 ###########################################
 
-part start mmc ${devnum} 9 mmc_env
-mmc dev ${devnum}
+part start ${devtype} ${devnum} 9 mmc_env
+${devtype} dev ${devnum}
 setenv loadbootstate " \
     echo 'loading env...'; \
-    mmc read ${ramdisk_addr_r} ${mmc_env} 0x10; \
+    ${devtype} read ${ramdisk_addr_r} ${mmc_env} 0x10; \
     env import -c ${ramdisk_addr_r} 0x2000;"
 
 setenv storebootstate " \
     echo 'storing env...'; \
     env export -c -s 0x2000 ${ramdisk_addr_r} BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT MACHINE_ID; \
-    mmc write ${ramdisk_addr_r} ${mmc_env} 0x10;"
+    ${devtype} write ${ramdisk_addr_r} ${mmc_env} 0x10;"
 
 run loadbootstate
 test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
@@ -29,31 +29,31 @@ setenv bootargs_a "root=PARTUUID=48617373-06 ro rootwait"
 setenv bootargs_b "root=PARTUUID=48617373-08 ro rootwait"
 
 # Load environment from haos-config.txt
-if test -e mmc ${devnum}:1 haos-config.txt; then
-  fatload mmc ${devnum}:1 ${ramdisk_addr_r} haos-config.txt
+if test -e ${devtype} ${devnum}:1 haos-config.txt; then
+  fatload ${devtype} ${devnum}:1 ${ramdisk_addr_r} haos-config.txt
   env import -t ${ramdisk_addr_r} ${filesize}
 fi
 
 # Load extraargs
-fileenv mmc ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
+fileenv ${devtype} ${devnum}:1 ${ramdisk_addr_r} cmdline.txt cmdline
 
 # Load device tree
 setenv fdtfile "meson-g12b-s922x-khadas-vim3.dtb"
 echo "Loading standard device tree ${fdtfile}"
-fatload mmc ${devnum}:1 ${fdt_addr_r} ${fdtfile}
+fatload ${devtype} ${devnum}:1 ${fdt_addr_r} ${fdtfile}
 fdt addr ${fdt_addr_r}
 
 # load dt overlays
 fdt resize 65536
 for overlay_file in ${overlays}; do
-  if fatload mmc ${devnum}:1 ${ramdisk_addr_r} overlays/${overlay_file}.dtbo; then
+  if fatload ${devtype} ${devnum}:1 ${ramdisk_addr_r} overlays/${overlay_file}.dtbo; then
     echo "Applying kernel provided DT overlay ${overlay_file}.dtbo"
     fdt apply ${ramdisk_addr_r} || setenv overlay_error "true"
   fi
 done
 if test "${overlay_error}" = "true"; then
   echo "Error applying DT overlays, restoring original DT"
-  fatload mmc ${devnum}:1 ${fdt_addr_r} ${fdtfile}
+  fatload ${devtype} ${devnum}:1 ${fdt_addr_r} ${fdtfile}
 fi
 
 # logical volumes get numbered after physical ones.
@@ -74,7 +74,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
-      if load mmc ${devnum}:5 ${kernel_addr_r} Image; then
+      if load ${devtype} ${devnum}:5 ${kernel_addr_r} Image; then
           setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
       fi
     fi
@@ -82,7 +82,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
-      if load mmc ${devnum}:7 ${kernel_addr_r} Image; then
+      if load ${devtype} ${devnum}:7 ${kernel_addr_r} Image; then
           setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
       fi
     fi


### PR DESCRIPTION
Currently its hardcoded in the script to use mmc command. This means the image can not be flashed to usb or nvme drive and booted from the same. Making it flexible to allow booting in such scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced boot script flexibility by replacing hardcoded device commands with a dynamic variable
	- Improved script adaptability for different device types without changing core boot management logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->