### PR TITLE
Fix RPi pre-image build hook with rpi-eeprom enabled

### DIFF
--- a/buildroot-external/board/raspberrypi/hassos-hook.sh
+++ b/buildroot-external/board/raspberrypi/hassos-hook.sh
@@ -21,12 +21,6 @@ function hassos_pre_image() {
     fi
     cp "${BINARIES_DIR}"/*.dtbo "${BOOT_DATA}/overlays/" 2>/dev/null || true
 
-    # EEPROM update for Raspberry Pi 4/Compute Module 4
-    if grep -Eq "^BR2_PACKAGE_RPI_EEPROM=y$" "${BR2_CONFIG}"; then
-        cp "${BINARIES_DIR}/rpi-eeprom/pieeprom.sig" "${BOOT_DATA}/pieeprom.sig"
-        cp "${BINARIES_DIR}/rpi-eeprom/pieeprom.upd" "${BOOT_DATA}/pieeprom.upd"
-    fi
-
     # Enable 64bit support
     if [[ "${BOARD_ID}" =~ "64" ]]; then
         sed -i "s|#arm_64bit|arm_64bit|g" "${BOOT_DATA}/config.txt"


### PR DESCRIPTION
Do not attempt to copy EEPROM update files to the boot partition, as they're not created build-time anymore.