### PR TITLE
Fix handling of hassio container updates in tests

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -10,6 +10,14 @@ _LOGGER = logging.getLogger(__name__)
 @pytest.mark.dependency()
 @pytest.mark.timeout(120)
 def test_init(shell):
+    # Disable auto-updates to avoid interference with other tests,
+    # do it directly on config level and restart Supervisor via systemd.
+    shell.run_check(
+        "jq '.auto_update = false' /mnt/data/supervisor/updater.json > /tmp/updater.json"
+        " && mv /tmp/updater.json /mnt/data/supervisor/updater.json"
+        " && systemctl restart hassos-supervisor.service"
+    )
+
     def check_container_running(container_name):
         out = shell.run_check(
             f"docker container inspect -f '{{{{.State.Status}}}}' {container_name} || true"
@@ -26,7 +34,7 @@ def test_init(shell):
     # wait for system ready
     while True:
         output = "\n".join(shell.run_check("ha os info || true"))
-        if "System is not ready" not in output:
+        if "System is not ready" not in output and "connection refused" not in output:
             break
 
         sleep(1)

--- a/tests/supervisor_test/test_supervisor.py
+++ b/tests/supervisor_test/test_supervisor.py
@@ -18,6 +18,14 @@ def stash() -> dict:
 @pytest.mark.dependency()
 @pytest.mark.timeout(360)
 def test_start_supervisor(shell, shell_json):
+    # Disable auto-updates to avoid interference with other tests,
+    # do it directly on config level and restart Supervisor via systemd.
+    shell.run_check(
+        "jq '.auto_update = false' /mnt/data/supervisor/updater.json > /tmp/updater.json"
+        " && mv /tmp/updater.json /mnt/data/supervisor/updater.json"
+        " && systemctl restart hassos-supervisor.service"
+    )
+
     def check_container_running(container_name):
         out = shell.run_check(f"docker container inspect -f '{{{{.State.Status}}}}' {container_name} || true")
         return "running" in out
@@ -84,31 +92,33 @@ def test_check_supervisor(shell_json):
 
 @pytest.mark.dependency(depends=["test_check_supervisor"])
 @pytest.mark.timeout(120)
-def test_update_supervisor(shell_json):
-    supervisor_info = shell_json("ha supervisor info --no-progress --raw-json")
-    supervisor_version = supervisor_info.get("data").get("version")
-    supervisor_version_latest = supervisor_info.get("data").get("version_latest")
-    assert supervisor_version_latest, "Missing latest supervisor version info"
-    if supervisor_version == supervisor_version_latest:
-        logger.info("Supervisor is already up to date")
-        pytest.skip("Supervisor is already up to date")
+@pytest.mark.parametrize("component", ["supervisor", "audio", "cli", "dns", "observer", "multicast"])
+def test_update_components(shell_json, component):
+    info = shell_json(f"ha {component} info --no-progress --raw-json")
+    version = info.get("data").get("version")
+    version_latest = info.get("data").get("version_latest")
+    assert version_latest, f"Missing latest {component} version info"
+    if version == version_latest:
+        logger.info("%s is already up to date", component)
+        pytest.skip(f"{component} is already up to date")
     else:
-        result = shell_json("ha supervisor update --no-progress --raw-json")
+        result = shell_json(f"ha {component} update --no-progress --raw-json")
         if result.get("result") == "error" and "Another job is running" in result.get("message"):
             pass
         else:
-            assert result.get("result") == "ok", f"Supervisor update failed: {result}"
+            assert result.get("result") == "ok", f"{component} update failed: {result}"
 
         while True:
             try:
-                supervisor_info = shell_json("ha supervisor info --no-progress --raw-json")
-                data = supervisor_info.get("data")
+                info = shell_json(f"ha {component} info --no-progress --raw-json")
+                data = info.get("data")
                 if data and data.get("version") == data.get("version_latest"):
                     logger.info(
-                        "Supervisor updated from %s to %s: %s",
-                        supervisor_version,
+                        "%s updated from %s to %s: %s",
+                        component,
+                        version,
                         data.get("version"),
-                        supervisor_info,
+                        info,
                     )
                     break
             except ExecutionError:


### PR DESCRIPTION
When running tests on an image that contains older hassio components (Supervisor or plugins), the autoupdate may interfere with the test run. To avoid this, patch Suprvisor updater config as early as possible and restart Supervisor.

For Supervisor tests, we need all components to be updated, so parametrize the supervisor update test to update all plugins too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup to disable automatic updates and restart services during initialization for a controlled testing environment
  * Improved system readiness checks to properly handle additional connection conditions
  * Expanded test coverage for component updates, now testing supervisor, audio, cli, dns, observer, and multicast components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->