### PR TITLE
Reenable systemd-resolved stub resolver

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf
@@ -20,6 +20,6 @@ DNSOverTLS=no
 #MulticastDNS=yes
 #LLMNR=yes
 #Cache=yes
-DNSStubListener=no
+#DNSStubListener=yes
 #ReadEtcHosts=yes
 #ResolveUnicastSingleLabel=no

--- a/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf.d/hassio.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/resolved.conf.d/hassio.conf
@@ -1,0 +1,2 @@
+[Resolve]
+DNSStubListenerExtra=172.30.32.1


### PR DESCRIPTION
Enable the systemd-resolved stub resolver and make it available on the hassio host network interface (172.30.32.1). This allows to use systemd-resolved directly from all containers.

Note that this makes /etc/resolv.conf point to the stub resolver running at 127.0.0.53 by default. This stub resolver isn't reachable from within containers. However, Docker does regnize this situation [1] and falls back to the alternate path at /run/systemd/resolve/resolv.conf, which is what /etc/resolv.conf is today. So this should not affect the initial /etc/resolv.conf in containers in practise.

This will however bind to port 53 and affect add-on potentially attempt to use that port. Add-ons should not bind to 127.0.0.53 or the hassio host network (172.30.32.1).

[1] https://github.com/moby/moby/blob/v28.0.4/libnetwork/internal/resolvconf/resolvconf_path.go#L51C32-L51C45