### PR TITLE
Fix hassio channel switching for dev builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -284,7 +284,7 @@ jobs:
         with:
           image: ${{ needs.prepare.outputs.build_container_image }}
           command: |
-            bash -c 'echo "${{ needs.prepare.outputs.hassio_channel_option }}=y" >> /build/.config && make olddefconfig'
+            bash -c 'echo "${{ needs.prepare.outputs.hassio_channel_option }}=y" >> /build/output/.config && make olddefconfig'
 
       - name: Build
         uses: "./.github/actions/haos-builder-command"


### PR DESCRIPTION
Fix build job to write config option for channel switching from #4043 to the actual config. As it was written to .config in the top-level build directory, it was never correctly applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to modify configuration settings in a different location, which may affect the build output. No user-facing features or functionality have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->