### PR TITLE
Fix scripts/enter.sh so it is usable on macOS

### DIFF
--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -4,28 +4,26 @@ set -e
 BUILDER_UID="$(id -u)"
 BUILDER_GID="$(id -g)"
 CACHE_DIR="${CACHE_DIR:-$HOME/hassos-cache}"
-ARGS="$*"
-COMMAND="${ARGS:-bash}"
 
 if [ "$BUILDER_UID" -eq "0" ] || [ "$BUILDER_GID" == "0" ]; then
   echo "ERROR: Please run this script as a regular (non-root) user with sudo privileges."
   exit 1
 fi
 
-sudo mkdir -p "${CACHE_DIR}"
-sudo chown -R "${BUILDER_UID}:${BUILDER_GID}" "${CACHE_DIR}"
-sudo docker build -t hassos:local .
+mkdir -p "${CACHE_DIR}"
+docker build -t hassos:local .
 
 if [ ! -f buildroot/Makefile ]; then
   # Initialize git submodule
   git submodule update --init
 fi
 
-# Make sure loop devices are present before starting the container
-sudo losetup -f > /dev/null
+if command -v losetup && [ ! -e /dev/loop0 ]; then
+  # Make sure loop devices are present before starting the container
+  sudo losetup -f > /dev/null
+fi
 
-# shellcheck disable=SC2086
-sudo docker run -it --rm --privileged \
+docker run -it --rm --privileged \
   -v "$(pwd):/build" -v "${CACHE_DIR}:/cache" \
   -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
-  hassos:local ${COMMAND}
+  hassos:local "${@:-bash}"

--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -18,7 +18,7 @@ if [ ! -f buildroot/Makefile ]; then
   git submodule update --init
 fi
 
-if command -v losetup && [ ! -e /dev/loop0 ]; then
+if command -v losetup >/dev/null && [ ! -e /dev/loop0 ]; then
   # Make sure loop devices are present before starting the container
   sudo losetup -f > /dev/null
 fi


### PR DESCRIPTION
Also, stop requiring `sudo` for actions that do not need it

Tested by building generic_x86_64 target on a macOS machine

----

This PR possibly also allows to build HAOS on Windows via WSL2, though I haven't tested it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forwards your command-line arguments directly into the container, defaulting to an interactive bash shell when none are provided.

* **Bug Fixes**
  * Only attempts loop-device setup when supported, avoiding failures on systems without losetup.

* **Refactor**
  * Removes sudo requirements for common operations and simplifies argument handling by eliminating unused environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->