### PR TITLE
Patch rpi-eeprom-update to show info on CM4 and make findBootFS faster

### DIFF
--- a/buildroot-external/package/rpi-eeprom/0004-rpi-eeprom-update-don-t-exit-early-on-CM4-and-set-UP.patch
+++ b/buildroot-external/package/rpi-eeprom/0004-rpi-eeprom-update-don-t-exit-early-on-CM4-and-set-UP.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Tue, 26 May 2026 11:12:26 +0200
+Subject: [PATCH] rpi-eeprom-update: don't exit early on CM4 and set
+ UPDATE_BLOCKED
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On CM4, the script exits early and only prints hints how to update. We
+don't want that behavior to get the EEPROM info in OS Agent, instead set
+the UPDATE_BLOCKED flag. We can still show the hints for CLI usage.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+Upstream: not applicable
+---
+ rpi-eeprom-update | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/rpi-eeprom-update b/rpi-eeprom-update
+index 82832a8..609072d 100755
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -460,6 +460,7 @@ checkDependencies() {
+    BOARD_REVISION=$((0x$BOARD_INFO & 0xf))
+ 
+    if ([ ${BOARD_TYPE} -eq 20 ] || [ ${BOARD_TYPE} -eq 21 ]) && [ "${CM4_ENABLE_RPI_EEPROM_UPDATE}" != '1' ]; then
++      UPDATE_BLOCKED=1
+       # For CM4/CM4S, USB device boot is the recommended method for EEPROM updates.
+       echo "rpi-eeprom-update is not enabled by default on CM4(S)."
+       echo "The recommended method for flashing the EEPROM is rpiboot."
+@@ -482,7 +483,6 @@ checkDependencies() {
+          echo "dtoverlay=audremap"
+          echo "dtoverlay=spi-gpio40-45"
+       echo
+-      exit ${EXIT_SUCCESS}
+    fi
+ 
+    if [ ${BOARD_TYPE} -eq 17 ] && [ ${BOARD_REVISION} -lt 4 ]; then
+@@ -744,7 +744,9 @@ printVersions()
+ # status inline instead of only failing once an update is attempted.
+ checkUpdateMethod()
+ {
+-   if blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
++   if [ "${UPDATE_BLOCKED}" = 1 ]; then
++      return
++   elif blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
+       # Booting from the SD card - recovery.bin can be staged on /mnt/boot.
+       UPDATE_BLOCKED=0
+    elif [ -n "${BOOTFS}" ]; then

--- a/buildroot-external/package/rpi-eeprom/0005-rpi-eeprom-update-scan-only-dev-mmcblk0p1-in-findBoo.patch
+++ b/buildroot-external/package/rpi-eeprom/0005-rpi-eeprom-update-scan-only-dev-mmcblk0p1-in-findBoo.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Tue, 26 May 2026 11:31:16 +0200
+Subject: [PATCH] rpi-eeprom-update: scan only /dev/mmcblk0p1 in findBootFS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make findBootFS check faster by scanning only the device that it looks
+for. Running blkid without argument can block for several seconds if any
+of the devices is busy and if the device doesn't exist, the command
+returns immediately. The regular expression already constrains the
+output to match only one device, so scanning all superblocks is
+wasteful.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+Upstream: https://github.com/raspberrypi/rpi-eeprom/pull/840
+---
+ rpi-eeprom-update | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rpi-eeprom-update b/rpi-eeprom-update
+index 609072d..e3324a2 100755
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -746,7 +746,7 @@ checkUpdateMethod()
+ {
+    if [ "${UPDATE_BLOCKED}" = 1 ]; then
+       return
+-   elif blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
++   elif blkid /dev/mmcblk0p1 | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
+       # Booting from the SD card - recovery.bin can be staged on /mnt/boot.
+       UPDATE_BLOCKED=0
+    elif [ -n "${BOOTFS}" ]; then
+@@ -772,7 +772,7 @@ findBootFS()
+       die "rpi-eeprom-update is only available when booting from an SD card or if flashrom can be used."
+    fi
+ 
+-   if blkid | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
++   if blkid /dev/mmcblk0p1 | grep -qE "/dev/mmcblk0p1.*LABEL_FATBOOT.*hassos-boot.*TYPE.*vfat"; then
+       # use HAOS default bootfs location if booting from SD card
+       BOOTFS="/mnt/boot"
+    elif [ -z "$BOOTFS" ]; then


### PR DESCRIPTION
On CM4, rpi-eeprom-update only prints warning if the env variable enabling self-update isn't set. In that case, also print bootloader info so we can propagate it further.

Also, add patch making findBootFS faster, avoiding scan of all block devices.

Refs #4631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted EEPROM update flow for CM4 devices to continue operation when updates are not enabled, preventing unintended early termination while preserving system guidance and information gathering capabilities.

* **Refactor**
  * Optimized boot filesystem detection process for improved system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->