### PR TITLE
Remove unnecessary and invalid e2scrub removal from post-build

### DIFF
--- a/buildroot-external/scripts/rootfs-layer.sh
+++ b/buildroot-external/scripts/rootfs-layer.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 function fix_rootfs() {
-
     # Cleanup etc
     rm -rf "${TARGET_DIR:?}/etc/init.d"
     rm -rf "${TARGET_DIR:?}/etc/network"
@@ -27,10 +26,6 @@ function fix_rootfs() {
 
     # Use systemd-resolved for Host OS resolve
     sed -i '/^hosts:/ {/resolve/! s/files/resolve [!UNAVAIL=return] files/}' "${TARGET_DIR}/etc/nsswitch.conf"
-
-    # Remove e2scrub (LVM specific tools provided by e2fsprogs)
-    rm -f "/usr/lib/systemd/system/e2scrub*"
-    rm -f "/usr/sbin/e2scrub*" "/usr/lib/e2fsprogs/e2scrub*"
 }
 
 


### PR DESCRIPTION
Removal of the e2scrub binary is not needed anymore, as it's not installed and only BR2_PACKAGE_E2FSPROGS_E2IMAGE is enabled. Moreover, it's been probably wrong since the very beginning, as the TARGET_DIR prefix was missing, possibly leading to removal of the binary from the host/builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined system maintenance routines by refining cleanup operations to enhance overall performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->