### PR TITLE
Update Docker to v28.0.1

### DIFF
--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -23,7 +23,7 @@ container=$(docker run --privileged -e DOCKER_TLS_CERTDIR="" \
 	-v "${build_dir}/data/":/data \
 	-v "${build_dir}/data/docker/":/var/lib/docker \
 	-v "${build_dir}":/build \
-	-d docker:27.2-dind --storage-driver overlay2)
+	-d docker:28.0-dind --storage-driver overlay2)
 
 docker exec "${container}" sh /build/dind-import-containers.sh "${channel}"
 


### PR DESCRIPTION
Update Docker to latest version and containerd to latest version from the 1.7 line. Runc updated to v1.2.5 with rebased patchset from the outstanding PR.

* buildroot 257ddc70ce...b4df362187 (4):
  > package/runc: bump version to v1.2.5
  > package/docker-cli: bump version to v28.0.1
  > package/docker-engine: bump version to v28.0.1
  > package/containerd: bump version to v1.7.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal project dependencies to align with the latest stable releases.
  - Upgraded the Docker image version used in key processes to boost reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->