### PR TITLE
Disable CQE on mmc0 to fix I/O freezes on CM5

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/linux/0003-dts-bcm2712-rpi-Disable-CQE-for-CM5-eMMC-to-work-aro.patch
+++ b/buildroot-external/board/raspberrypi/patches/linux/0003-dts-bcm2712-rpi-Disable-CQE-for-CM5-eMMC-to-work-aro.patch
@@ -1,0 +1,32 @@
+From ec7a5ea27ef759c67225b1616e4266bcff0d7fb4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Tue, 14 Jan 2025 18:27:20 +0100
+Subject: [PATCH] dts: bcm2712-rpi: Disable CQE for CM5 eMMC to work around FS
+ lockups
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With CQE enabled, HAOS first boot often fails during swap file initilization,
+and leaves hanging on all I/O access. For some reason, this only happens when
+an ext4lazyinit on the accessed partition hasn't been finished yet. Before the
+real solution is found, disable CQE at the cost of a small performance cost.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+index 099d14ecf19a4..d49fc876cccc1 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5.dtsi
+@@ -339,7 +339,7 @@ &sdio1 {
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
+ 	broken-cd;
+-	supports-cqe;
++	//supports-cqe;
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
Similarly to #3705, enabled CQE triggers I/O freezes usually on the first boot when the swapfile is being created. While we disabled it for Yellow, with #3782 the issue started to appear on generic CM5 targets with the rpi5-64 image.

In the meantime it was discovered that there seems to be some relation with the ext4lazyinit task, which happens as a result of data partition resize, yet it's still unclear if the pattern of the access triggered by the concurrent FS initialization is somehow responsible, or if another factor comes in play. Disabling CQE yet makes the issue go away and serves as an acceptable workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved eMMC initialization issues on Raspberry Pi Compute Module 5 by disabling Command Queue Engine (CQE) feature.
	- Improved system stability during first boot of Home Assistant Operating System.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->