### PR TITLE
Use correct per-channel AppArmor profile on clean installs

### DIFF
--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -9,7 +9,7 @@ docker_version=$4
 data_img="${dst_dir}/data.ext4"
 data_dir="${build_dir}/data"
 
-APPARMOR_URL="https://version.home-assistant.io/apparmor.txt"
+APPARMOR_URL="https://version.home-assistant.io/apparmor_${channel}.txt"
 
 # Make image
 rm -f "${data_img}"


### PR DESCRIPTION
Since home-assistant/version#305 the AppArmor profiles were split to per-channel files. This was never reflected in hassio package build though. Currently this doesn't cause any trouble and the profile is replaced later by the Supervisor but make sure we're always using the correct one from the beginning.