### PR TITLE
Add workflow for locking old issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,20 @@
+name: Lock
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  lock:
+    if: github.repository_owner == 'home-assistant'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5.0.1
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: "30"
+          exclude-issue-created-before: "2025-01-01T00:00:00Z"
+          issue-lock-reason: ""
+          pr-inactive-days: "7"
+          exclude-pr-created-before: "2025-01-01T00:00:00Z"
+          pr-lock-reason: ""


### PR DESCRIPTION
To avoid necroposting to old issues that's usually left unnoticed, add workflow for locking issues similar to the one that Core has.

The PR locking limit can be increased as the traffic is much lower compared to Core. Issues before 2025 have been locked manually via the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated process that runs hourly to manage and lock inactive issues and pull requests. Inactive issues (after a longer period) and pull requests (after a shorter period) may be automatically locked, ensuring that discussions remain focused and up-to-date while exempting recently created items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->