### PR TITLE
Prevent root from running the enter.sh helper script

### DIFF
--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -8,7 +8,7 @@ ARGS="$*"
 COMMAND="${ARGS:-bash}"
 
 if [ "$BUILDER_UID" -eq "0" ] || [ "$BUILDER_GID" == "0" ]; then
-  echo "ERROR: Please use a non-root with sudo rights for running this script."
+  echo "ERROR: Please run this script as a regular (non-root) user with sudo privileges."
   exit 1
 fi
 


### PR DESCRIPTION
Since configure doesn't like being ran as root, check in the enter.sh script that the user running it is not UID/GID 0. The script itself takes care of running what needs to be executed privileged with explicit sudo commands.

Fixes #4214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a check to prevent running the script as the root user or group, displaying an error message and exiting if detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->