### PR TITLE
Update request feature link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report Form
+name: Report an issue with Home Assistant Operating System
 description: Report an issue related to the Home Assistant Operating System.
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@ contact_links:
     about: Our developer documentation has its own issue tracker. Please report issues with the website there.
 
   - name: Request a feature for the Operating System
-    url: https://community.home-assistant.io/c/feature-requests
+    url: https://github.com/orgs/home-assistant/discussions
     about: Request an new feature for the Operating System.
 
   - name: I have a question or need support


### PR DESCRIPTION
Feature requests are now collected using the org wide GitHub Community. Update the link accordingly.

While at it, also align the title to create issues with what is used in Home Assistant Core's template.