### PR TITLE
Improve UX of HA CLI wrapper and emergency console

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
@@ -15,6 +15,9 @@ Before=getty.target
 Conflicts=rescue.service
 Before=rescue.service
 
+# Same value as RestartMaxDelaySec to avoid marking the service as failed
+StartLimitIntervalSec=3s
+
 [Service]
 # the VT is cleared by TTYVTDisallocate
 # The '-o' option value tells agetty to replace 'login' arguments with an
@@ -23,7 +26,9 @@ Before=rescue.service
 ExecStart=/usr/sbin/hassos-cli
 Type=idle
 Restart=always
-RestartSec=0
+RestartSec=100ms
+RestartMaxDelaySec=3s
+RestartSteps=3
 UtmpIdentifier=%I
 TTYPath=/dev/%I
 TTYReset=yes

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -1,17 +1,42 @@
-#!/bin/sh
+#!/bin/ash
 # ==============================================================================
 # Run logging cli
 # ==============================================================================
 
-echo "Waiting for the Home Assistant CLI to be ready..."
+run_shell() { exec /bin/ash -l; }
+interrupt() { echo -e " cancelled"; systemctl reset-failed "ha-cli@*"; run_shell; }
+emergency_shell() {
+    echo -e "\n\n[WARNING] Home Assistant CLI is not starting or was interrupted."
+    echo ""
+    echo "This happens when start of all services takes longer than expected, or because"
+    echo "of slow internet connection. Emergency console has been started, you can use"
+    echo "for example the following commands for troubleshooting:"
+    echo ""
+    echo " * 'docker ps -a' - e.g. to check if 'hassio_supervisor' container is running"
+    echo " * 'journalctl -e' - to investigate latest system logs"
+    echo " * 'exit' or Ctrl+D - to exit the emergency console and retry HA CLI startup"
+    echo ""
+    run_shell
+}
+
+trap interrupt INT
+
+echo -n "Waiting for the Home Assistant CLI to be ready..."
 
 i=0
 while [ ! "$(docker ps -q -f name=hassio_cli)" ]; do
     sleep 1
+
+    if [ $((i % 4)) = 0 ]; then
+        echo -ne "\010\010\010   \010\010\010"
+    else
+        echo -n "."
+    fi
+
     i=$((i+1))
-    if [ $i = 60 ]; then
-        echo "[WARN] Home Assistant CLI not starting! Jumping into emergency console..."
-        exec /bin/ash -l
+
+    if [ $i = 180 ]; then
+        emergency_shell
     fi
 done
 
@@ -22,16 +47,20 @@ docker container exec \
 case $? in
   10)
     # Jump to root login shell (login command)
-    exec /bin/ash -l
+    run_shell
+    ;;
+  130)
+    # 130 is CLI termination with Ctrl+C (SIGINT)
+    echo -e "\nHome Assistant CLI has been interrupted."
+    systemctl reset-failed "ha-cli@*"
     ;;
   143)
     # 143 graceful termination (SIGTERM). Most likely a proper shutdown.
     # Just sleep for a while until actual systemd shutdown gets invoked.
-    echo ""
-    echo "Home Assistant CLI has been terminated."
+    echo -e "\nHome Assistant CLI has been terminated."
     sleep 30
     ;;
   *)
-    echo "HA CLI failed with error code: $?"
+    echo -e "\nHA CLI failed with error code: $?"
     ;;
 esac


### PR DESCRIPTION
For many users, the emergency console gives feeling that the system is completely broken. However, there are various cases when the system just takes just a bit longer to start up and the emergency message is shown, while it finishes a proper startup shortly after. This change tries to improve the UX in several ways:

* The limit before a forced emergency console startup is changed to 3 minutes
* Waiting can be interrupted with Ctrl+C (reset counter is cleared then)
* Some hints what to check have been added before starting the shell
* Also, because if the HA CLI failed for 5 times in a row in quick succession, the CLI startup was then not retried anymore and user may have been left with a black screen, the restart limits timeouts have been adjusted only to back off and never mark the unit as failed

Closes #4273