### PR TITLE
Use OCI archive in hassio import to fix Containerd snapshotter issues

### DIFF
--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -52,7 +52,7 @@ dst_image_file_path="${dst_dir}/${image_file_name}.tar"
 	if [ ! -f "${image_file_path}" ]
 	then
 		echo "Fetching image: ${full_image_name} (digest ${image_digest})"
-		retry 3 "skopeo copy 'docker://${image_name}@${image_digest}' 'docker-archive:${image_file_path}:${full_image_name}'"
+		retry 3 "skopeo copy 'docker://${image_name}@${image_digest}' 'oci-archive:${image_file_path}:${full_image_name}'"
 	else
 		echo "Skipping download of existing image: ${full_image_name} (digest ${image_digest})"
 	fi


### PR DESCRIPTION
Importing docker-archive format leads to some layers missing in the content storage which results in some image metadata missing. This appears to be the same regression as moby/moby#49473. Importing OCI archives when bootstrapping the data partition seems to work this bug around.

Fixes #4385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image storage format in build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->