### PR TITLE
Remove all info pages in post-build script

### DIFF
--- a/buildroot-external/scripts/rootfs-layer.sh
+++ b/buildroot-external/scripts/rootfs-layer.sh
@@ -12,6 +12,10 @@ function fix_rootfs() {
     rm -rf "${TARGET_DIR:?}/srv"
     rm -rf "${TARGET_DIR:?}/opt"
 
+    # Remove info pages
+    rm -rf "${TARGET_DIR:?}/share/info"
+    rm -rf "${TARGET_DIR:?}/usr/share/info"
+
     # Cleanup miscs
     rm -rf "${TARGET_DIR}/usr/lib/modules-load.d"
 


### PR DESCRIPTION
As we don't have the info utility in HAOS, it's worthless to preserve info pages. While there are currently some files in /share/info (coming from GRUB2 tools install), /usr/share/info was added pre-emptively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced system cleanup to remove unnecessary documentation files, ensuring a leaner deployment and optimized resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->