### PR TITLE
Add device-specific symlinks for WiFi firmware on Yellow

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.bin
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.bin

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.clm_blob
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.clm_blob

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.txt
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module-ha-yellow.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.bin
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.bin
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.bin

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.clm_blob
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.clm_blob
@@ -1,0 +1,1 @@
+../cypress/cyfmac43455-sdio.clm_blob

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.txt
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.bin
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.bin
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.bin

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.clm_blob
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.clm_blob
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.clm_blob

--- a/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.txt
+++ b/buildroot-external/board/raspberrypi/yellow/rootfs-overlay/usr/lib/firmware/brcm/brcmfmac43456-sdio.raspberrypi,4-compute-module-ha-yellow.txt
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.txt


### PR DESCRIPTION
Because we use custom compatible strings in Yellow DTS's, the firmware loader first attempts to load a firmware with this compatible in its name. Because it doesn't exists, it shows error like this one before falling back to a more generic one:

brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,5-compute-module-ha-yellow.bin failed with error -2

While these errors are mostly harmless, add symlinks with our compatible in the name to suppress them. Instead of patching upstream package/brcmfmac_sdio-firmware-rpi which installs the firmware files, add them to yellow overlay to make maintenance easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new firmware and configuration files to support additional Raspberry Pi Compute Module variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->