### PR TITLE
Fix missing rpi-rf-mod overlay on Yellow

### DIFF
--- a/buildroot-external/board/raspberrypi/hassos-hook.sh
+++ b/buildroot-external/board/raspberrypi/hassos-hook.sh
@@ -19,7 +19,10 @@ function hassos_pre_image() {
     else
         cp "${BOARD_DIR}/../cmdline.txt" "${BOOT_DATA}/cmdline.txt"
     fi
-    cp "${BINARIES_DIR}"/*.dtbo "${BOOT_DATA}/overlays/" 2>/dev/null || true
+    if ls "${BINARIES_DIR}"/*.dtbo >/dev/null 2>&1; then
+        mkdir -p "${BOOT_DATA}/overlays"
+        cp "${BINARIES_DIR}"/*.dtbo "${BOOT_DATA}/overlays/"
+    fi
 
     # Enable 64bit support
     if [[ "${BOARD_ID}" =~ "64" ]]; then


### PR DESCRIPTION
Before update to Buildroot 2025.02, the overlays directory on Yellow was created by rpi-firmware in a condition added confusingly in firmware bump [1]. However, this got lost during Buildroot update, and since Yellow doesn't copy overlays from the rpi-firmware repo, the directory was never created and the rpi-rf-mod.dtbo couldn't be copied there in pre-image build hook.

To make things more robust, create the overlays directory for rpi targets conditionally in the hook instead of relying on rpi-firmware to create it.

[1] https://github.com/home-assistant/buildroot/commit/f1af1a0bf7af1f7d7b330a990e254bbf6da5b976

Fixes #4233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raspberry Pi image preparation by conditionally handling Device Tree overlay files. Overlays are now copied only when present, avoiding unnecessary directory creation and suppressing misleading errors when none exist. This results in cleaner build logs and more reliable boot partition contents, with no behavior change for setups that include overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->