### PR TITLE
Remove usage of --content-trust CLI option in Supervisor tests

### DIFF
--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -117,11 +117,7 @@ def test_addon_install(shell_json):
 
 
 @pytest.mark.dependency(depends=["test_supervisor_is_updated"])
-def test_code_sign(shell_json):
-    # enable Content-Trust
-    assert (
-        shell_json("ha security options --content-trust=true --no-progress --raw-json").get("result") == "ok"
-    ), "Content-Trust enable failed"
+def test_supervisor_errors(shell_json):
     # run Supervisor health check
     health_check = shell_json("ha resolution healthcheck --no-progress --raw-json")
     assert health_check.get("result") == "ok", "Supervisor health check failed"


### PR DESCRIPTION
With https://github.com/home-assistant/cli/pull/604, there is no --content-trust option anymore. Remove the call and only check if Supervisor is healthy and there are no issues. This replaces #4370 which is too broad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated supervisor health check tests to validate that error states are properly handled and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->