### PR TITLE
Create VM image .zip files in parallel using pigz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Build tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	automake \
+        automake \
         bash \
         bc \
         binutils \
@@ -31,13 +31,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         file \
         git \
         graphviz \
-	help2man \
+        help2man \
         jq \
         make \
         ncurses-dev \
         openssh-client \
         patch \
         perl \
+        pigz \
         python3 \
         python3-matplotlib \
         python-is-python3 \
@@ -45,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         rsync \
         skopeo \
         sudo \
-	texinfo \
+        texinfo \
         unzip \
         vim \
         wget \

--- a/buildroot-external/scripts/hdd-image.sh
+++ b/buildroot-external/scripts/hdd-image.sh
@@ -100,5 +100,5 @@ function convert_disk_image_zip() {
     hdd_img="$(hassos_image_name "${hdd_ext}")"
 
     rm -f "${hdd_img}.zip"
-    zip -j -m -q -r "${hdd_img}.zip" "${hdd_img}"
+    pigz -q -K -S ".zip" "${hdd_img}"
 }


### PR DESCRIPTION
When creating OVA image, the CPU is slacking at the end of the build because it is creating three ZIP archives, each one on a single CPU only. As we're creating only single-entry archives, we can use pigz to use all cores.

The actual speedup on my machine (16C/32T) reflects the number of cores - it takes around 2 seconds instead of 1 minute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to use `pigz` for compressing disk images instead of `zip`, improving compression performance.
  - Added `pigz` to the set of installed build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->