### PR TITLE
Fix permissions for the lock workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+permissions:
+  discussions: write
+  issues: write
+  pull-requests: write
+
 jobs:
   lock:
     if: github.repository_owner == 'home-assistant'


### PR DESCRIPTION
Unlike Core this repo has stricter default policy for actions. Explicitly enable permissions for scope the lock workflow needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced automation processes to better manage community interactions, including discussions, issue updates, and pull request feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->