### PR TITLE
Fix flaky timeout after boot slot switching test

### DIFF
--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -3,7 +3,6 @@ import logging
 from time import sleep
 
 import pytest
-from labgrid.driver import ExecutionError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +85,7 @@ def test_boot_other_slot(shell, shell_json, target):
 
     shell.run_check(f"ha os boot-slot other --no-progress || true")
 
-    shell.console.expect("Booting `Slot ")
+    shell.console.expect("Booting `Slot ", timeout=60)
 
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)


### PR DESCRIPTION
Add timeout to expect call when waiting for the OS reboot after switching slots. While it never fails for me locally, it regularly breaks tests in GHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Increased the timeout for a console output check in the boot slot test to improve reliability.
  - Removed an unused import from the test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->