### PR TITLE
Fix rpi-eeprom-config when booting RPi 5 from NVMe

### DIFF
--- a/buildroot-external/package/rpi-eeprom/0001-rpi-eeprom-update-adjust-bootfs-discovery-for-HAOS.patch
+++ b/buildroot-external/package/rpi-eeprom/0001-rpi-eeprom-update-adjust-bootfs-discovery-for-HAOS.patch
@@ -1,4 +1,4 @@
-From 5b3c41b3465a98025b6869c4ed14d210b68b7e24 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
 Date: Tue, 13 May 2025 17:19:59 +0200
 Subject: [PATCH] rpi-eeprom-update: adjust bootfs discovery for HAOS
@@ -15,11 +15,11 @@ booting from an NVMe).
 Signed-off-by: Jan Čermák <sairon@sairon.cz>
 Upstream: not applicable
 ---
- rpi-eeprom-update | 22 ++++++++--------------
- 1 file changed, 8 insertions(+), 14 deletions(-)
+ rpi-eeprom-update | 21 ++++++++-------------
+ 1 file changed, 8 insertions(+), 13 deletions(-)
 
 diff --git a/rpi-eeprom-update b/rpi-eeprom-update
-index b970142..3e9d75f 100755
+index 4087ce6..66ca8b4 100755
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
 @@ -725,20 +725,14 @@ findBootFS()
@@ -30,7 +30,13 @@ index b970142..3e9d75f 100755
 -      TMP_BOOTFS_MNT="$(mktemp -d)"
 -      mount /dev/mmcblk0p1 "${TMP_BOOTFS_MNT}"
 -      BOOTFS="${TMP_BOOTFS_MNT}"
--   elif [ -z "$BOOTFS" ]; then
++   if blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
++      # use HAOS default bootfs location if booting from SD card
++      BOOTFS="/mnt/boot"
++   elif [ -z "$BOOTFS" ] && [ "${RPI_EEPROM_USE_FLASHROM}" = "1" ]; then
++      # image for flashrom will created in bootfs
++      BOOTFS="/mnt/boot"
+    elif [ -z "$BOOTFS" ]; then
 -      if ! BOOTFS=$(/usr/lib/raspberrypi-sys-mods/get_fw_loc 2> /dev/null); then
 -         for BOOTFS in /boot/firmware /boot; do
 -            if [ -f "${BOOTFS}/config.txt" ]; then
@@ -40,14 +46,15 @@ index b970142..3e9d75f 100755
 -            fi
 -         done
 -      fi
-+   if blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
-+      # use HAOS default bootfs location if booting from SD card
-+      BOOTFS="/mnt/boot"
-+   elif [ -z "$BOOTFS" ] && [ "${RPI_EEPROM_USE_FLASHROM}" = "1" ]; then
-+      # image for flashrom will created in bootfs
-+      BOOTFS="/mnt/boot"
-+   elif [ -z "$BOOTFS" ]; then
 +      die "rpi-eeprom-update is only available when booting from an SD card or if flashrom can be used."
     fi
  
     # If BOOTFS is not a directory or doesn't contain any .elf files then
+@@ -986,6 +980,7 @@ while getopts A:abdhilf:m:ju:rs option; do
+       AUTO_UPDATE_VL805=1
+       ;;
+    b)
++      checkDependencies
+       findBootFS
+       echo "${BOOTFS}"
+       exit 0

--- a/buildroot-external/package/rpi-eeprom/0002-rpi-eeprom-update-remove-raspi-config-mentions-and-u.patch
+++ b/buildroot-external/package/rpi-eeprom/0002-rpi-eeprom-update-remove-raspi-config-mentions-and-u.patch
@@ -1,4 +1,4 @@
-From bea845559542e556dfaffcec7334695a6387e0d9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
 Date: Tue, 13 May 2025 18:07:13 +0200
 Subject: [PATCH] rpi-eeprom-update: remove raspi-config mentions and
@@ -18,7 +18,7 @@ Upstream: not applicable
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/rpi-eeprom-update b/rpi-eeprom-update
-index 720efb7..eb19872 100755
+index 66ca8b4..095cd30 100755
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
 @@ -30,7 +30,6 @@ FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
@@ -55,7 +55,7 @@ index 720efb7..eb19872 100755
  
     if [ "${BCM_CHIP}" = 2711 ]; then
        echo ""
-@@ -905,9 +903,7 @@ checkVersion()
+@@ -899,9 +897,7 @@ checkVersion()
     if [ "${ACTION_UPDATE_BOOTLOADER}" = 1 ] || [ "${ACTION_UPDATE_VL805}" = 1 ]; then
        echo "*** UPDATE AVAILABLE ***"
        echo ""


### PR DESCRIPTION
Update the patch adjusting findBootFS for HAOS. Make sure that the hardware survey is performed before that so we know if we can/should use flashrom on Pi 5 with NVMe.

Fixes #4574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced boot filesystem detection specifically for Home Assistant OS installations on SD cards
  * Added dependency validation checks for command-line options

* **Chores**
  * Simplified user-facing command examples in help text
  * Streamlined help messages by removing external configuration tool references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->