### PR TITLE
Add check for tainted kernel to automatic tests

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -76,3 +76,11 @@ def test_systemctl_status(shell):
 def test_systemctl_check_no_failed(shell):
     output = shell.run_check("systemctl --no-pager -l list-units --state=failed")
     assert "0 loaded units listed." in output, f"Some units failed:\n{"\n".join(output)}"
+
+
+@pytest.mark.dependency(depends=["test_init"])
+def test_kernel_not_tainted(shell):
+    """Check if the kernel is not tainted - do it at the end of the
+    test suite to increase the chance of catching issues."""
+    output = shell.run_check("cat /proc/sys/kernel/tainted")
+    assert output == "0\n", f"Kernel tainted: {output}"

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -190,3 +190,11 @@ def test_restore_ssl_directory(shell_json, stash):
     result = shell_json(f"ha backups restore {stash.get('slug')} --folders ssl --no-progress --raw-json")
     assert result.get("result") == "ok", f"Backup restore failed: {result}"
     logger.info("Backup restore result: %s", result)
+
+
+@pytest.mark.dependency(depends=["test_start_supervisor"])
+def test_kernel_not_tainted(shell):
+    """Check if the kernel is not tainted - do it at the end of the
+    test suite to increase the chance of catching issues."""
+    output = shell.run_check("cat /proc/sys/kernel/tainted")
+    assert output == "0\n", f"Kernel tainted: {output}"


### PR DESCRIPTION
Add test that the kernel isn't tainted at the end of the basic and supervisor test suites, allowing us to catch e.g. kernel warnings that may left unnoticed if dmesg isn't checked. There is no other source of tainting, so the value should be always zero.