### PR TITLE
Enable PCI I/O virtualization in kernel

### DIFF
--- a/buildroot-external/kernel/v6.12.y/device-support-pci.config
+++ b/buildroot-external/kernel/v6.12.y/device-support-pci.config
@@ -1,4 +1,4 @@
-# enable SR-IOV driver support for a few NICs
+# enable IOV (e.g. for SR-IOV support in some NICs)
 CONFIG_PCI_IOV=y
 
 CONFIG_IGB=y

--- a/buildroot-external/kernel/v6.12.y/device-support-pci.config
+++ b/buildroot-external/kernel/v6.12.y/device-support-pci.config
@@ -1,3 +1,6 @@
+# enable SR-IOV driver support for a few NICs
+CONFIG_PCI_IOV=y
+
 CONFIG_IGB=y
 CONFIG_I40E=m
 CONFIG_IGC=m


### PR DESCRIPTION
Setting `CONFIG_PCI_IOV=y` should enable SR-IOV functionality for a few NIC drivers, BNXT for example:

https://github.com/torvalds/linux/blob/a2cc6ff5ec8f91bc463fd3b0c26b61166a07eb11/drivers/net/ethernet/broadcom/Kconfig#L222

handy for those of us running HAOS via proxmox or the like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for Single Root I/O Virtualization (SR-IOV) to enhance networking capabilities for select interface cards without altering the existing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->