### PR TITLE
Fix OS update tests when update returns no response

### DIFF
--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -55,15 +55,15 @@ def test_os_update(shell, shell_json, target):
 
     # Core (and maybe Supervisor) might be downloaded at this point, so we need to keep trying
     while True:
-        output = "\n".join(shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=120))
-        if "Don't have an URL for OTA updates" in output:
-            shell.run_check("ha su reload --no-progress")
-        elif "Command completed successfully" in output:
+        shell.console.sendline(f"ha os update --no-progress --version {stable_version} || true")
+        # a successful update may reboot the system immediately, so wait for the new slot to boot
+        index, *_ = shell.console.expect(["Booting `Slot ", "Don't have an URL for OTA updates"], timeout=120)
+        # matched on "Booting `Slot "
+        if index == 0:
             break
-
+        # no timeout -> matched on the second pattern
+        shell.run_check("ha su reload --no-progress")
         sleep(5)
-
-    shell.console.expect("Booting `Slot ", timeout=60)
 
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)


### PR DESCRIPTION
When the update command returns no response, which may happen after the shutdown reordering implemented as part of #4642, the OS update test hangs waiting for this response. To fix it, fire away the OS update command and wait either for message about missing OTA info or for early boot output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OS update test reliability through improved boot detection patterns and refined retry mechanisms for handling OTA update scenarios, ensuring more robust verification of system reboot processes during platform updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->