### PR TITLE
Switch Raspberry Pi 4 default DRM driver from legacy FKMS to KMS

### DIFF
--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -76,12 +76,15 @@ dtparam=audio=on
 initial_turbo=0
 
 [pi4]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+# Enable DRM VC4 V3D driver
 dtoverlay=vc4-kms-v3d
 max_framebuffers=2
 # Enable boost from 1.5Ghz to 1.8Ghz on compatible models
 arm_boost=1
 
+# Don't have the firmware create an initial video= setting in cmdline.txt.
+# Use the kernel's default instead.
+disable_fw_kms_setup=1
+
+
 [all]
-#dtoverlay=vc4-fkms-v3d
-#max_framebuffers=2

--- a/buildroot-external/board/raspberrypi/config.txt
+++ b/buildroot-external/board/raspberrypi/config.txt
@@ -77,7 +77,7 @@ initial_turbo=0
 
 [pi4]
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
+dtoverlay=vc4-kms-v3d
 max_framebuffers=2
 # Enable boost from 1.5Ghz to 1.8Ghz on compatible models
 arm_boost=1


### PR DESCRIPTION
The linux kernel didn't create /dev/cec0 and /dev/cec1 even though the hardware supports hdmi-cec. Fkms is not being updated anymore:

https://forums.raspberrypi.com/viewtopic.php?t=332742

CEC-Scan before:
```
[21:38:45] INFO: Starting CEC client scan...
s6-rc: info: service legacy-services successfully started
autodetect FAILED
```

CEC-Scan after:
```
[22:31:44] INFO: Starting CEC client scan...
opening a connection to the CEC adapter...
requesting CEC bus information ...
CEC bus information
===================
device #0: TV
address:       0.0.0.0
active source: no
vendor:        Unknown
osd string:    TV
CEC version:   1.4
power status:  on
language:      eng
device #1: Recorder 1
address:       2.0.0.0
active source: no
vendor:        Pulse Eight
osd string:    CECTester
CEC version:   1.4
power status:  on
language:      eng
device #4: Playback 1
address:       3.0.0.0
active source: yes
vendor:        Unknown
osd string:   TV
CEC version:   2.0
power status:  on
language:      ???
currently active source: Playback 1 (4)
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi 4 graphics/boot configuration to enable the newer VC4 V3D driver and prevent firmware from forcing an initial video mode. This improves display compatibility, makes boot-time display mode handling more predictable, and reduces mode-related startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->