### PR TITLE
Drop `_workstation._tcp` service annoucement from HAOS

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/dnssd/workstation.dnssd
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/dnssd/workstation.dnssd
@@ -1,3 +1,0 @@
-[Service]
-Name=%H [%m]
-Type=_workstation._tcp


### PR DESCRIPTION
Since switching to systemd-resolved we've announced Home Assistant Operating System as a workstation through `_workstation._tcp` DNS-SD. This most likely came in to preserve what avahi announced by default. However, the service has not a clear definition what it means and there is no need for the service announcement really. The host name gets announced even without a service announcement. This commit removes the service announcement file from the rootfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the workstation DNS-SD service advertisement configuration, disabling network discovery of workstation services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->