### PR TITLE
Use original hadolint action instead of outdated fork

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: true
 
     - name: Check Dockerfile
-      uses: brpaz/hadolint-action@c27bd9edc1e95eed30474db8f295ff5807ebca14 # v1.5.0
+      uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
       with:
         dockerfile: Dockerfile
 


### PR DESCRIPTION
The brpaz fork wasn't maintained for roughly four years, replace it with the maintained upstream action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI to use the latest Hadolint action for Dockerfile linting, improving reliability, performance, and compatibility with newer rules. No changes to application behavior; PR checks remain the same functionally with up-to-date tooling. Ensures ongoing support and security updates. Reduces false positives and aligns our checks with current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->