### PR TITLE
Use shell script instead of OS Agent for device wipe

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
@@ -4,15 +4,13 @@ DefaultDependencies=no
 RefuseManualStart=true
 RefuseManualStop=true
 Wants=mnt-boot.mount
-Requires=haos-agent.service
-After=haos-agent.service mnt-boot.mount
+After=mnt-boot.mount
 Before=mnt-data.mount mnt-overlay.mount
 ConditionKernelCommandLine=haos.wipe=1
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/busctl --verbose --timeout=1h call io.hass.os /io/hass/os/System io.hass.os.System WipeDevice
-ExecStartPost=/usr/bin/sed -i 's/\s*haos.wipe=1//g' /mnt/boot/cmdline.txt
+ExecStart=/usr/libexec/haos-wipe
 
 [Install]
 WantedBy=sysinit.target

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-wipe
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-wipe
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+PARTITION_OVERLAY="/dev/disk/by-label/hassos-overlay"
+PARTITION_DATA="/dev/disk/by-label/hassos-data"
+
+if [ ! -b "$PARTITION_OVERLAY" ]; then
+    echo "[ERROR] Overlay partition not found"
+    exit 1
+elif findmnt "$PARTITION_OVERLAY" > /dev/null; then
+    echo "[ERROR] Unable to wipe overlay partition while it is already mounted"
+    exit 1
+fi
+
+if [ ! -b "$PARTITION_DATA" ]; then
+    echo "[ERROR] Data partition not found"
+    exit 1
+elif findmnt "$PARTITION_DATA" > /dev/null; then
+    echo "[ERROR] Unable to wipe data partition while it is already mounted"
+    exit 1
+fi
+
+echo "[INFO] Wiping data partition"
+mkfs.ext4 -L "hassos-data" -E lazy_itable_init=0,lazy_journal_init=0 "$PARTITION_DATA"
+
+echo "[INFO] Wiping overlay partition"
+mkfs.ext4 -L "hassos-overlay" -I 256 -E lazy_itable_init=0,lazy_journal_init=0 "$PARTITION_OVERLAY"
+
+echo "[INFO] Removing wipe flag from cmdline.txt"
+/usr/bin/sed -i 's/\s*haos.wipe=1//g' /mnt/boot/cmdline.txt


### PR DESCRIPTION
Use simple shell script to perform device wipe instead of calling OS Agent to do that through the UDisks2 API. While it might have been a good idea to use high level interface for that back then, it turns out it causes more issues than the benefits it could bring.

Main problem currently is that the OS Agent needs to read sysctl variables, but those are only set after mounting the overlay partition. But at the same time, the overlay partition can't be mounted if we want to wipe it - this creates a dependency cycle through the haos-agent.service.

To get rid of the cycle and simplify things, use a shell script doing basically the same what the OS Agent does. Since the wipe functionality only makes sense to be implemented on HAOS targets (not on Supervised), there's little point of having it in higher layer of abstraction that OS Agent provides.

It should be also checked if changes from #1291 are needed anymore, as the driving factor for those have been probably the wipe feature in OS Agent too, but at this point they seem to be harmless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a secure wipe tool that safely validates and formats specific partitions, ensuring proper conditions before execution.
- **Refactor**
	- Streamlined the wipe process by updating service startup order and removing unnecessary dependencies, simplifying execution and enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->