### PR TITLE
Remove bug label from the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report Form
 description: Report an issue related to the Home Assistant Operating System.
-labels: bug
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Same reasoning as in home-assistant/supervisor#5955, don't apply any labels or issue types before triaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the default "bug" label from new bug report submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->