### PR TITLE
Add test that no AppArmor denied events are produced

### DIFF
--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -193,6 +193,13 @@ def test_restore_ssl_directory(shell_json, stash):
 
 
 @pytest.mark.dependency(depends=["test_start_supervisor"])
+def test_no_apparmor_denies(shell):
+    """Check there are no AppArmor denies in the logs raised during Supervisor tests."""
+    output = shell.run_check("journalctl -t audit | grep DENIED || true")
+    assert not output, f"AppArmor denies found: {output}"
+
+
+@pytest.mark.dependency(depends=["test_start_supervisor"])
 def test_kernel_not_tainted(shell):
     """Check if the kernel is not tainted - do it at the end of the
     test suite to increase the chance of catching issues."""


### PR DESCRIPTION
As discussed in #3885, now that fixed Supervisor is in stable, we can test that no AppArmor denied events are logged during CI tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added an automated check to confirm that system logs remain free of unexpected security denial messages. This enhancement bolsters the overall reliability of our testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->