### PR TITLE
Make usage of top-level make easier, drop 'all' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,8 @@ default:
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL)
 
 $(TARGETS_CONFIG): %-config:
-	@if [ -d $(O) ] && [ "$$(ls -A $(O))" ]; then \
-		echo "$(COLOR_WARN)WARNING: Output directory '$(O)' is not empty!$(TERM_RESET)"; \
-		echo "         This may cause errors if it was previously used for a different target."; \
+	@if [ -f $(O)/.config ] && ! grep -q 'BR2_DEFCONFIG="$(DEFCONFIG_DIR)/$*_defconfig"' $(O)/.config; then \
+		echo "$(COLOR_WARN)WARNING: Output directory '$(O)' already contains files for another target!$(TERM_RESET)"; \
 		echo "         Before running build for a different target, run 'make distclean' first."; \
 		echo ""; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ $(TARGETS_CONFIG): %-config:
 		echo "$(COLOR_WARN)WARNING: Output directory '$(O)' already contains files for another target!$(TERM_RESET)"; \
 		echo "         Before running build for a different target, run 'make distclean' first."; \
 		echo ""; \
+		bash -c 'read -t 10 -p "Waiting 10s, press enter to continue or Ctrl-C to abort..."' || true; \
 	fi
 	@echo "$(COLOR_STEP)=== Using $*_defconfig ===$(TERM_RESET)"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$*_defconfig"

--- a/Makefile
+++ b/Makefile
@@ -14,37 +14,46 @@ else
 override O := $(BUILDDIR)/$(O)
 endif
 
-.NOTPARALLEL: $(TARGETS) $(TARGETS_CONFIG) all
+################################################################################
 
-.PHONY: $(TARGETS) $(TARGETS_CONFIG) all buildroot-help help
+COLOR_STEP := $(shell tput smso 2>/dev/null)
+COLOR_WARN := $(shell (tput setab 3; tput setaf 0) 2>/dev/null)
+TERM_RESET := $(shell tput sgr0 2>/dev/null)
 
-all: $(TARGETS)
+################################################################################
+
+.NOTPARALLEL: $(TARGETS) $(TARGETS_CONFIG) default
+
+.PHONY: $(TARGETS) $(TARGETS_CONFIG) default buildroot-help help
+
+# fallback target when target undefined here is given
+.DEFAULT:
+	@echo "$(COLOR_STEP)=== Falling back to Buildroot target '$@' ===$(TERM_RESET)"
+	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$@"
+
+# default target when no target is given - must be first in Makefile
+default:
+	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL)
 
 $(TARGETS_CONFIG): %-config:
-	@echo "config $*"
+	@if [ -d $(O) ] && [ "$$(ls -A $(O))" ]; then \
+		echo "$(COLOR_WARN)WARNING: Output directory '$(O)' is not empty!$(TERM_RESET)"; \
+		echo "         This may cause errors if it was previously used for a different target."; \
+		echo "         Before running build for a different target, run 'make distclean' first."; \
+		echo ""; \
+	fi
+	@echo "$(COLOR_STEP)=== Using $*_defconfig ===$(TERM_RESET)"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$*_defconfig"
 
 $(TARGETS): %: %-config
-	@echo "build $@"
+	@echo "$(COLOR_STEP)=== Building $@ ===$(TERM_RESET)"
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL)
-
-	# Do not clean when building for one target
-ifneq ($(words $(filter $(TARGETS),$(MAKECMDGOALS))), 1)
-	@echo "clean $@"
-	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) clean
-endif
-	@echo "finished $@"
-
-.DEFAULT:
-	@echo "falling back to Buildroot target '$@'"
-	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$@"
 
 buildroot-help:
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) help
 
 help:
 	@echo "Run 'make <target>' to build a target image."
-	@echo "Run 'make all' to build all target images."
 	@echo "Run 'make <target>-config' to configure buildroot for a target."
 	@echo ""
 	@echo "Supported targets: $(TARGETS)"


### PR DESCRIPTION
Make it easier when using top-level make - proxy all possible commands to Buildroot make and only wrap build for individual target builds. This way it's still possible to run e.g. 'make ova' which would read the defconfig and run the build, while we can also use the top-level make in the same way as it's in vanilla Buildroot.

Target 'all' was dropped in favor of Buildroot 'make' without any arguments - as it's fairly pointless to run all builds sequentially. With the current 19 targets it would take about a day even on a decent hardware and the build artifacts would be lost in the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved user feedback with colored terminal messages during build and configuration steps.
	- Replaced the previous default build target with a new `default` target for streamlined usage.
	- Enhanced handling of unknown targets with informative fallback messages.
	- Simplified help output and added explanations about fallback behavior.
	- Added warnings when attempting configuration with a non-empty output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->