### PR TITLE
Make usb_modeswitch include directory writable

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-usb_modeswitch.d.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-usb_modeswitch.d.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=USB modeswitch persistent directory
+Requires=mnt-overlay.mount
+After=mnt-overlay.mount
+Before=hassos-config.service
+
+[Mount]
+What=/mnt/overlay/etc/usb_modeswitch.d
+Where=/etc/usb_modeswitch.d
+Type=None
+Options=bind
+
+[Install]
+WantedBy=hassos-bind.target


### PR DESCRIPTION
The /etc/usb_modeswitch.d is present and empty but it can't be written to allow user modification. Bind-mount it like other /etc folders to make it possible to adjust usb_modeswitch config.

Fixes #3785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new systemd mount unit for managing USB modeswitch persistent directory configuration
  - Ensures proper mounting of USB modeswitch configuration files during system boot

<!-- end of auto-generated comment: release notes by coderabbit.ai -->