### PR TITLE
Disable UAS via usb-storage.quirks on RPi for JMicron JMS583Gen 2 to PCIe Gen3x2 Bridge

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty0 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u
+dwc_otg.lpm_enable=0 console=tty0 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u


### PR DESCRIPTION
To support [this adapter](https://amzn.eu/d/8gEYLWu)

Vendor ID: 152d
Product ID: 0583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced USB storage device compatibility by implementing additional kernel-level device handling configurations, improving system stability and ensuring proper recognition and functionality of a wider range of external storage devices and peripherals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->