### PR TITLE
Set initial_turbo=0 in config.txt on Raspberry Pi 3

### DIFF
--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -71,6 +71,10 @@ kernel=u-boot.bin
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+[pi3]
+# Added to fix #3965
+initial_turbo=0
+
 [pi4]
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
 dtoverlay=vc4-fkms-v3d

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -63,7 +63,7 @@ install_boot() {
                 sed -i '/^\[pi3\]/a # Added to fix #3965\ninitial_turbo=0' "${BOOT_MNT}/config.txt"
             else
                 echo "Adding [pi3] section with initial_turbo=0 to config.txt"
-                sed -i 's/^\[pi4\]/\[pi3\]\n# Added to fix #3965\ninitial_turbo=0\n\n\[pi4\]/' "${BOOT_MNT}/config.txt"
+                sed -i 's/^\[all\]/\[pi3\]\n# Added to fix #3965\ninitial_turbo=0\n\n\[all\]/' "${BOOT_MNT}/config.txt"
             fi
         fi
     fi

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -53,6 +53,21 @@ install_boot() {
         fi
     fi
 
+    # Fix for Pi3 not booting from some SD cards with now default initial_turbo=60
+    # see: https://github.com/home-assistant/operating-system/issues/3965
+    if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-rpi3" ] || [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-rpi3-64" ]; then
+        # Don't change anything if initial_turbo is already set anywhere
+        if ! grep -q "^initial_turbo=" "${BOOT_MNT}/config.txt"; then
+            if grep -q '^\[pi3\]' "${BOOT_MNT}/config.txt"; then
+                echo "Adding initial_turbo=0 to [pi3] section of config.txt"
+                sed -i '/^\[pi3\]/a # Added to fix #3965\ninitial_turbo=0' "${BOOT_MNT}/config.txt"
+            else
+                echo "Adding [pi3] section with initial_turbo=0 to config.txt"
+                sed -i 's/^\[pi4\]/\[pi3\]\n# Added to fix #3965\ninitial_turbo=0\n\n\[pi4\]/' "${BOOT_MNT}/config.txt"
+            fi
+        fi
+    fi
+
     # Prepare rauc.db for migration, should be removed in HAOS 16
     # (along with raucdb-migrate.service and related raucdb-update changes)
     if [ -f /mnt/data/rauc.db ]; then


### PR DESCRIPTION
Firmware change that set initial_turbo to 60 from the previous 0 has broken initialization of some SD cards in U-Boot. Adjust the value in config.txt on OS update if the value is not already set by the user, and put it to the default config.txt.

The config.txt also contains a short comment explaining the purpose. The purpose of it is also to make it easier to revert this change in the future if the problem is fixed in the firmware or U-Boot.

Fixes #3965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration section for Raspberry Pi 3, including the parameter `initial_turbo=0`.
- **Bug Fixes**
	- Enhanced Raspberry Pi 3 boot reliability by automatically applying necessary configuration settings during startup, ensuring stable operation with various SD cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->