### PR TITLE
Bump to latest default FW version (2025-05-08) in rpi-eeprom-update

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  9e64372f0480b8410fce3f9cc12c01548eaac36e36fe0fe8f979535281d41290  rpi-eeprom-cd4048df1d55be89bf84879754a4acf9c92e1f7a.tar.gz
+sha256  67e82c88f3bd3d9dd4adac48f1d6839b715931bd7700d768b21125f6d43517ca  rpi-eeprom-2349daafacfb7a7abe2cfecf30a49ae837bdf2c6.tar.gz
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = cd4048df1d55be89bf84879754a4acf9c92e1f7a
+RPI_EEPROM_VERSION = 2349daafacfb7a7abe2cfecf30a49ae837bdf2c6
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -14,7 +14,7 @@ define RPI_EEPROM_INSTALL_RPI4_FILES
 	$(INSTALL) -d $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/recovery.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/vl805-000138c0.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
-	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/pieeprom-2025-02-11.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
+	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/pieeprom-2025-05-08.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
 endef
 endif
 
@@ -22,7 +22,7 @@ ifneq ($(BR2_PACKAGE_RPI_EEPROM_TARGET_ANY)$(BR2_PACKAGE_RPI_EEPROM_TARGET_RPI5)
 define RPI_EEPROM_INSTALL_RPI5_FILES
 	$(INSTALL) -d $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/recovery.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
-	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/pieeprom-2025-03-10.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
+	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/pieeprom-2025-05-08.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
 endef
 endif
 


### PR DESCRIPTION
Make rpi-eeprom-update install latest default FW version when `rpi-eeprom-update -a` is executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Raspberry Pi 4 and Raspberry Pi 5 bootloader firmware to the latest versions dated 2025-05-08.

* **Chores**
  * Updated package version and checksum for the rpi-eeprom firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->