### PR TITLE
Bump os-agent to v1.7.1

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.6.0
+OS_AGENT_VERSION = 1.7.1
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Adds new DBus APIs for NTP servers and swap:
 - https://github.com/home-assistant/os-agent/pull/207
 - https://github.com/home-assistant/os-agent/pull/222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the OS Agent package version from 1.6.0 to 1.7.1, ensuring that the released version information reflects the latest update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->