### PR TITLE
Disable Wi-Fi powersave by default for all connections

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
+++ b/buildroot-external/rootfs-overlay/etc/NetworkManager/NetworkManager.conf
@@ -13,6 +13,7 @@ backend=journal
 [connection]
 connection.mdns=2
 connection.llmnr=2
+wifi.powersave=2
 
 [connectivity]
 uri=http://checkonline.home-assistant.io/online.txt


### PR DESCRIPTION
Set wifi.powersave to 2 (disabled) in NetworkManager settings by default for all connections. Since HAOS is generally used on servers, powersaving doesn't bring any obvious benefit and is often cause of problems and higher network latency. If needed, nmcli can be used to override the new default.

Refs #3832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Wi-Fi power saving in network configuration to optimize battery consumption and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->