### PR TITLE
Allow enter.sh to run without TTY

### DIFF
--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -23,7 +23,14 @@ if command -v losetup >/dev/null && [ ! -e /dev/loop0 ]; then
   sudo losetup -f > /dev/null
 fi
 
-docker run -it --rm --privileged \
+TTY_OPTS=""
+
+if [ -t 0 ]; then
+  TTY_OPTS="-it"
+fi
+
+docker run --rm --privileged \
+  ${TTY_OPTS} \
   -v "$(pwd):/build" -v "${CACHE_DIR}:/cache" \
   -e BUILDER_UID="${BUILDER_UID}" -e BUILDER_GID="${BUILDER_GID}" \
   hassos:local "${@:-bash}"


### PR DESCRIPTION
Since enter.sh starts Docker with `--interactive --tty` flags, it fails to run if started from another script which doesn't allocate TTY. Detect if the parent shell is a terminal and if not, do not attempt to run in interactive mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Docker environment startup script to properly detect and handle terminal availability, improving compatibility when running in automated environments or without an attached terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->