### PR TITLE
Update HOME_URL in os-release metadata

### DIFF
--- a/buildroot-external/scripts/post-build.sh
+++ b/buildroot-external/scripts/post-build.sh
@@ -27,7 +27,7 @@ setup_localtime
     echo "VERSION_ID=$(hassos_version)"
     echo "PRETTY_NAME=\"${HASSOS_NAME} $(hassos_version)\""
     echo "CPE_NAME=cpe:2.3:o:home-assistant:${HASSOS_ID}:$(hassos_version):*:${DEPLOYMENT}:*:*:*:${BOARD_ID}:*"
-    echo "HOME_URL=https://hass.io/"
+    echo "HOME_URL=https://www.home-assistant.io/"
     echo "VARIANT=\"${HASSOS_NAME} ${BOARD_NAME}\""
     echo "VARIANT_ID=${BOARD_ID}"
     echo "SUPERVISOR_MACHINE=${SUPERVISOR_MACHINE}"


### PR DESCRIPTION
The URL in os-release still pointed to hass.io domain which is currently defunct. Point to the Home Assistant's main homepage instead.

Fixes #4295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected the system information link to point to the official Home Assistant website (https://www.home-assistant.io/) instead of the outdated URL.

- Chores
  - Updated release metadata to reflect the new Home URL value used in generated system information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->