### PR TITLE
Revert kernel patch breaking 6.12.43 build for Tinker

### DIFF
--- a/buildroot-external/board/asus/tinker/patches/linux/0009-Revert-can-ti_hecc-fix-Woverflow-compiler-warning.patch
+++ b/buildroot-external/board/asus/tinker/patches/linux/0009-Revert-can-ti_hecc-fix-Woverflow-compiler-warning.patch
@@ -1,0 +1,32 @@
+From 1ce3a9bcf0b0b69e62411879113d83452c1b859e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Thu, 28 Aug 2025 10:34:56 +0200
+Subject: [PATCH] Revert "can: ti_hecc: fix -Woverflow compiler warning"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit 1da38b70d90f8529c060dd380d0c18e6d9595463.
+
+There is no BIT_U32 in 6.12.y, the patch was incorrectly applied to 6.12
+series.
+
+Link: https://lore.kernel.org/stable/63e25fdb-095a-40eb-b341-75781e71ea95@roeck-us.net/
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ drivers/net/can/ti_hecc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/can/ti_hecc.c b/drivers/net/can/ti_hecc.c
+index e6d6661a908ab..644e8b8eb91e7 100644
+--- a/drivers/net/can/ti_hecc.c
++++ b/drivers/net/can/ti_hecc.c
+@@ -383,7 +383,7 @@ static void ti_hecc_start(struct net_device *ndev)
+ 	 * overflows instead of the hardware silently dropping the
+ 	 * messages.
+ 	 */
+-	mbx_mask = ~BIT_U32(HECC_RX_LAST_MBOX);
++	mbx_mask = ~BIT(HECC_RX_LAST_MBOX);
+ 	hecc_write(priv, HECC_CANOPC, mbx_mask);
+ 
+ 	/* Enable interrupts */


### PR DESCRIPTION
Revert patch added to 6.12.43 which breaks the build of CAN_TI_HECC module present in Tinker config. While it's quite unlikely anyone would be using it, so we could just simply disable the module, this seems to be a better solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restores stable CAN bus operation on TI HECC controllers by reverting a recent change that introduced a regression.
  * Improves reliability and compatibility of CAN communications on supported Asus Tinker devices.
  * Reduces potential compiler-related warnings impacting build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->