### PR TITLE
Suppress new warnings from shellcheck v0.11.0

### DIFF
--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-# shellcheck disable=SC2317  # Being usesd in trap which shellcheck can't follow
+# shellcheck disable=SC2317,SC2329  # Being usesd in trap which shellcheck can't follow
 cleanup_boot() {
     umount "${BOOT_NEW}"
     rm -rf "${BOOT_TMP}" "${BOOT_NEW}"


### PR DESCRIPTION
Shellcheck v0.11.0 added new warnings which raise false positive on the trap function in the OTA hook script. Suppress also that warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis settings for improved code linting compliance. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->