### PR TITLE
Use Python 3.13 for the build and artifacts index jobs

### DIFF
--- a/.github/workflows/artifacts-index.yaml
+++ b/.github/workflows/artifacts-index.yaml
@@ -31,7 +31,7 @@ on:
         required: true
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   build-index:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ on:
         default: true
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   prepare:


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Python version from 3.10 to 3.13 in GitHub workflow configurations
	- Upgraded Python environment for build and artifacts index workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->