### PR TITLE
Allow boot from USB and NVMe on ODROID-M1

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
@@ -1,15 +1,15 @@
-part start mmc ${devnum} hassos-bootstate mmc_env
-mmc dev ${devnum}
+part start ${devtype} ${devnum} hassos-bootstate mmc_env
+${devtype} dev ${devnum}
 
 setenv loadbootstate " \
     echo 'loading env...'; \
-    mmc read ${ramdisk_addr_r} ${mmc_env} 0x40; \
+    ${devtype} read ${ramdisk_addr_r} ${mmc_env} 0x40; \
     env import -c ${ramdisk_addr_r} 0x8000;"
 
 setenv storebootstate " \
     echo 'storing env...'; \
     env export -c -s 0x8000 ${ramdisk_addr_r} BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT MACHINE_ID; \
-    mmc write ${ramdisk_addr_r} ${mmc_env} 0x40;"
+    ${devtype} write ${ramdisk_addr_r} ${mmc_env} 0x40;"
 
 run loadbootstate
 test -n "${BOOT_ORDER}" || setenv BOOT_ORDER "A B"
@@ -26,34 +26,34 @@ setenv bootargs_hassos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${M
 setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rootwait"
 setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro rootwait"
 
-part number mmc ${devnum} hassos-boot boot_partnum
+part number ${devtype} ${devnum} hassos-boot boot_partnum
 
 # Load environment from haos-config.txt
-if test -e mmc ${devnum}:${boot_partnum} haos-config.txt; then
-  fatload mmc ${devnum}:${boot_partnum} ${ramdisk_addr_r} haos-config.txt
+if test -e ${devtype} ${devnum}:${boot_partnum} haos-config.txt; then
+  fatload ${devtype} ${devnum}:${boot_partnum} ${ramdisk_addr_r} haos-config.txt
   env import -t ${ramdisk_addr_r} ${filesize}
 fi
 
 # Load extraargs
-fileenv mmc ${devnum}:${boot_partnum} ${ramdisk_addr_r} cmdline.txt cmdline
+fileenv ${devtype} ${devnum}:${boot_partnum} ${ramdisk_addr_r} cmdline.txt cmdline
 
 # Load device tree
 setenv fdtfile rk3568-odroid-m1.dtb
 echo "Loading standard device tree ${fdtfile}"
-fatload mmc ${devnum}:${boot_partnum} ${fdt_addr_r} ${fdtfile}
+fatload ${devtype} ${devnum}:${boot_partnum} ${fdt_addr_r} ${fdtfile}
 fdt addr ${fdt_addr_r}
 
 # load dt overlays
 fdt resize 65536
 for overlay_file in ${overlays}; do
-  if fatload mmc ${devnum}:${boot_partnum} ${ramdisk_addr_r} overlays/${overlay_file}.dtbo; then
+  if fatload ${devtype} ${devnum}:${boot_partnum} ${ramdisk_addr_r} overlays/${overlay_file}.dtbo; then
     echo "Applying kernel provided DT overlay ${overlay_file}.dtbo"
     fdt apply ${ramdisk_addr_r} || setenv overlay_error "true"
   fi
 done
 if test "${overlay_error}" = "true"; then
   echo "Error applying DT overlays, restoring original DT"
-  fatload mmc ${devnum}:${boot_partnum} ${fdt_addr_r} ${fdtfile}
+  fatload ${devtype} ${devnum}:${boot_partnum} ${fdt_addr_r} ${fdtfile}
 fi
 
 setenv bootargs
@@ -64,8 +64,8 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
-      part number mmc ${devnum} hassos-kernel0 kernel_partnum
-      if load mmc ${devnum}:${kernel_partnum} ${kernel_addr_r} Image; then
+      part number ${devtype} ${devnum} hassos-kernel0 kernel_partnum
+      if load ${devtype} ${devnum}:${kernel_partnum} ${kernel_addr_r} Image; then
           setenv bootargs "${bootargs_hassos} ${bootargs_a} rauc.slot=A ${cmdline}"
       fi
     fi
@@ -73,8 +73,8 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     if test ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
-      part number mmc ${devnum} hassos-kernel1 kernel_partnum
-      if load mmc ${devnum}:${kernel_partnum} ${kernel_addr_r} Image; then
+      part number ${devtype} ${devnum} hassos-kernel1 kernel_partnum
+      if load ${devtype} ${devnum}:${kernel_partnum} ${kernel_addr_r} Image; then
           setenv bootargs "${bootargs_hassos} ${bootargs_b} rauc.slot=B ${cmdline}"
       fi
     fi


### PR DESCRIPTION
In similar vein to @viraniac's https://github.com/home-assistant/operating-system/pull/3784, but for the ODROID-M1.

I've adapted Armbian's mainline u-boot (which is a decent [way to get rid of Petitboot](https://www.armbian.com/odroid-m1/)) with support for `setexpr` and `fileenv` and `squashfs`: see https://github.com/armbian/build/pull/7769. With those we can now boot HAOS using mainline u-boot in SPI, and thus run HAOS completely from NVMe, drastically enhancing performance and reliability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced boot script flexibility by introducing dynamic device type handling
  - Updated boot configuration to support more versatile storage device loading
  - Improved script adaptability for different hardware configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->