### PR TITLE
Add Marvell 88E1XXX driver for x86-64

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -163,4 +163,8 @@ CONFIG_BMP280=m
 # Required for some PCIe devices such as ath12k
 CONFIG_IRQ_REMAP=y
 
+# Pin control support
 CONFIG_PINCTRL_CANNONLAKE=m
+
+# Network devices
+CONFIG_MARVELL_PHY=m


### PR DESCRIPTION
Add driver for Marvell PHYs, such as 88E1543(4L) on an ASRock C3758D4I-4L board. Adding it to x86 config only, as it seems it's not widely used anywhere else.

Fixes #4025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled support for Marvell PHY network devices.
- **Style**
  - Improved organization of kernel configuration options with clearer comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->