### PR TITLE
Fix artifacts index job by downgrading awscli

### DIFF
--- a/.github/workflows/artifacts-index.yaml
+++ b/.github/workflows/artifacts-index.yaml
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install AWS CLI
-        run: pip install awscli
+        run: pip install 'awscli<1.37.0'
 
       - name: Create build index
         env:


### PR DESCRIPTION
Similarly to #3803, artifact index update fails because the R2 doesn't like the new awscli. The regression apparently comes from 1.37.0 as well, so pin to version older than that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated AWS CLI installation version constraint in GitHub Actions workflow to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->