### PR TITLE
Pin awscli to older version to work around R2 issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Install AWS CLI
         if: ${{ github.event_name != 'release' && needs.prepare.outputs.publish_build == 'true' }}
-        run: pip install awscli
+        run: pip install 'awscli<1.37.0'
 
       - name: Set version suffix
         if: ${{ github.event_name != 'release' }}


### PR DESCRIPTION
CI job fails to upload build artifacts because R2 doesn't support checksums [1]. This was added in awscli 1.37.0 [2], pin to a version older than that to work around the issue before R2 supports it or ignores the header.

[1] https://www.cloudflarestatus.com/incidents/t5nrjmpxc1cj
[2] https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated AWS CLI installation in GitHub Actions workflow to use a specific version range
	- Pinned AWS CLI version to be lower than 1.37.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->