### PR TITLE
Add tests for checking connectivity, fix Supervisor update test

### DIFF
--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -59,7 +59,9 @@ def test_check_supervisor(shell_json):
 def test_update_supervisor(shell_json):
     supervisor_info = shell_json("ha supervisor info --no-progress --raw-json")
     supervisor_version = supervisor_info.get("data").get("version")
-    if supervisor_version == supervisor_info.get("data").get("version_latest"):
+    supervisor_version_latest = supervisor_info.get("data").get("version_latest")
+    assert supervisor_version_latest, "Missing latest supervisor version info"
+    if supervisor_version == supervisor_version_latest:
         logger.info("Supervisor is already up to date")
         pytest.skip("Supervisor is already up to date")
     else:


### PR DESCRIPTION
When there's a problem with connectivity, it may result in obscure errors later in the testing. Add checks testing three scenarions:

* connectivity in host - both using curl and nmcli
* connectivity in Supervisor container (uses docker0 as default via)
* connectivity in CLI container (uses hassio as default via)

Also make sure that Supervisor upgrade isn't attempted when the version information is missing.