### PR TITLE
Fix RPi 5 getting stuck in bootloader after some reboots

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
+++ b/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
@@ -10,19 +10,30 @@ boot_dir="/mnt/boot"
 root_slot_a="PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd"
 root_slot_b="PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20"
 
+get_primary() {
+    echo "tryboot get-primary" >&2
+    cmdline=$(head -n1 "${boot_dir}/cmdline.txt")
+    get_value rauc.slot "${cmdline}"
+}
+
 case "$1" in
     get-primary)
         # Actions to be performed when getting the primary bootloader
         # Example: Output the path to the current primary bootloader
-        echo "tryboot get-primary" >&2
-        cmdline=$(head -n1 "${boot_dir}/cmdline.txt")
-        get_value rauc.slot "${cmdline}"
+        get_primary
         ;;
 
     set-primary)
         # Actions to be performed when setting the primary bootloader
         # Example: Set the specified bootloader as the primary one
         slot_bootname="$2"
+
+        # Do nothing if we're already booted in the requested slot
+        if [ "$(get_primary)" = "${slot_bootname}" ]; then
+            echo "tryboot set-primary $slot_bootname: already set" >&2
+            exit 0
+        fi
+
         echo "tryboot set-primary $slot_bootname" >&2
         cmdline=$(head -n1 "${boot_dir}/cmdline.txt")
         if [ "${slot_bootname}" = "A" ]; then
@@ -85,6 +96,7 @@ case "$1" in
                 "${boot_dir}/tryboot.txt" > "${boot_dir}/config.txt"
             mv "${boot_dir}/cmdline-tryboot.txt" "${boot_dir}/cmdline.txt"
             rm "${boot_dir}/tryboot.txt"
+            rm /run/systemd/reboot-param
         fi
         ;;
 


### PR DESCRIPTION
Probably since home-assistant/supervisor#5276 introduced in Supervisor 2024.9.0, RAUC bootloader handler for tryboot can set the tryboot flag also when the tryboot file is not present, causing the Pi to become stuck in bootloader, trying to load the tryboot file.

This happens when the device is already in the tryboot state, in that case the tryboot files and flag are created by set-primary and in turn the files are removed in set-state, while the flag is persisted, causing the bootloader to attempt loading non-existing file.

To avoid unnecessary juggling with tryboot/config files, only create them and set the flag if the boot slot is different than the current one. Also, make sure that the flag is reboot parameter is cleared when the tryboot files are removed by the handler.

Fixes #3740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved bootloader slot management logic
	- Added safeguards to prevent unintended primary slot changes
	- Ensured proper cleanup of reboot parameters after state commitment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->