### PR TITLE
Rework /usr/sbin/hassos-supervisor script

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-supervisor
@@ -43,7 +43,7 @@ touch ${SUPERVISOR_STARTUP_MARKER}
 # Using updater information instead of config. If the config version is
 # broken, this creates a way back (e.g., bad release).
 SUPERVISOR_VERSION=$(jq -r --arg chan "$SUPERVISOR_CHANNEL" '.supervisor // $chan' "${SUPERVISOR_DATA}/updater.json" || echo "$SUPERVISOR_CHANNEL")
-SUPERVISOR_IMAGE_TPL="$(jq -r '.images.supervisor // empty' "${SUPERVISOR_DATA}/updater.json" 2>/dev/null || true)"
+SUPERVISOR_IMAGE_TPL="$(jq -r '.image.supervisor // empty' "${SUPERVISOR_DATA}/updater.json" 2>/dev/null || true)"
 # Get version from channel in case we have no local version
 # information.
 if [ -z "${SUPERVISOR_VERSION}" ] || [ "${SUPERVISOR_VERSION}" = "$SUPERVISOR_CHANNEL" ] || [ -z "${SUPERVISOR_IMAGE_TPL}" ]; then


### PR DESCRIPTION
Rework /usr/sbin/hassos-supervisor script:
- remove hardcoded url for image
- add get image url from updater.json/internet
- add SUPERVISOR_CHANNEL defaults to stable
- move version url to variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Channel-based Supervisor updates for controlled rollouts.
  - Automatic selection of the correct architecture image at runtime.
  - Remote version fallback when local update metadata is missing or stale.

- Refactor
  - Switched from a fixed image target to a template-driven, arch-aware image resolution.
  - Improved cleanup of old images and more robust update pull/tag and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->