### PR TITLE
logind: Set InhibitDelayMaxSec=300 to allow Supervisor graceful shutdown

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/systemd/logind.conf
+++ b/buildroot-external/rootfs-overlay/etc/systemd/logind.conf
@@ -17,7 +17,7 @@
 #KillUserProcesses=yes
 #KillOnlyUsers=
 #KillExcludeUsers=root
-#InhibitDelayMaxSec=5
+InhibitDelayMaxSec=300
 HandlePowerKey=ignore
 HandlePowerKeyLongPress=poweroff
 HandleRebootKey=ignore


### PR DESCRIPTION
Supervisor takes a logind delay inhibitor lock on startup and releases it after gracefully stopping all add-ons, Home Assistant Core, and plugins in the correct order. The default 5s window is far too short — Core alone can take 40+ seconds to stop. 300s gives enough headroom for a clean shutdown.

Related to: https://github.com/home-assistant/supervisor/pull/6631 https://github.com/home-assistant/operating-system/issues/4498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the maximum delay for system shutdown from 5 to 300 seconds, allowing applications more time to respond to shutdown requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->