### PR TITLE
Mount Systemd Journal socket to the Supervisor container

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -95,6 +95,7 @@ if [ -z "${SUPERVISOR_CONTAINER_ID}" ]; then
         --oom-score-adj=-300 \
         -v /run/docker.sock:/run/docker.sock:rw \
         -v /run/containerd/containerd.sock:/run/containerd/containerd.sock:rw \
+        -v /run/systemd/journal/socket:/run/systemd/journal/socket:rw \
         -v /run/systemd-journal-gatewayd.sock:/run/systemd-journal-gatewayd.sock:rw \
         -v /run/dbus:/run/dbus:ro \
         -v /run/supervisor:/run/os:rw \


### PR DESCRIPTION
Bind-mount Systemd Journal socket to the Supervisor container. This way Supervisor can use the socket directly for writing log entries using the Systemd native Journal protocol [1] instead of logging to stderr of the container.

[1] https://systemd.io/JOURNAL_NATIVE_PROTOCOL/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mounting the systemd journal socket into the supervisor container, enabling improved integration with system logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->