### PR TITLE
Fix kernel tainted test

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -83,4 +83,4 @@ def test_kernel_not_tainted(shell):
     """Check if the kernel is not tainted - do it at the end of the
     test suite to increase the chance of catching issues."""
     output = shell.run_check("cat /proc/sys/kernel/tainted")
-    assert output == "0\n", f"Kernel tainted: {output}"
+    assert "\n".join(output) == "0", f"Kernel tainted: {output}"

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -197,4 +197,4 @@ def test_kernel_not_tainted(shell):
     """Check if the kernel is not tainted - do it at the end of the
     test suite to increase the chance of catching issues."""
     output = shell.run_check("cat /proc/sys/kernel/tainted")
-    assert output == "0\n", f"Kernel tainted: {output}"
+    assert "\n".join(output) == "0", f"Kernel tainted: {output}"


### PR DESCRIPTION
I have only tested that it fails for unreleased 6.6.72 kernel but haven't tested the happy path and missed that it also failed because the types were different. Stupid me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated `test_kernel_not_tainted` function assertions in multiple test files to handle newline characters more precisely when checking kernel tainted status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->