### PR TITLE
Fix retry in hassio container fetching, retry with backoff

### DIFF
--- a/buildroot-external/package/hassio/fetch-container-image.sh
+++ b/buildroot-external/package/hassio/fetch-container-image.sh
@@ -14,21 +14,24 @@ dst_dir=$6
 retry() {
 	local retries="$1"
 	local cmd=$2
+	local delay=5
 
 	local output
-	output=$(eval "$cmd")
-	local rc=$?
+	local rc
+	output=$(eval "$cmd") && rc=$? || rc=$?
 
-	# shellcheck disable=SC2086
-	if [ $rc -ne 0 ] && [ $retries -gt 0 ]; then
-		echo "Retrying \"$cmd\" $retries more times..." >&2
-		sleep 3s
+	while [ "$rc" -ne 0 ] && [ "$retries" -gt 0 ]; do
+		echo "Retrying \"$cmd\" in ${delay}s ($retries retries left)..." >&2
+		sleep "${delay}s"
 		# shellcheck disable=SC2004
-		retry $(($retries - 1)) "$cmd"
-	else
-		echo "$output"
-		return $rc
-	fi
+		delay=$(($delay * 3))
+		# shellcheck disable=SC2004
+		retries=$(($retries - 1))
+		output=$(eval "$cmd") && rc=$? || rc=$?
+	done
+
+	echo "$output"
+	return $rc
 }
 
 image_name=$(jq -e -r --arg image_json_name "${image_json_name}" \


### PR DESCRIPTION
The retry when fetching containers from the registry didn't work because the script was executed with `set -e`. Capture the error code also for non-zero exit status.

Also use while loop instead of recursion and back off exponentially - start with 5s and multiply by 3 (i.e. 5s, 15s, 45s - waiting in total up to 1 minute for the registry to recover).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image fetch retry mechanism with exponential backoff to enhance reliability during transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->