### PR TITLE
Implement better support for --silent flag in top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ endif
 
 ################################################################################
 
+SILENT := $(findstring s,$(word 1, $(MAKEFLAGS)))
+
+define print
+	$(if $(SILENT),,$(info $1))
+endef
+
 COLOR_STEP := $(shell tput smso 2>/dev/null)
 COLOR_WARN := $(shell (tput setab 3; tput setaf 0) 2>/dev/null)
 TERM_RESET := $(shell tput sgr0 2>/dev/null)
@@ -28,7 +34,7 @@ TERM_RESET := $(shell tput sgr0 2>/dev/null)
 
 # fallback target when target undefined here is given
 .DEFAULT:
-	@echo "$(COLOR_STEP)=== Falling back to Buildroot target '$@' ===$(TERM_RESET)"
+	$(call print,$(COLOR_STEP)=== Falling back to Buildroot target '$@' ===$(TERM_RESET))
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$@"
 
 # default target when no target is given - must be first in Makefile
@@ -42,11 +48,11 @@ $(TARGETS_CONFIG): %-config:
 		echo ""; \
 		bash -c 'read -t 10 -p "Waiting 10s, press enter to continue or Ctrl-C to abort..."' || true; \
 	fi
-	@echo "$(COLOR_STEP)=== Using $*_defconfig ===$(TERM_RESET)"
+	$(call print,$(COLOR_STEP)=== Using $*_defconfig ===$(TERM_RESET))
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL) "$*_defconfig"
 
 $(TARGETS): %: %-config
-	@echo "$(COLOR_STEP)=== Building $@ ===$(TERM_RESET)"
+	$(call print,$(COLOR_STEP)=== Building $@ ===$(TERM_RESET))
 	$(MAKE) -C $(BUILDROOT) O=$(O) BR2_EXTERNAL=$(BUILDROOT_EXTERNAL)
 
 buildroot-help:


### PR DESCRIPTION
The extra information printed when using the top-level makefile can clutter the output when it needs to be further processed, e.g. when running `make show-info | jq`. Make it respect the --silent flag (which also suppresses messages about changing directories which would break parsing as well).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build now supports silent mode: invoking make with -s suppresses non-essential status messages while keeping default verbosity unchanged.
  * Status messages are now conditionally suppressed when silent mode is active.

* **Chores**
  * Centralized printing of build status messages for consistent, cleaner output across targets without altering build results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->