### PR TITLE
Generate Virtual Disk Image (VDI) for aarch64 build

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/hassos-hook.sh
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/hassos-hook.sh
@@ -20,9 +20,11 @@ function hassos_pre_image() {
 
 function hassos_post_image() {
     convert_disk_image_virtual vmdk
+    convert_disk_image_virtual vdi
     convert_disk_image_virtual qcow2
 
     convert_disk_image_zip vmdk
+    convert_disk_image_zip vdi
     convert_disk_image_xz qcow2
 
     convert_disk_image_xz


### PR DESCRIPTION
As there is VirtualBox available for aarch64 on Apple Macs, provide OS images also in the native VirtualBox format, which also grants the ability to resize existing disk images, unlike VMDK.

Fixes #4171 & fixes #4172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional image format conversions for the "vdi" disk image type during the image creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->