### PR TITLE
Enable ES1371 sound card module for VMWare guests

### DIFF
--- a/buildroot-external/board/pc/ova/kernel.config
+++ b/buildroot-external/board/pc/ova/kernel.config
@@ -21,6 +21,8 @@ CONFIG_VMWARE_VMCI_VSOCKETS=m
 CONFIG_VMWARE_VMCI=y
 CONFIG_VMWARE_BALLOON=y
 CONFIG_VMWARE_PVSCSI=y
+# VMWare has optional ES1371 sound card emulation
+CONFIG_SND_ENS1371=m
 
 # These options are for LXD Guest Support
 CONFIG_NET_9P=m


### PR DESCRIPTION
VMWare has option to emulate ES1371 soundcard which supposedly works better than the default hdaudio. Enable its driver for the OVA image.

Fixes #3778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for VMWare ES1371 sound card emulation in the kernel configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->