### PR TITLE
Add checkbox for running test in GH build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,11 @@ on:
         required: true
         type: boolean
         default: true
+      run_tests:
+        description: 'Run tests after build'
+        required: true
+        type: boolean
+        default: true
       hassio_channel:
         description: 'Release channel to use (default: stable for GH releases, dev otherwise)'
         type: choice
@@ -152,12 +157,21 @@ jobs:
             }
 
             const boardFilter = "${{ github.event.inputs.boards }}"
+            const runTests = "${{ github.event.inputs.run_tests }}" === "true"
+
             if (boardFilter == "") {
               console.log("Run full build for all boards")
               return { "board": boards }
             } else {
               console.log("Run partial build")
               const boardSet = new Set(boardFilter.split(","))
+
+              // if tests are enabled, we need to ensure the OVA board is included
+              if (runTests && !boardSet.has("ova")) {
+                console.log("Adding OVA board for integration tests")
+                boardSet.add("ova")
+              }
+
               const buildBoards = boards.filter(b => boardSet.has(b.id))
               return { "board": buildBoards }
             }
@@ -410,6 +424,7 @@ jobs:
 
   test:
     name: Test OS image
+    if: ${{ github.event_name == 'release' || inputs.run_tests == true }}
     needs: [ build, prepare ]
     uses: ./.github/workflows/test.yaml
     with:


### PR DESCRIPTION
Currently when we run a build with limited set of boards that doesn't include OVA, the test job fails because the OVA artifact is missing. Add a checkbox for running tests and ensure that OVA artifact is built if it's enabled.