### PR TITLE
Make all Raspberry Pi LAN drivers built-in

### DIFF
--- a/buildroot-external/board/raspberrypi/kernel.config
+++ b/buildroot-external/board/raspberrypi/kernel.config
@@ -8,5 +8,17 @@ CONFIG_LEDS_TRIGGERS=y
 CONFIG_LEDS_TRIGGER_DISK=y
 CONFIG_LEDS_TRIGGER_ACTIVITY=y
 
+# make sure all network drivers are built-in
+# RPi 3B USB LAN drivers - 3B uses SMSC95XX, 3B+ uses LAN78XX
+CONFIG_USB_NET_DRIVERS=y
+CONFIG_USB_USBNET=y
+CONFIG_USB_LAN78XX=y
+CONFIG_USB_NET_SMSC95XX=y
+# RPi 4 uses bcmgenet driver and BCM54213PE PHY
+CONFIG_BCMGENET=y
+CONFIG_BROADCOM_PHY=y
+# RPi 5 uses Cadence driver and BCM54213PE PHY (above)
+CONFIG_MACB=y
+
 # do not use RPi in-tree driver, use one from BR package instead
 # CONFIG_MEDIA_PCI_HAILO is not set


### PR DESCRIPTION
Make sure that all LAN drivers used on Raspberry Pi boards are built-in. Although they are defined as such in the base defconfig, we change them to modules in device support includes. For simplicity and keeping kernel config close to the RPi OS config, change them all to built-in in the main RPi include for all RPi targets.

This is not only a formal change - at least one regression is known if the PHY driver on RPi 5 is not built-in and MAC driver is - in that case the PHY hooked up to the RP1 isn't initialized properly, and it is reported as "Generic PHY" instead, e.g. breaking the control of LEDs through dtparams. Relevant dmesg log before the change:

 macb 1f00100000.ethernet end0: PHY [1f00100000.ethernet-ffffffff:01] driver [Generic PHY] (irq=POLL)

And after the change:

 macb 1f00100000.ethernet eth0: PHY [1f00100000.ethernet-ffffffff:01] driver [Broadcom BCM54213PE] (irq=POLL)

Fixes #3333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network support for Raspberry Pi devices by enabling relevant Ethernet and USB network drivers for models 3B, 3B+, 4, and 5. This ensures improved compatibility and connectivity across different hardware versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->