### PR TITLE
Fix broken outgoing connections caused by upstream kernel regression

### DIFF
--- a/buildroot-external/patches/linux/6.12.43/0001-ipv6-add-option-to-explicitly-enable-reachability-te.patch
+++ b/buildroot-external/patches/linux/6.12.43/0001-ipv6-add-option-to-explicitly-enable-reachability-te.patch
@@ -1,0 +1,52 @@
+From 3a369be3f99ff577e09f8fc02703c7c9e4e74f3d Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 28 Mar 2023 12:02:10 +0200
+Subject: [PATCH] ipv6: add option to explicitly enable reachability test
+
+Systems which act as host as well as router might prefer the host
+behavior. Currently the kernel does not allow to use IPv6 forwarding
+globally and at the same time use route reachability probing.
+
+Add a compile time flag to enable route reachability probe in any
+case.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ net/ipv6/Kconfig | 9 +++++++++
+ net/ipv6/route.c | 3 ++-
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/net/ipv6/Kconfig b/net/ipv6/Kconfig
+index 1c9c686d9522f..ee4d9ca9d2e24 100644
+--- a/net/ipv6/Kconfig
++++ b/net/ipv6/Kconfig
+@@ -48,6 +48,15 @@ config IPV6_OPTIMISTIC_DAD
+ 
+ 	  If unsure, say N.
+ 
++config IPV6_REACHABILITY_PROBE
++	bool "IPv6: Always use reachability probing (RFC 4191)"
++	help
++	  By default reachability probing is disabled on router devices (when
++	  IPv6 forwarding is enabled). This option explicitly enables
++	  reachability probing always.
++
++	  If unsure, say N.
++
+ config INET6_AH
+ 	tristate "IPv6: AH transformation"
+ 	select XFRM_AH
+diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index 8ebfed5d63232..f1a61af0f5199 100644
+--- a/net/ipv6/route.c
++++ b/net/ipv6/route.c
+@@ -2223,7 +2223,8 @@ struct rt6_info *ip6_pol_route(struct net *net, struct fib6_table *table,
+ 
+ 	strict |= flags & RT6_LOOKUP_F_IFACE;
+ 	strict |= flags & RT6_LOOKUP_F_IGNORE_LINKSTATE;
+-	if (READ_ONCE(net->ipv6.devconf_all->forwarding) == 0)
++	if (READ_ONCE(net->ipv6.devconf_all->forwarding) == 0 ||
++	    IS_ENABLED(CONFIG_IPV6_REACHABILITY_PROBE))
+ 		strict |= RT6_LOOKUP_F_REACHABLE;
+ 
+ 	rcu_read_lock();

--- a/buildroot-external/patches/linux/6.12.43/0002-net-ipv4-fix-regression-in-local-broadcast-routes.patch
+++ b/buildroot-external/patches/linux/6.12.43/0002-net-ipv4-fix-regression-in-local-broadcast-routes.patch
@@ -1,0 +1,51 @@
+From f356e2a2604bfc26be8bc51bf83f6a023f06316f Mon Sep 17 00:00:00 2001
+From: Oscar Maes <oscmaes92@gmail.com>
+Date: Wed, 27 Aug 2025 08:23:21 +0200
+Subject: [PATCH] net: ipv4: fix regression in local-broadcast routes
+
+[ Upstream commit 5189446ba995556eaa3755a6e875bc06675b88bd ]
+
+Commit 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+introduced a regression where local-broadcast packets would have their
+gateway set in __mkroute_output, which was caused by fi = NULL being
+removed.
+
+Fix this by resetting the fib_info for local-broadcast packets. This
+preserves the intended changes for directed-broadcast packets.
+
+Cc: stable@vger.kernel.org
+Fixes: 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+Reported-by: Brett A C Sheffield <bacs@librecast.net>
+Closes: https://lore.kernel.org/regressions/20250822165231.4353-4-bacs@librecast.net
+Signed-off-by: Oscar Maes <oscmaes92@gmail.com>
+Reviewed-by: David Ahern <dsahern@kernel.org>
+Link: https://patch.msgid.link/20250827062322.4807-1-oscmaes92@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ net/ipv4/route.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/net/ipv4/route.c b/net/ipv4/route.c
+index 9a5c9497b3931..261ddb6542a40 100644
+--- a/net/ipv4/route.c
++++ b/net/ipv4/route.c
+@@ -2532,12 +2532,16 @@ static struct rtable *__mkroute_output(const struct fib_result *res,
+ 		    !netif_is_l3_master(dev_out))
+ 			return ERR_PTR(-EINVAL);
+ 
+-	if (ipv4_is_lbcast(fl4->daddr))
++	if (ipv4_is_lbcast(fl4->daddr)) {
+ 		type = RTN_BROADCAST;
+-	else if (ipv4_is_multicast(fl4->daddr))
++
++		/* reset fi to prevent gateway resolution */
++		fi = NULL;
++	} else if (ipv4_is_multicast(fl4->daddr)) {
+ 		type = RTN_MULTICAST;
+-	else if (ipv4_is_zeronet(fl4->daddr))
++	} else if (ipv4_is_zeronet(fl4->daddr)) {
+ 		return ERR_PTR(-EINVAL);
++	}
+ 
+ 	if (dev_out->flags & IFF_LOOPBACK)
+ 		flags |= RTCF_LOCAL;


### PR DESCRIPTION
Upstream commit [1] caused regression in IPv4 routing which can cause some routes becoming broadcast even though they should be routed as unicast, e.g.:

```
 # ip route get 1.1.1.1
 broadcast 1.1.1.1 via 192.168.122.1 dev enp0s3 src 192.168.122.204 uid 0
     cache <local,brd>
```

It's not entirely clear yet why it happens but this behavior seems to be triggered for instance when the SSDP integration sends the broadcast packet on HA startup. While this behavior is not described in the regression report [1], the commit cherry-picked from Linux master fixes the problems for us as well.

Patches moved to version-specific folder, as this one shouldn't be applied on Raspberry Pi targets.

[1] https://lore.kernel.org/all/20250710142714.12986-1-oscmaes92@gmail.com/
[2] https://lore.kernel.org/stable/20250822165231.4353-4-bacs@librecast.net/

Fixes #4265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build-time option to always enable IPv6 reachability probing, improving consistency of route reachability in specific configurations.

* **Bug Fixes**
  * Corrected IPv4 handling of local broadcast and multicast destinations to avoid unintended gateway resolution.
  * Ensured zeronet destinations are rejected with a proper error, and preserved directed-broadcast behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->