### PR TITLE
Remove unnecessary GRUB userspace tools and other files

### DIFF
--- a/buildroot-external/scripts/rootfs-layer.sh
+++ b/buildroot-external/scripts/rootfs-layer.sh
@@ -26,6 +26,15 @@ function fix_rootfs() {
 
     # Use systemd-resolved for Host OS resolve
     sed -i '/^hosts:/ {/resolve/! s/files/resolve [!UNAVAIL=return] files/}' "${TARGET_DIR}/etc/nsswitch.conf"
+
+    # Remove unnecessary grub userspace tools, config, modules and translations
+    find "${TARGET_DIR}"/usr/{,s}bin -name "grub-*" -not -name "grub-editenv" -delete
+    rm -rf "${TARGET_DIR}/etc/grub.d"
+    rm -rf "${TARGET_DIR}/usr/lib/grub"
+    if [ -d "${TARGET_DIR}/share/locale" ]; then
+        find "${TARGET_DIR}/share/locale" -name "grub.mo" -delete
+        find "${TARGET_DIR}/share/locale" -type d -empty -delete
+    fi
 }
 
 


### PR DESCRIPTION
Because the OTA hooks interact with GRUB environment using grub-editenv, we have BR2_TARGET_GRUB2_INSTALL_TOOLS enabled. However, that brings massive bloat of files that are never used in HAOS, as it also installs many other binaries, GRUB modules and translations.

As it's not possible to configure what gets installed in grub2 package, remove the undesired files in the post-build function. This brings savings of ~8.5MB of space in the root partition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved system housekeeping by removing unnecessary GRUB components to streamline the environment and reduce clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->