### PR TITLE
Restructure Linux version docs page

### DIFF
--- a/Documentation/kernel.md
+++ b/Documentation/kernel.md
@@ -1,19 +1,30 @@
 
 # Kernel Version
 
+## Mainline Linux
+
+The following boards are using [mainline Linux kernel](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/):
+
 | Board | Version |
 |-------|---------|
-| Open Virtual Appliance | 6.18.22 |
-| Raspberry Pi 3 | 6.12.75 |
-| Raspberry Pi 4 | 6.12.75 |
-| Raspberry Pi 5 | 6.12.75 |
-| Home Assistant Yellow | 6.12.75 |
+| Generic aarch64 | 6.18.22 |
+| Generic x86-64 | 6.18.22 |
 | Home Assistant Green | 6.18.22 |
+| Khadas VIM3 | 6.18.22 |
 | ODROID-C2 | 6.18.22 |
 | ODROID-C4 | 6.18.22 |
 | ODROID-M1 | 6.18.22 |
 | ODROID-M1S | 6.18.22 |
 | ODROID-N2 | 6.18.22 |
-| Generic aarch64 | 6.18.22 |
-| Generic x86-64 | 6.18.22 |
-| Khadas VIM3 | 6.18.22 |
+| Open Virtual Appliance | 6.18.22 |
+
+## Raspberry Pi Linux
+
+The following boards are using [Raspberry Pi's Linux fork](https://github.com/raspberrypi/linux/):
+
+| Board | Version |
+|-------|---------|
+| Home Assistant Yellow | 6.12.75 |
+| Raspberry Pi 3 | 6.12.75 |
+| Raspberry Pi 4 | 6.12.75 |
+| Raspberry Pi 5 | 6.12.75 |


### PR DESCRIPTION
Split boards per used source of the Linux kernel and sort them alphabetically. This should reduce occasional collisions when both sources are updated, and make the docs bit more explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized kernel version docs into separate "Mainline Linux" and "Raspberry Pi Linux" sections for clearer navigation.
  * Mainline list updated to show generic architectures (aarch64, x86-64), reorder entries, and include Khadas VIM3 and Open Virtual Appliance.
  * Added a Raspberry Pi Linux table listing Raspberry Pi 3/4/5 and Home Assistant Yellow at the Raspberry Pi fork kernel version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->