### PR TITLE
Use matching version of DinD daemon when creating hassio data partition

### DIFF
--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -4,6 +4,7 @@ set -e
 build_dir=$1
 dst_dir=$2
 channel=$3
+docker_version=$4
 
 data_img="${dst_dir}/data.ext4"
 
@@ -17,13 +18,12 @@ mkdir -p "${build_dir}/data/"
 sudo mount -o loop,discard "${data_img}" "${build_dir}/data/"
 
 # Use official Docker in Docker images
-# Ideally we use the same version as Buildroot is using in case the
-# overlayfs2 storage format changes
+# We use the same version as Buildroot is using to ensure best compatibility
 container=$(docker run --privileged -e DOCKER_TLS_CERTDIR="" \
 	-v "${build_dir}/data/":/data \
 	-v "${build_dir}/data/docker/":/var/lib/docker \
 	-v "${build_dir}":/build \
-	-d docker:28.0-dind --storage-driver overlay2)
+	-d "docker:${docker_version}-dind" --storage-driver overlay2)
 
 docker exec "${container}" sh /build/dind-import-containers.sh "${channel}"
 

--- a/buildroot-external/package/hassio/hassio.mk
+++ b/buildroot-external/package/hassio/hassio.mk
@@ -37,7 +37,7 @@ endef
 HASSIO_INSTALL_IMAGES = YES
 
 define HASSIO_INSTALL_IMAGES_CMDS
-	$(BR2_EXTERNAL_HASSOS_PATH)/package/hassio/create-data-partition.sh "$(@D)" "$(BINARIES_DIR)" "$(HASSIO_VERSION_CHANNEL)"
+	$(BR2_EXTERNAL_HASSOS_PATH)/package/hassio/create-data-partition.sh "$(@D)" "$(BINARIES_DIR)" "$(HASSIO_VERSION_CHANNEL)" "$(DOCKER_ENGINE_VERSION)"
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Use the version used in the docker-engine package to ensure it stays in sync. Although we haven't seen any issues related to the fact it was sometimes mismatching, reduce the burden of needing it to be synced manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Installation now respects your configured Docker Engine version during data partition setup for improved compatibility.
- Refactor
  - Replaced a hard-coded container image tag with a configurable version parameter to align with selected Docker versions.
- Chores
  - Updated install flow to pass the Docker Engine version through to setup, enhancing reliability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->