### PR TITLE
Bump OS Agent to v1.8.0

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.7.2
+OS_AGENT_VERSION = 1.8.0
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Adds support for Docker storage driver migration, among other things.

Full changelog:
* https://github.com/home-assistant/os-agent/releases/tag/1.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OS Agent to version 1.8.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->