### PR TITLE
Use F2FS file system for the Data and Overlay partitions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -373,7 +373,7 @@ jobs:
           echo "## Partitions" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size (bytes) | Size (formatted) |" >> $GITHUB_STEP_SUMMARY
           echo "|:-|:-|:-|" >> $GITHUB_STEP_SUMMARY
-          for f in boot.vfat kernel.img rootfs.erofs overlay.ext4 data.ext4; do
+          for f in boot.vfat kernel.img rootfs.erofs overlay.f2fs data.f2fs; do
             echo "| ${f} | $(du -b output/images/$f | cut -f1) | $(du -bh output/images/$f | cut -f1) |" >> $GITHUB_STEP_SUMMARY
           done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         cpio \
         e2fsprogs \
+        f2fs-tools-udeb \
         file \
         git \
         graphviz \

--- a/buildroot-external/genimage/images-os.cfg
+++ b/buildroot-external/genimage/images-os.cfg
@@ -8,13 +8,12 @@ image kernel.img {
 	}
 }
 
-image overlay.ext4 {
+image overlay.f2fs {
 	size = ${OVERLAY_SIZE}
 	empty = "yes"
 
-	ext4 {
-		use-mke2fs = "yes"
+	f2fs {
 		label = "hassos-overlay"
-		extraargs = "-I 256 -E lazy_itable_init=0,lazy_journal_init=0"
+		extraargs = "-O extra_attr,inode_checksum,sb_checksum,flexible_inline_xattr"
 	}
 }

--- a/buildroot-external/genimage/partitions-os-gpt.cfg
+++ b/buildroot-external/genimage/partitions-os-gpt.cfg
@@ -36,7 +36,7 @@ partition hassos-overlay {
 	partition-type-uuid = "linux"
 	partition-uuid = "f1326040-5236-40eb-b683-aaa100a9afcf"
 	size = ${OVERLAY_SIZE}
-	image = "overlay.ext4"
+	image = "overlay.f2fs"
 }
 
 partition hassos-data {

--- a/buildroot-external/genimage/partitions-os-mbr.cfg
+++ b/buildroot-external/genimage/partitions-os-mbr.cfg
@@ -35,7 +35,7 @@ partition hassos-bootstate {
 partition hassos-overlay {
 	partition-type = 0x83
 	size = ${OVERLAY_SIZE}
-	image = "overlay.ext4"
+	image = "overlay.f2fs"
 	forced-primary = "yes"
 }
 

--- a/buildroot-external/package/hassio/create-data-partition.sh
+++ b/buildroot-external/package/hassio/create-data-partition.sh
@@ -6,7 +6,7 @@ dst_dir=$2
 channel=$3
 docker_version=$4
 
-data_img="${dst_dir}/data.ext4"
+data_img="${dst_dir}/data.f2fs"
 data_dir="${build_dir}/data"
 
 APPARMOR_URL="https://version.home-assistant.io/apparmor_${channel}.txt"
@@ -14,7 +14,7 @@ APPARMOR_URL="https://version.home-assistant.io/apparmor_${channel}.txt"
 # Make image
 rm -f "${data_img}"
 truncate --size="1280M" "${data_img}"
-mkfs.ext4 -L "hassos-data" -E lazy_itable_init=0,lazy_journal_init=0 "${data_img}"
+mkfs.f2fs -l "hassos-data" -O extra_attr,inode_checksum,sb_checksum,flexible_inline_xattr "${data_img}"
 
 # Mount / init file structs
 mkdir -p "${data_dir}"

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-data.mount
@@ -11,8 +11,7 @@ Wants=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2ddata.service systemd-growfs@mn
 [Mount]
 What=/dev/disk/by-label/hassos-data
 Where=/mnt/data
-Type=ext4
-Options=commit=30
+Type=auto
 
 [Install]
 WantedBy=local-fs.target

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-overlay.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/mnt-overlay.mount
@@ -9,7 +9,7 @@ Wants=systemd-fsck@dev-disk-by\x2dlabel-hassos\x2doverlay.service
 [Mount]
 What=/dev/disk/by-label/hassos-overlay
 Where=/mnt/overlay
-Type=ext4
+Type=auto
 
 [Install]
 WantedBy=local-fs.target

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-wipe
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-wipe
@@ -21,10 +21,10 @@ elif findmnt "$PARTITION_DATA" > /dev/null; then
 fi
 
 echo "[INFO] Wiping data partition"
-mkfs.ext4 -L "hassos-data" -E lazy_itable_init=0,lazy_journal_init=0 "$PARTITION_DATA"
+mkfs.f2fs -l "hassos-data" -O extra_attr,inode_checksum,sb_checksum,flexible_inline_xattr "$PARTITION_DATA"
 
 echo "[INFO] Wiping overlay partition"
-mkfs.ext4 -L "hassos-overlay" -I 256 -E lazy_itable_init=0,lazy_journal_init=0 "$PARTITION_OVERLAY"
+mkfs.f2fs -l "hassos-overlay" -O extra_attr,inode_checksum,sb_checksum,flexible_inline_xattr "$PARTITION_OVERLAY"
 
 echo "[INFO] Removing wipe flag from cmdline.txt"
 /usr/bin/sed -i 's/\s*haos.wipe=1//g' /mnt/boot/cmdline.txt

--- a/buildroot-external/scripts/name.sh
+++ b/buildroot-external/scripts/name.sh
@@ -25,7 +25,7 @@ function path_boot_dir() {
 }
 
 function path_data_img() {
-    echo "${BINARIES_DIR}/data.ext4"
+    echo "${BINARIES_DIR}/data.f2fs"
 }
 
 function path_rootfs_img() {


### PR DESCRIPTION
The f2fs filesystem should improve the longevity of SD cards and eMMC memory which is mostly used on all kinds of HAOS hardware. F2FS may also improve the overall performance as shown by some [benchmarks](https://www.phoronix.com/review/linux-615-filesystems).

The mounting rules were also changed so they can mount both ext4 and f2fs partitions.

This pull request is a RFC. If developers don't want to be so radical and change the default FS, we may just leave the mounting rules change so people (like me) can continue using a custom-formatted sdcard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated system storage partitions from ext4 to F2FS filesystem
  * Updated system mount configurations to support F2FS
  * Added required F2FS utilities to build tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->