### PR TITLE
Extend hassos-supervisor.service stop timeout for graceful shutdown

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/hassos-supervisor.service
@@ -15,7 +15,12 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-/usr/bin/docker stop hassio_supervisor
 ExecStart=/usr/sbin/hassos-supervisor
-ExecStop=-/usr/bin/docker stop hassio_supervisor
+# This unit is ordered After=docker.service, so on host shutdown it is
+# stopped before Docker tears containers down. Supervisor handles the
+# SIGTERM from "docker stop" by gracefully stopping Home Assistant Core,
+# apps and plugins; allow ample time for that to complete.
+ExecStop=-/usr/bin/docker stop -t 420 hassio_supervisor
+TimeoutStopSec=450s
 
 [Install]
 WantedBy=multi-user.target

--- a/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
+++ b/buildroot-external/rootfs-overlay/usr/sbin/hassos-cli
@@ -58,7 +58,6 @@ case $? in
     # 143 graceful termination (SIGTERM). Most likely a proper shutdown.
     # Just sleep for a while until actual systemd shutdown gets invoked.
     printf "\nHome Assistant CLI has been terminated.\n"
-    sleep 30
     ;;
   *)
     printf "\nHA CLI failed with error code: %s\n" "$?"


### PR DESCRIPTION
Give Supervisor enough time to gracefully stop Home Assistant Core, apps and plugins when the host shuts down. The unit is already ordered After=docker.service, so on a host reboot or power off it is stopped before Docker tears containers down.

Supervisor should handle the SIGTERM from "docker stop" by running its managed shutdown within 420 seconds, after that point it would be killed by Docker, and ultimately 30 seconds later by Systemd.

Also, drop the delay after SIGTERM for ha-cli added in #2507. Once Systemd shutdown is invoked, the ha-cli is no longer restarted.

Refs #4642, refs #4584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined supervisor service shutdown sequence with extended timeout to ensure graceful container termination
  * Improved system CLI termination handling to respond faster during shutdown scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->