### PR TITLE
Generate list of built-in containers in GH build summary

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -338,6 +338,18 @@ jobs:
       - name: Generate build summary
         run: |
           echo "# ${{ matrix.board.id }} build summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Built-in OS components" >> $GITHUB_STEP_SUMMARY
+          echo "Release channel: ${{ inputs.hassio_channel }} (${{ needs.prepare.outputs.hassio_channel_option }})" >> $GITHUB_STEP_SUMMARY
+          echo "| Container | Version |" >> $GITHUB_STEP_SUMMARY
+          echo "|:-|:-|" >> $GITHUB_STEP_SUMMARY
+          supervisor_version=$(jq -r ".supervisor" output/build/hassio-*/version.json)
+          landingpage_version=$(curl -fsSL https://api.github.com/repos/home-assistant/landingpage/releases/latest | jq -r '.tag_name')
+          echo "| supervisor | [${supervisor_version}](https://github.com/home-assistant/supervisor/releases/tag/${supervisor_version}) |" >> $GITHUB_STEP_SUMMARY
+          echo "| landingpage | [${landingpage_version}](https://github.com/home-assistant/landingpage/releases/tag/${landingpage_version}) |" >> $GITHUB_STEP_SUMMARY
+          for plugin in dns audio cli multicast observer; do
+            version=$(jq -r ".${plugin}" output/build/hassio-*/version.json)
+            echo "| plugin-${plugin} | [${version}](https://github.com/home-assistant/plugin-${plugin}/releases/tag/${version}) |" >> $GITHUB_STEP_SUMMARY
+          done
           echo "## Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size (bytes) | Size (formatted) |" >> $GITHUB_STEP_SUMMARY
           echo "|:-|:-|:-|" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add list of hassio components from version.json that are built-in in the data partition to the GH step summary. For landingpage, get the latest stable release at the time of the build, as it's what should be published as homeassistant:landingpage by that time.

Closes #4242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build summary now includes a “Built-in OS components” section with a two-column table (Container | Version).
  * Displays the selected release channel and the resolved channel option.
  * Automatically lists versions for Supervisor and Landing Page with links to their release tags.
  * Iterates over core plugins (DNS, Audio, CLI, Multicast, Observer), adding versioned entries with release links.
  * Existing “Artifacts” section remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->