### PR TITLE
Update build container to Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,24 @@
-FROM debian:bullseye
+FROM debian:trixie
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Docker
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        apt-transport-https \
         ca-certificates \
         curl \
-        gpg-agent \
-        gpg \
-        dirmngr \
-        software-properties-common \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/docker.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/docker.gpg] \
-        https://download.docker.com/linux/debian $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && . /etc/os-release \
+    && printf '%s\n' \
+        'Types: deb' \
+        'URIs: https://download.docker.com/linux/debian' \
+        "Suites: $VERSION_CODENAME" \
+        'Components: stable' \
+        "Architectures: $(dpkg --print-architecture)" \
+        'Signed-By: /etc/apt/keyrings/docker.asc' \
+        > /etc/apt/sources.list.d/docker.sources \
     && apt-get update && apt-get install -y --no-install-recommends \
         docker-ce \
     && rm -rf /var/lib/apt/lists/*
@@ -28,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         bzip2 \
         cpio \
+        e2fsprogs \
         file \
         git \
         graphviz \


### PR DESCRIPTION
The image for the build container was still using Bullseye which will be EOL this August. Update to Trixie and adjust Dockerfile accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated base operating system in Docker image from Debian bullseye to trixie.
* Modernized Docker repository configuration and setup process.
* Adjusted build dependencies to align with the updated system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->