### PR TITLE
Revert kernel patch causing USB 3 and PCIe breakage on ODROID-M1/M1S

### DIFF
--- a/buildroot-external/patches-rockchip/linux/0004-Revert-phy-rockchip-naneng-combphy-fix-phy-reset.patch
+++ b/buildroot-external/patches-rockchip/linux/0004-Revert-phy-rockchip-naneng-combphy-fix-phy-reset.patch
@@ -1,0 +1,32 @@
+From 411b308e89929c2b13ef902fd97c1735d8280023 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Wed, 29 Jan 2025 16:28:26 +0100
+Subject: [PATCH] Revert "phy: rockchip: naneng-combphy: fix phy reset"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit 908806a2e789998f8897ebab83be10b4b058b6e2.
+
+This commit causes USB3 and PCIe regression on ODROID-M1 and ODROID-M1S. Revert
+it before a fix is merged upstream.
+
+Link: https://lore.kernel.org/regressions/91993fed-6398-4362-8c62-87beb9ade32b@sairon.cz/
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ drivers/phy/rockchip/phy-rockchip-naneng-combphy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+index 9c231094ba359..26b157f53f3da 100644
+--- a/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
++++ b/drivers/phy/rockchip/phy-rockchip-naneng-combphy.c
+@@ -309,7 +309,7 @@ static int rockchip_combphy_parse_dt(struct device *dev, struct rockchip_combphy
+ 
+ 	priv->ext_refclk = device_property_present(dev, "rockchip,ext-refclk");
+ 
+-	priv->phy_rst = devm_reset_control_get(dev, "phy");
++	priv->phy_rst = devm_reset_control_array_get_exclusive(dev);
+ 	if (IS_ERR(priv->phy_rst))
+ 		return dev_err_probe(dev, PTR_ERR(priv->phy_rst), "failed to get phy reset\n");
+ 


### PR DESCRIPTION
Revert the patch changing phy reset behavior, requiring also changes in the device tree that are missing in the stable backport. The issue was reported to the regressions mailing list and hopefully future patch release should contain a proper fix.

The patch is added to the patches-rockchip directory, potentially affecting Green as well, although the broken peripherals are not used there.

Fixes #3837, fixes #3841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Revert**
	- Reverted a previous PHY reset patch for Rockchip naneng-combphy driver
	- Addresses regressions in USB3 and PCIe functionality on ODROID-M1 and ODROID-M1S devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->