### PR TITLE
Update bundled RPi bootloader to 2026-01-09 (2711)/2026-05-11 (2712)

### DIFF
--- a/buildroot-external/package/rpi-eeprom/0001-rpi-eeprom-update-adjust-bootfs-discovery-for-HAOS.patch
+++ b/buildroot-external/package/rpi-eeprom/0001-rpi-eeprom-update-adjust-bootfs-discovery-for-HAOS.patch
@@ -19,10 +19,10 @@ Upstream: not applicable
  1 file changed, 8 insertions(+), 13 deletions(-)
 
 diff --git a/rpi-eeprom-update b/rpi-eeprom-update
-index 4087ce6..66ca8b4 100755
+index 8eaaaeb..e371897 100755
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
-@@ -725,20 +725,14 @@ findBootFS()
+@@ -731,20 +731,14 @@ findBootFS()
     # If ${BOOTFS} is not writable OR is not on /dev/mmcblk0 then error because the ROM
     # can only load recovery.bin from the on-board SD-CARD slot or the EEPROM.
  
@@ -50,7 +50,7 @@ index 4087ce6..66ca8b4 100755
     fi
  
     # If BOOTFS is not a directory or doesn't contain any .elf files then
-@@ -986,6 +980,7 @@ while getopts A:abdhilf:m:ju:rs option; do
+@@ -992,6 +986,7 @@ while getopts A:abdhilf:m:ju:rs option; do
        AUTO_UPDATE_VL805=1
        ;;
     b)

--- a/buildroot-external/package/rpi-eeprom/0002-rpi-eeprom-update-remove-raspi-config-mentions-and-u.patch
+++ b/buildroot-external/package/rpi-eeprom/0002-rpi-eeprom-update-remove-raspi-config-mentions-and-u.patch
@@ -18,7 +18,7 @@ Upstream: not applicable
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/rpi-eeprom-update b/rpi-eeprom-update
-index 66ca8b4..095cd30 100755
+index e371897..354344c 100755
 --- a/rpi-eeprom-update
 +++ b/rpi-eeprom-update
 @@ -30,7 +30,6 @@ FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-default}
@@ -29,7 +29,7 @@ index 66ca8b4..095cd30 100755
  
  # Self-update is preferred to using recovery.bin because it avoids modifiy the
  # boot partition in order to rename recovery.bin after use. Since the 2711 ROM
-@@ -315,7 +314,7 @@ applyRecoveryUpdate()
+@@ -314,7 +313,7 @@ applyRecoveryUpdate()
     echo "EEPROM updates pending. Please reboot to apply the update."
  
     if [ "${RPI_EEPROM_USE_FLASHROM}" = 0 ]; then
@@ -38,7 +38,7 @@ index 66ca8b4..095cd30 100755
     fi
  }
  
-@@ -634,7 +633,7 @@ To update the configuration file in an EEPROM image:
+@@ -640,7 +639,7 @@ To update the configuration file in an EEPROM image:
     rpi-eeprom-config pieeprom.bin --config bootconf.txt --out pieeprom-new.bin
  
  To flash the new image:
@@ -47,7 +47,7 @@ index 66ca8b4..095cd30 100755
  
  The syntax is the same as config.txt See online documentation for the list of parameters.
  
-@@ -694,7 +693,6 @@ printVersions()
+@@ -700,7 +699,6 @@ printVersions()
     echo "   CURRENT: $(date -u "-d@${BOOTLOADER_CURRENT_VERSION}") (${BOOTLOADER_CURRENT_VERSION})"
     echo "    LATEST: $(date -u "-d@${BOOTLOADER_UPDATE_VERSION}") (${BOOTLOADER_UPDATE_VERSION})"
     echo "   RELEASE: ${FIRMWARE_RELEASE_STATUS} (${FIRMWARE_IMAGE_DIR})"
@@ -55,7 +55,7 @@ index 66ca8b4..095cd30 100755
  
     if [ "${BCM_CHIP}" = 2711 ]; then
        echo ""
-@@ -899,9 +897,7 @@ checkVersion()
+@@ -905,9 +903,7 @@ checkVersion()
     if [ "${ACTION_UPDATE_BOOTLOADER}" = 1 ] || [ "${ACTION_UPDATE_VL805}" = 1 ]; then
        echo "*** UPDATE AVAILABLE ***"
        echo ""

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  67e82c88f3bd3d9dd4adac48f1d6839b715931bd7700d768b21125f6d43517ca  rpi-eeprom-2349daafacfb7a7abe2cfecf30a49ae837bdf2c6.tar.gz
+sha256  d9ac41f83bd4cef718df66505162a192d8ae3f8a1ad8bfdf00661e3a3337e22a  rpi-eeprom-e25fc5dcb8eb072eafb745cd546c3d9f73d102b5.tar.gz
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 2349daafacfb7a7abe2cfecf30a49ae837bdf2c6
+RPI_EEPROM_VERSION = e25fc5dcb8eb072eafb745cd546c3d9f73d102b5
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -14,7 +14,7 @@ define RPI_EEPROM_INSTALL_RPI4_FILES
 	$(INSTALL) -d $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/recovery.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/vl805-000138c0.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
-	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/pieeprom-2025-05-08.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
+	$(INSTALL) -D -m 0644 $(@D)/firmware-2711/default/pieeprom-2026-01-09.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2711/default/
 endef
 endif
 
@@ -22,7 +22,7 @@ ifneq ($(BR2_PACKAGE_RPI_EEPROM_TARGET_ANY)$(BR2_PACKAGE_RPI_EEPROM_TARGET_RPI5)
 define RPI_EEPROM_INSTALL_RPI5_FILES
 	$(INSTALL) -d $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default
 	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/recovery.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
-	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/pieeprom-2025-05-08.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
+	$(INSTALL) -D -m 0644 $(@D)/firmware-2712/default/pieeprom-2026-05-11.bin $(TARGET_DIR)/usr/lib/firmware/raspberrypi/bootloader-2712/default/
 endef
 endif
 


### PR DESCRIPTION
Update bootloaders to the latest default versions and refresh patches.

Changelogs:
* https://github.com/raspberrypi/rpi-eeprom/blob/v2026.05.11-2712/firmware-2711/release-notes.md#2026-01-09-arm_loader-apply-rpifwcrypto-lock-permissions-getset-user-otp-latest
* https://github.com/raspberrypi/rpi-eeprom/blob/v2026.05.11-2712/firmware-2712/release-notes.md#2026-05-11-2712-set-bootloader-mfg-verison-id-to-1-latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader discovery on HAOS systems for reliable boot partition identification
  * Removed unnecessary configuration tool references from user-facing messages for clarity

* **Chores**
  * Updated bootloader firmware for Raspberry Pi 4 (January 2026) and Pi 5 (May 2026)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->