### PR TITLE
Fix U-Boot config to access all RAM on 16 GB CM5

### DIFF
--- a/buildroot-external/board/raspberrypi/patches/uboot/0013-configs-rpi-set-NR_DRAM_BANKS-to-8-to-accommodate-RA.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0013-configs-rpi-set-NR_DRAM_BANKS-to-8-to-accommodate-RA.patch
@@ -1,0 +1,33 @@
+From 2525238175cb77f2cc0d83d77cc527997160bd90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Wed, 30 Apr 2025 18:33:53 +0200
+Subject: [PATCH] configs: rpi: set NR_DRAM_BANKS to 8 to accommodate RAM on
+ 16GB models
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Raspberry Pi 5 can now have up to 16 GiB of RAM where the memory spans 8
+DRAM banks in total. Increase the config value to 8 to initialize the
+whole RAM. Without this change, kernel only sees 8 GiB of RAM on the 16
+GiB CM5 as reported in [1].
+
+[1] https://github.com/home-assistant/operating-system/issues/3989
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ configs/rpi_arm64_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
+index 9fe5d177943..69e8e72c5d7 100644
+--- a/configs/rpi_arm64_defconfig
++++ b/configs/rpi_arm64_defconfig
+@@ -2,6 +2,7 @@ CONFIG_ARM=y
+ CONFIG_POSITION_INDEPENDENT=y
+ CONFIG_ARCH_BCM283X=y
+ CONFIG_TARGET_RPI_ARM64=y
++CONFIG_NR_DRAM_BANKS=8
+ CONFIG_ENV_SIZE=0x4000
+ CONFIG_DEFAULT_DEVICE_TREE="bcm2711-rpi-4-b"
+ CONFIG_OF_LIBFDT_OVERLAY=y

--- a/buildroot-external/board/raspberrypi/patches/uboot/0013-configs-rpi-set-NR_DRAM_BANKS-to-8-to-accommodate-RA.patch
+++ b/buildroot-external/board/raspberrypi/patches/uboot/0013-configs-rpi-set-NR_DRAM_BANKS-to-8-to-accommodate-RA.patch
@@ -15,6 +15,7 @@ GiB CM5 as reported in [1].
 [1] https://github.com/home-assistant/operating-system/issues/3989
 
 Signed-off-by: Jan Čermák <sairon@sairon.cz>
+Upstream: https://patchwork.ozlabs.org/project/uboot/patch/20250430171555.144243-1-sairon@sairon.cz/
 ---
  configs/rpi_arm64_defconfig | 1 +
  1 file changed, 1 insertion(+)


### PR DESCRIPTION
U-Boot defconfig used for Yellow checks only 4 DRAM banks, however, CM5 with 16 GB has the memory spread across 8 banks. Add a patch (submitted upstream) to the defconfig to get access to the whole RAM.

Fixes #3989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for Raspberry Pi 5 models with 16 GiB RAM, allowing the system to recognize and utilize the full memory capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->