### PR TITLE
Add brcmfmac module options to improve RPi WiFi stability

### DIFF
--- a/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/modprobe.d/brcmfmac.conf
+++ b/buildroot-external/board/raspberrypi/rootfs-overlay/usr/lib/modprobe.d/brcmfmac.conf
@@ -1,0 +1,1 @@
+options brcmfmac roamoff=1 feature_disable=0x282000


### PR DESCRIPTION
Latest RPi firmware package contains module options that supposedly improve stability, with details described in [1].

Since the feature_disable mask also disables the dump_obss feature, this change would also mitigate `brcmf_set_channel: set chanspec ... fail` messages still seen in some environments even after #3719.

Fixes #3367

[1] https://github.com/RPi-Distro/firmware-nonfree/commit/2788cb549a19bf2e77901c4071ef88c2ad683b7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated wireless driver settings to disable roaming and adjust feature options for improved network behavior on Raspberry Pi devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->