### PR TITLE
Drop experimental and ip6tables config

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -1,8 +1,6 @@
 {
     "storage-driver": "overlay2",
     "log-driver": "journald",
-    "experimental": true,
-    "ip6tables": true,
     "log-opts": {
         "tag": "{{.Name}}"
     },


### PR DESCRIPTION
The ip6tables configuration is now enabled by default since Docker 27 (see https://github.com/moby/moby/pull/47747). The experimental config got introduced with the ip6tables flag in #2051. There is no other experimental feature used from what I am aware of, so lets remove the experimental flag as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker daemon configuration by removing experimental and IPv6 ip6tables options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->