### PR TITLE
Enable publishing of dev builds to R2 without bumping version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -432,7 +432,7 @@ jobs:
 
   bump_version:
     name: Bump ${{ needs.prepare.outputs.channel }} channel version
-    if: ${{ github.repository == 'home-assistant/operating-system' && needs.prepare.outputs.publish_build == 'true' }}
+    if: ${{ github.repository == 'home-assistant/operating-system' && needs.prepare.outputs.publish_build == 'true' && (needs.prepare.outputs.channel != 'dev' || github.ref == 'refs/heads/dev') }}
     environment: ${{ needs.prepare.outputs.channel }}
     needs: [ build, prepare ]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
We currently can only use Github artifacts for on-demand builds from feature branches. However, downloading of these requires authentication and it's tricky to update a device if we need feedback from user testing. On the other hand, we never want to publish to the dev channel from anything else than from the dev branch. Restrict version bump to builds from release channels or from the dev branch only.