### PR TITLE
Drop explicit IPv6 forwarding sysctl

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/sysctl.d/60-otbr-ip-forward.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/sysctl.d/60-otbr-ip-forward.conf
@@ -1,1 +1,0 @@
-net.ipv6.conf.all.forwarding = 1


### PR DESCRIPTION
Remove net.ipv6.conf.all.forwarding=1 from 60-otbr-ip-forward.conf and rely on Docker to enable IPv6 forwarding instead, just as we already rely on it for IPv4 forwarding (needed for NAT64 in OTBR). When this sysctl was added (d9ec60316), Docker did not enable IPv6 by default. Since Docker 27 (April 2024), IPv6 support — including ip6tables — is enabled by default, and Docker enables IPv6 forwarding at startup just like it does for IPv4.

Importantly, when Docker enables forwarding itself (rather than finding it already on), it also sets the FORWARD chain policy to DROP as a safety measure, Pre-enabling the sysctl prevents this, leaving the IPv6 FORWARD chain at ACCEPT. By removing our sysctl, we get the same protective DROP policy for IPv6 that we already benefit from for IPv4.

All Docker networks have separate rules which protect the network by default, so the default `ACCEPT` is not problematic for the `docker0` or `hassio` network.

The OpenThread Border Router app by default sets the `FORWARD` policy to `ACCEPT` as part of its startup script, so this does not break installations using the OpenThread Border Router app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted system network configuration by removing IPv6 forwarding initialization setting. This change impacts automatic network routing behavior during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->