### PR TITLE
Unbind Broadcom HCI driver on RPi/CM without WiFi

### DIFF
--- a/buildroot-external/package/pi-bluetooth/hciunbind.service
+++ b/buildroot-external/package/pi-bluetooth/hciunbind.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Unbind Broadcom HCI driver if WiFi/Bluetooth module is not present
+ConditionPathExists=!/sys/bus/sdio/devices/mmc1:0001:1
+ConditionPathExists=/sys/bus/serial/drivers/hci_uart_bcm/unbind
+ConditionPathExists=/proc/device-tree/chosen/rpi-boardrev-ext
+Before=bluetooth.service
+
+[Service]
+Type=oneshot
+ExecCondition=/bin/sh -c 'test $((16#$(xxd -p -g4 /proc/device-tree/chosen/rpi-boardrev-ext) & 16#40000000)) -gt 0'
+ExecStart=/bin/sh -c 'echo "serial0-0" > /sys/bus/serial/drivers/hci_uart_bcm/unbind'
+
+[Install]
+WantedBy=hassos-hardware.target

--- a/buildroot-external/package/pi-bluetooth/pi-bluetooth.mk
+++ b/buildroot-external/package/pi-bluetooth/pi-bluetooth.mk
@@ -12,6 +12,7 @@ PI_BLUETOOTH_LICENSE_FILES = debian/copyright
 define PI_BLUETOOTH_INSTALL_TARGET_CMDS
 	$(INSTALL) -d $(TARGET_DIR)/etc/systemd/system/hassos-hardware.target.wants
 	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/hciuart.service $(TARGET_DIR)/usr/lib/systemd/system/
+	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/hciunbind.service $(TARGET_DIR)/usr/lib/systemd/system/
 	$(INSTALL) -m 0644 $(BR2_EXTERNAL_HASSOS_PATH)/package/pi-bluetooth/bthelper@.service $(TARGET_DIR)/usr/lib/systemd/system/
 
 	$(INSTALL) -d $(TARGET_DIR)/usr/bin


### PR DESCRIPTION
Unbind the Bluetooth driver for Broadcom HCI module before the bluetooth service starts if running on board without WiFi module. This is a replacement for #2948 but using a more targeted approach for removing the particular driver and better detection of no-WiFi (thus no-Bluetooth) models.

This still means the driver will be probed and couple of lines printed when it fails to set baudrate and reset the module, yet this should be benign, at least the all-zero MAC device no longers appears in Bluetooth stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new service that conditionally unbinds the Broadcom HCI driver for certain hardware configurations. This service runs automatically before Bluetooth services start and only activates if specific hardware conditions are met.

* **Chores**
  * Updated installation routines to include the new service in the system setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->