### PR TITLE
Improve tests traceability, add test for Systemd dependency cycles

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ./tests/run_tests.sh
+          ./tests/run_tests.sh --durations=0 --durations-min=5.0
 
       - name: Archive logs
         uses: actions/upload-artifact@v4

--- a/tests/smoke_test/test_offline.py
+++ b/tests/smoke_test/test_offline.py
@@ -27,7 +27,7 @@ def _check_connectivity(shell, *, connected):
         raise AssertionError(f"expecting connected but all targets are down")
 
 
-@pytest.mark.timeout(300)  # takes quite a while also because of 90s NTP sync timeout
+@pytest.mark.timeout(120)
 @pytest.mark.usefixtures("without_internet")
 def test_ha_runs_offline(shell):
     def check_container_running(container_name):

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -16,7 +16,7 @@ def stash() -> dict:
 
 
 @pytest.mark.dependency()
-@pytest.mark.timeout(600)
+@pytest.mark.timeout(120)
 def test_start_supervisor(shell, shell_json):
     def check_container_running(container_name):
         out = shell.run_check(f"docker container inspect -f '{{{{.State.Status}}}}' {container_name} || true")
@@ -55,7 +55,7 @@ def test_check_supervisor(shell_json):
 
 
 @pytest.mark.dependency(depends=["test_check_supervisor"])
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(120)
 def test_update_supervisor(shell_json):
     supervisor_info = shell_json("ha supervisor info --no-progress --raw-json")
     supervisor_version = supervisor_info.get("data").get("version")
@@ -153,7 +153,7 @@ def test_addon_uninstall(shell_json):
 
 
 @pytest.mark.dependency(depends=["test_supervisor_is_updated"])
-@pytest.mark.timeout(450)
+@pytest.mark.timeout(120)
 def test_restart_supervisor(shell, shell_json):
     result = shell_json("ha supervisor restart --no-progress --raw-json")
     assert result.get("result") == "ok", f"Supervisor restart failed: {result}"


### PR DESCRIPTION
* Add test checking journal logs for dependency cycles
* Run some test cases to get their output also when full init fails
* Remove high timeouts from the times when GHA couldn't use KVM
* Enable logging durations for future optimizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the test runner to provide more detailed duration metrics.
  - Adjusted several test timeouts for quicker feedback.
  - Removed dependencies between tests to allow for independent execution.
  - Added a new test to check for proper management of system dependency cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->