### PR TITLE
Ensure haos-wipe service can be called only once per boot

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-wipe.service
@@ -10,6 +10,7 @@ ConditionKernelCommandLine=haos.wipe=1
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/libexec/haos-wipe
 
 [Install]


### PR DESCRIPTION
In some cases, the wipe service may be called due to a race condition for the second time during the boot, very likely failing because the filesystems are already mounted. This can not be reproduced on OVA but can be fairly easy triggered e.g. on RPi. As we want the service to be executed exactly only once, we can do what's suggested in [1] and set the RemainAfterExit=yes. That should ensure the unit is not ever started for the second time.

[1] https://www.github.com/systemd/systemd/issues/29367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved background service behavior now keeps a vital process active after execution, enhancing overall system stability during startup and ensuring smoother operation for dependent services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->