### PR TITLE
Fall back to buildroot make in top-level make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,9 @@ endif
 
 .NOTPARALLEL: $(TARGETS) $(TARGETS_CONFIG) all
 
-.PHONY: $(TARGETS) $(TARGETS_CONFIG) all clean help
+.PHONY: $(TARGETS) $(TARGETS_CONFIG) all buildroot-help clean help
 
 all: $(TARGETS)
-
-savedefconfig:
-	@echo "config $*"
-	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "savedefconfig"
 
 $(TARGETS_CONFIG): %-config:
 	@echo "config $*"
@@ -42,9 +38,19 @@ endif
 clean:
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) clean
 
+.DEFAULT:
+	@echo "falling back to Buildroot target '$@'"
+	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$@"
+
+buildroot-help:
+	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) help
+
 help:
-	@echo "Supported targets: $(TARGETS)"
 	@echo "Run 'make <target>' to build a target image."
 	@echo "Run 'make all' to build all target images."
 	@echo "Run 'make clean' to clean the build output."
 	@echo "Run 'make <target>-config' to configure buildroot for a target."
+	@echo ""
+	@echo "Supported targets: $(TARGETS)"
+	@echo ""
+	@echo "Unknown Makefile targets fall back to Buildroot make - for detauls run 'make buildroot-help'"

--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ help:
 	@echo ""
 	@echo "Supported targets: $(TARGETS)"
 	@echo ""
-	@echo "Unknown Makefile targets fall back to Buildroot make - for detauls run 'make buildroot-help'"
+	@echo "Unknown Makefile targets fall back to Buildroot make - for details run 'make buildroot-help'"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 .NOTPARALLEL: $(TARGETS) $(TARGETS_CONFIG) all
 
-.PHONY: $(TARGETS) $(TARGETS_CONFIG) all buildroot-help clean help
+.PHONY: $(TARGETS) $(TARGETS_CONFIG) all buildroot-help help
 
 all: $(TARGETS)
 
@@ -35,9 +35,6 @@ ifneq ($(words $(filter $(TARGETS),$(MAKECMDGOALS))), 1)
 endif
 	@echo "finished $@"
 
-clean:
-	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) clean
-
 .DEFAULT:
 	@echo "falling back to Buildroot target '$@'"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$@"
@@ -48,7 +45,6 @@ buildroot-help:
 help:
 	@echo "Run 'make <target>' to build a target image."
 	@echo "Run 'make all' to build all target images."
-	@echo "Run 'make clean' to clean the build output."
 	@echo "Run 'make <target>-config' to configure buildroot for a target."
 	@echo ""
 	@echo "Supported targets: $(TARGETS)"


### PR DESCRIPTION
To make running Buildroot commands easier, define .DEFAULT rule and fall back to targets from Buildroot with necessary variables set. This makes "savedefconfig" redundant as it's been simply passed to BR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new target to display Buildroot help information.
  - Unknown targets now automatically forward to the Buildroot make system with a helpful message.

- **Improvements**
  - Enhanced the help output with clearer explanations and formatting.

- **Removals**
  - Removed the savedefconfig and clean targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->