### PR TITLE
Bump OS Agent to v1.9.0

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.8.1
+OS_AGENT_VERSION = 1.9.0
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release adds the RPi firmware update API and updates to Go 1.26.

Full changelog:
- https://github.com/home-assistant/os-agent/releases/tag/1.9.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OS Agent to version 1.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->