### PR TITLE
Make tests involving reboot more robust

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -115,7 +115,8 @@ def test_custom_swap_size(shell, target):
     output = shell.run_check("stat -c '%s' /mnt/data/swapfile")
     # set new swap size to half of the previous size - round to 4k blocks
     new_swap_size = (int(output[0]) // 2 // 4096) * 4096
-    shell.run_check(f"echo 'SWAPSIZE={new_swap_size/1024/1024}M' > /etc/default/haos-swapfile; reboot")
+    shell.console.sendline(f"echo 'SWAPSIZE={new_swap_size/1024/1024}M' > /etc/default/haos-swapfile; reboot")
+    shell.console.expect("Booting `Slot ", timeout=60)
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)
     target.activate(shell)
@@ -125,7 +126,8 @@ def test_custom_swap_size(shell, target):
 
 @pytest.mark.dependency(depends=["test_custom_swap_size"])
 def test_no_swap(shell, target):
-    output = shell.run_check("echo 'SWAPSIZE=0' > /etc/default/haos-swapfile; reboot")
+    shell.console.sendline("echo 'SWAPSIZE=0' > /etc/default/haos-swapfile; reboot")
+    shell.console.expect("Booting `Slot ", timeout=60)
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)
     target.activate(shell)

--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -57,7 +57,7 @@ def test_os_update(shell, shell_json, target):
 
         sleep(5)
 
-    shell.console.expect("Booting `Slot ")
+    shell.console.expect("Booting `Slot ", timeout=60)
 
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)
@@ -83,7 +83,9 @@ def test_boot_other_slot(shell, shell_json, target):
     os_info = shell_json("ha os info --no-progress --raw-json")
     other_version = os_info["data"]["boot_slots"]["A"]["version"]
 
-    shell.run_check(f"ha os boot-slot other --no-progress || true")
+    # as we sometimes don't get another shell prompt after the boot slot switch,
+    # use plain sendline instead of the run_check method
+    shell.console.sendline(f"ha os boot-slot other --no-progress || true")
 
     shell.console.expect("Booting `Slot ", timeout=60)
 


### PR DESCRIPTION
The tests that are involving reboots are flaky and fail when waiting for the command to return or when waiting for a new login prompt. To mitigate this, do not use run_check, as it needs the shell prompt to reappear, and instead use sendline and wait up to a minute for the GRUB message.