### PR TITLE
Enable IPv6 on Docker default bridge

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/docker/daemon.json
+++ b/buildroot-external/rootfs-overlay/etc/docker/daemon.json
@@ -4,5 +4,6 @@
         "tag": "{{.Name}}"
     },
     "data-root": "/mnt/data/docker",
-    "bip": "172.30.232.1/23"
+    "bip": "172.30.232.1/23",
+    "ipv6": true
 }


### PR DESCRIPTION
Restores IPv6 forwarding that was dropped in #4589. With ipv6=true, dockerd enables net.ipv6.conf.all.forwarding at startup (and sets the IPv6 FORWARD chain policy to DROP), matching IPv4 behavior. Fixes the regression worked around in https://github.com/home-assistant/supervisor/pull/6720 (issue #4630).

Note: Supervisor since https://github.com/home-assistant/supervisor/pull/6720 (shipped with Supervisor 2026.04.0) already enables IPv6 explicitly on the hassio bridge by default, so this OS-level change is not strictly required to restore IPv6 forwarding. It is still the right thing to do - letting Docker take control of IPv6 forwarding (just like IPv4) is what the original commit intended, and it ensures correct behavior independent of Supervisor's defaults.