### PR TITLE
Add landing page test to the basic test set

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -65,6 +65,12 @@ def test_supervisor_logs(shell):
     _LOGGER.info("%s", "\n".join(output))
 
 
+@pytest.mark.dependency(depends=["test_init"])
+def test_landing_page(shell):
+    web_index = shell.run_check("curl http://localhost:8123")
+    assert "</html>" in " ".join(web_index)
+
+
 def test_systemctl_status(shell):
     output = shell.run_check("systemctl --no-pager -l status -a || true")
     _LOGGER.info("%s", "\n".join(output))


### PR DESCRIPTION
We check that landing page is working when the network is down but we don't check it in the happy path. Add its test to make it more obvious when the just landing page is broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a new automated check to verify that the landing page loads correctly and returns valid HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->