### PR TITLE
change suffix version syntax

### DIFF
--- a/buildroot-external/scripts/name.sh
+++ b/buildroot-external/scripts/name.sh
@@ -16,7 +16,7 @@ function hassos_version() {
     if [ -z "${VERSION_SUFFIX}" ]; then
         echo "${VERSION_MAJOR}.${VERSION_MINOR}"
     else
-        echo "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_SUFFIX}"
+        echo "${VERSION_MAJOR}.${VERSION_MINOR}~${VERSION_SUFFIX}"
     fi
 }
 


### PR DESCRIPTION
Very minor detail but `.dev` sorts higher than the release which makes version checks do the wrong thing. `~dev` seems to be the accepted syntax for this.

```
$ printf '15.1\n15.1.dev0\n15.0\n15.0.dev0' | sort -V
15.0
15.0.dev0
15.1
15.1.dev0
$ printf '15.1\n15.1~dev0\n15.0\n15.0~dev0' | sort -V
15.0~dev0
15.0
15.1~dev0
15.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Updated Version Display:** Version information now uses a distinct tilde separator when additional details are included. This change enhances clarity by clearly differentiating primary releases from those with extra identifiers, ensuring users can easily interpret and compare version details across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->