### PR TITLE
Add pre-shutdown phase to coordinate shutdown with Supervisor

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
@@ -2,12 +2,12 @@
 Description=Home Assistant CLI
 Wants=hassos-supervisor.service
 After=systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target hassos-supervisor.service
-Conflicts=getty@%i.service
+Conflicts=getty@%i.service haos-pre-shutdown.target
 
 # If additional gettys are spawned during boot then we should make
 # sure that this is synchronized before getty.target, even though
 # getty.target didn't actually pull it in.
-Before=getty.target
+Before=getty.target haos-pre-shutdown.target
 
 # IgnoreOnIsolate causes issues with sulogin, if someone isolates
 # rescue.target or starts rescue.service from multi-user.target or

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service.d/haos.conf
@@ -1,2 +1,5 @@
 [Install]
 DefaultInstance=tty1
+# Enable the matching console shutdown notice for the same instance, so the
+# tty1 default lives in exactly one place.
+Also=haos-shutdown-notice@%i.service

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-pre-shutdown.target
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-pre-shutdown.target
@@ -1,0 +1,7 @@
+[Unit]
+Description=Home Assistant OS pre-shutdown phase
+# Started explicitly by Supervisor before an API-triggered reboot/shutdown so
+# that units conflicting with it (e.g. ha-cli@.service) are stopped cleanly
+# before Supervisor stops the matching plugin containers.
+DefaultDependencies=no
+RefuseManualStop=yes

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-shutdown-notice@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-shutdown-notice@.service
@@ -9,7 +9,8 @@ After=ha-cli@%i.service
 Before=haos-pre-shutdown.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/libexec/haos-shutdown-notice
 TTYPath=/dev/%i
 TTYReset=yes

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-shutdown-notice@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-shutdown-notice@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Home Assistant OS console shutdown notice on %I
+DefaultDependencies=no
+ConditionPathExists=/dev/%i
+# Take over the console once the Home Assistant CLI instance has been stopped,
+# and have the notice up before the pre-shutdown phase completes so there is no
+# blank gap. Enabled via ha-cli@.service's "Also=".
+After=ha-cli@%i.service
+Before=haos-pre-shutdown.target
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/haos-shutdown-notice
+TTYPath=/dev/%i
+TTYReset=yes
+StandardOutput=tty
+StandardError=journal
+
+[Install]
+WantedBy=haos-pre-shutdown.target

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -15,7 +15,12 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop hassio_supervisor
 ExecStart=/usr/sbin/hassos-supervisor
-ExecStop=-/usr/bin/docker stop hassio_supervisor
+# This unit is ordered After=docker.service, so on host shutdown it is
+# stopped before Docker tears containers down. Supervisor handles the
+# SIGTERM from "docker stop" by gracefully stopping Home Assistant Core,
+# apps and plugins; allow ample time for that to complete.
+ExecStop=-/usr/bin/docker stop -t 420 hassio_supervisor
+TimeoutStopSec=450s
 
 [Install]
 WantedBy=multi-user.target

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-shutdown-notice
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-shutdown-notice
@@ -7,20 +7,14 @@
 # without this the console would just show a blinking cursor.
 # ==============================================================================
 
-# Move to the top, clear the screen and hide the cursor.
-printf '\033[H\033[2J\033[?25l'
+# Move to the top and clear the screen.
+printf '\033[H\033[2J'
 
 cat <<'EOF'
 
 
     Home Assistant is shutting down...
 
-    This can take a moment, the system will power off or restart shortly.
+    This can take a moment, the system will power off or reboot shortly.
 
 EOF
-
-# Keep the service alive so the notice stays on screen until Systemd kills
-# this service and starts printing its messages.
-while true; do
-    sleep 3600
-done

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-shutdown-notice
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-shutdown-notice
@@ -1,0 +1,26 @@
+#!/bin/sh
+# ==============================================================================
+# Display a shutdown notice on the console.
+#
+# Started via haos-pre-shutdown.target when a reboot or power off is triggered
+# via API. The Home Assistant CLI on default tty is stopped at that point, so
+# without this the console would just show a blinking cursor.
+# ==============================================================================
+
+# Move to the top, clear the screen and hide the cursor.
+printf '\033[H\033[2J\033[?25l'
+
+cat <<'EOF'
+
+
+    Home Assistant is shutting down...
+
+    This can take a moment, the system will power off or restart shortly.
+
+EOF
+
+# Keep the service alive so the notice stays on screen until Systemd kills
+# this service and starts printing its messages.
+while true; do
+    sleep 3600
+done


### PR DESCRIPTION
Introduce haos-pre-shutdown.target, a phase Supervisor enters before a API-triggered reboot or power off. ha-cli@.service conflicts with the target, so the console CLI is stopped by a regular stop job instead of restart-looping once Supervisor stops the CLI plugin (#4584).

While the CLI is down, haos-shutdown-notice@.service takes over its tty and shows a shutdown notice, so the console no longer shows just a blinking cursor. It is a template enabled through ha-cli@.service's Also=, keeping the console instance defined in a single place.

hassos-supervisor.service gets a longer "docker stop" timeout. As the unit is already ordered after docker.service, Supervisor can now stop Home Assistant Core, add-ons and plugins gracefully on SIGTERM before Docker tears the containers down (#4642).

Supervisor will the target and perform the graceful shutdown via a separate change.

Closes #4584, closes #4642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console shutdown/restart notifications shown on system consoles during shutdown.
  * A pre-shutdown phase that ensures services are stopped in a controlled order before reboot/shutdown.

* **Improvements**
  * More graceful service termination with a longer, explicit stop timeout to reduce abrupt container/service exits.
* **Quality**
  * Ordering tweaks to avoid console gaps during shutdown notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->