### PR TITLE
systemd: Increase runtime watchdog timeout to 5 minutes

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system.conf.d/watchdog.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system.conf.d/watchdog.conf
@@ -1,3 +1,3 @@
 [Manager]
-RuntimeWatchdogSec=default
+RuntimeWatchdogSec=300
 WatchdogDevice=/dev/watchdog


### PR DESCRIPTION
## Summary

- Bump `RuntimeWatchdogSec` from `default` (driver-dependent: ~30s on iTCO_wdt/i6300esb, 15s on BCM2835) to a uniform `300` seconds.
- Motivation: PID1 can stall in `nfs_getattr` for an NFS RPC major-timeout while running `mount_enter_mounting()` (chase/open_tree, is_dir, mkdir_p_label, unit_warn_if_dir_nonempty), which exceeds the previous hardware-default heartbeats and causes spurious reboots on network-storage stalls rather than genuine kernel hangs. Reported by https://github.com/home-assistant/supervisor/issues/6827 and upstream as systemd/systemd#42050.
- Hardware-limit wrinkle: drivers using `max_hw_heartbeat_ms` (notably BCM2835 since kernel v6.8, commit [f33f5b1fd1be](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v7.1-rc3&id=f33f5b1fd1be)) accept any userspace timeout and let the watchdog core multiplex hardware pings in the background, so 300s is honored on all Pi variants. Drivers still using `max_timeout` directly will fall back to their own value — no worse than the previous behavior.

Issue #2675 (ODROID-M1 / Green) remains addressed via disabled `CONFIG_DW_WATCHDOG`; this change has no impact on those boards since they expose no `/dev/watchdog`.

## Test plan

- [x] Boot generic-x86-64 (iTCO_wdt); verify `systemctl show | grep -i watchdog` reports `RuntimeWatchdogUSec=5min` and `WatchdogLastPingTimestamp` advances.
- [x] Boot OVA on KVM with `-watchdog i6300esb`; same check.
- [ ] Boot Raspberry Pi 4 / 5; `cat /sys/class/watchdog/watchdog0/timeout` should return 300 (post-v6.8 BCM2835 driver multiplexing).
- [x] Reproduce systemd#42050 scenario (NFS mount with unreachable server, `systemctl reload` then `restart`); confirm the box stays up instead of rebooting during the ~60s `nfs_getattr` D-state.
- [x] Genuine PID1 hang (e.g. `kill -STOP 1` in a throwaway VM) still reboots within ~5min + driver pre-timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system runtime watchdog timeout configuration to 300 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->