### PR TITLE
Add missing compatible/model to Yellow+CM5 DTS

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0023-ARM-dts-bcm2712-yellow-add-compatible-and-model-lost.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0023-ARM-dts-bcm2712-yellow-add-compatible-and-model-lost.patch
@@ -1,0 +1,32 @@
+From 3816eacd48bc8a6a392e784dd6f0cc6aea672ff8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Wed, 7 May 2025 16:44:16 +0200
+Subject: [PATCH] ARM: dts: bcm2712: yellow: add compatible and model lost in
+ cleanup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Although it's not used anywhere currently, compatible string and model name
+were lost when DTS was simplified after 6.12.y update. Add it back to override
+the CM5 default.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+index 32ada582e50d..1db56db1e95f 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+@@ -47,6 +47,9 @@ &hdmi1 {
+ // HA Yellow Board-specific stuff
+ 
+ / {
++	compatible = "raspberrypi,5-compute-module-ha-yellow", "raspberrypi,5-compute-module", "brcm,bcm2712";
++	model = "Raspberry Pi Compute Module 5 on Home Assistant Yellow";
++
+ 	chosen: chosen {
+ 		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0";
+ 		stdout-path = "serial2:115200n8";


### PR DESCRIPTION
The refactored DTS from #4036 was missing compatible and model strings for CM5 on Yellow. While this shouldn't cause any issues, add them back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored board-specific identification properties for the Raspberry Pi Compute Module 5 on Home Assistant Yellow, improving compatibility and device recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->