### PR TITLE
bluetooth: Increase TemporaryTimeout to 195 seconds

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/bluetooth/main.conf
+++ b/buildroot-external/rootfs-overlay/etc/bluetooth/main.conf
@@ -1,5 +1,9 @@
 [General]
 Experimental=true
+# Increase temporary device timeout from 30s to 195s to prevent device
+# removal during connection retries and to align with Home Assistant's
+# Bluetooth stack expectations
+TemporaryTimeout=195
 
 [Policy]
 AutoEnable=true


### PR DESCRIPTION
Increase the BlueZ temporary device timeout from the default 30s to 195s. This prevents devices from being removed from D-Bus during connection retries, especially when multiple connection attempts are queued.

The 195s timeout aligns with Home Assistant's Bluetooth stack behavior for ESPHome proxies and prevents the 'device removal spiral' that occurs when devices timeout during sequential connection attempts because the scanner is not runner and they are not refreshed during connection attempts leading to them being removed from DBus when they are still alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bluetooth connection stability by increasing the temporary device timeout to 195 seconds. This reduces premature device removal during connection retries and better aligns behavior with Home Assistant’s Bluetooth stack. Users should see fewer dropouts and more reliable reconnection/pairing for devices that require multiple attempts. No other Bluetooth settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->