### PR TITLE
Adjust lock workflow to run only once a day

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,7 +2,7 @@ name: Lock
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "45 5 * * *"
 
 permissions:
   discussions: write


### PR DESCRIPTION
It's unnecessary to run it every hour, adjust it to run shortly after the current stale workflow.