### PR TITLE
Change algorithm name in OVA manifest from SHA2-256 to SHA256

### DIFF
--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -81,7 +81,7 @@ function convert_disk_image_ova() {
 
     cp -a "${BOARD_DIR}/home-assistant.ovf" "${ova_data}/home-assistant.ovf"
     qemu-img convert -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic "${hdd_img}" "${ova_data}/home-assistant.vmdk"
-    (cd "${ova_data}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* >home-assistant.mf)
+    (cd "${ova_data}" || exit 1; "${HOST_DIR}/bin/openssl" sha256 home-assistant.* | sed 's/SHA2-256/SHA256/' > home-assistant.mf)
     tar -C "${ova_data}" --owner=root --group=root -cf "${hdd_ova}" home-assistant.ovf home-assistant.vmdk home-assistant.mf
 }
 


### PR DESCRIPTION
Update of OpenSSL in OS 12.2 from 1.1.1 to 3.2 changed the output of `openssl sha256` command. It seems that some hypervisors don't like this and fail if it's not plain "SHA256".

Fixes #3654