### PR TITLE
Add CAs for new signing certificates to RAUC keyring

### DIFF
--- a/buildroot-external/genimage/image-raucb-nospl.cfg
+++ b/buildroot-external/genimage/image-raucb-nospl.cfg
@@ -1,6 +1,8 @@
 rauc {
 	key = "/build/key.pem"
 	cert = "/build/cert.pem"
+	# intermediate can be removed after May 14th 2028, along with old CAs from the keyrings
+	intermediate = "${BR2_EXTERNAL_HAOS_PATH}/ota/rel-ca-xsign-oldroot.cert.pem"
 	keyring = "${TARGET_DIR}/etc/rauc/keyring.pem"
 	manifest = "${RAUC_MANIFEST:-PLEASE_SPECIFY_RAUC_MANIFEST}"
 	file hook { image = "${BR2_EXTERNAL_HAOS_PATH}/ota/rauc-hook" }

--- a/buildroot-external/genimage/image-raucb-spl.cfg
+++ b/buildroot-external/genimage/image-raucb-spl.cfg
@@ -1,6 +1,8 @@
 rauc {
 	key = "/build/key.pem"
 	cert = "/build/cert.pem"
+	# intermediate can be removed after May 14th 2028, along with old CAs from the keyrings
+	intermediate = "${BR2_EXTERNAL_HAOS_PATH}/ota/rel-ca-xsign-oldroot.cert.pem"
 	keyring = "${TARGET_DIR}/etc/rauc/keyring.pem"
 	manifest = "${RAUC_MANIFEST:-PLEASE_SPECIFY_RAUC_MANIFEST}"
 	file hook { image = "${BR2_EXTERNAL_HAOS_PATH}/ota/rauc-hook" }

--- a/buildroot-external/ota/dev-ca.pem
+++ b/buildroot-external/ota/dev-ca.pem
@@ -2,6 +2,168 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number: 1 (0x1)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:48 2026 GMT
+            Not After : Jun  9 08:50:48 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:a0:5d:4c:00:e8:37:6b:f2:ff:c4:ad:88:5d:f5:
+                    37:6f:79:fc:a6:7a:5e:a1:cc:f8:98:54:9b:ff:93:
+                    85:1a:66:62:ec:07:96:73:2f:38:2d:dc:11:63:1e:
+                    34:4d:45:b8:f7:b9:4f:f5:14:5e:58:4d:1a:3e:b5:
+                    b8:65:c9:4e:60:6c:ce:3b:06:16:ea:75:af:d5:23:
+                    53:80:f9:96:44:ff:55:af:e3:ba:eb:21:92:1b:a2:
+                    ab:a6:bb:ee:d4:9e:fb
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:64:02:30:09:d1:15:1b:f6:07:43:6c:75:ee:68:3e:c1:39:
+        47:67:39:60:71:ca:22:ce:8a:11:66:df:6d:7e:a2:5e:61:81:
+        b2:3c:c3:79:97:c2:cd:1d:a5:d4:d6:f1:64:b9:9e:af:02:30:
+        7b:2e:09:70:74:31:d0:61:45:17:ba:12:c2:67:d9:a8:0d:d8:
+        6b:df:40:40:f9:34:98:b0:48:0e:75:23:b4:0f:34:82:91:f3:
+        ad:4e:cb:de:8b:33:cd:8e:62:d9:e0:9c
+-----BEGIN CERTIFICATE-----
+MIICKDCCAa+gAwIBAgIBATAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDQ4WhcNNDYwNjA5MDg1MDQ4WjBNMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJvb3QwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AASgXUwA6Ddr8v/ErYhd9Tdvefymel6hzPiYVJv/k4UaZmLsB5ZzLzgt3BFjHjRN
+Rbj3uU/1FF5YTRo+tbhlyU5gbM47Bhbqda/VI1OA+ZZE/1Wv47rrIZIboqumu+7U
+nvujYzBhMB0GA1UdDgQWBBSZt5KddtQU6PERmfkMCtBUgVCA1jAfBgNVHSMEGDAW
+gBSZt5KddtQU6PERmfkMCtBUgVCA1jAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB
+/wQEAwIBBjAKBggqhkjOPQQDAwNnADBkAjAJ0RUb9gdDbHXuaD7BOUdnOWBxyiLO
+ihFm321+ol5hgbI8w3mXws0dpdTW8WS5nq8CMHsuCXB0MdBhRRe6EsJn2agN2Gvf
+QED5NJiwSA51I7QPNIKR861Oy96LM82OYtngnA==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:49 2026 GMT
+            Not After : Jun  8 08:50:49 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Release
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:7b:03:3b:2f:4d:08:94:ed:c2:f4:d8:53:7d:cf:
+                    54:0d:ea:f5:57:07:48:29:a4:fd:10:5d:ce:a8:90:
+                    71:95:78:bc:a9:fe:c3:71:f6:6f:68:c1:7e:74:d4:
+                    6e:fe:af:35:52:d1:f0:8e:25:ff:28:30:29:ce:67:
+                    b1:4b:2e:59:b2:01:d7:94:7e:33:4d:56:e2:55:1e:
+                    a1:65:64:d3:6a:77:6a:bc:8b:14:9f:3b:b8:6f:12:
+                    a0:d5:7d:ae:ff:20:71
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                1F:AC:8A:E1:90:EA:B2:72:11:63:2A:3D:10:66:3C:0F:0A:29:FF:0A
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:65:02:31:00:9a:99:3f:03:32:81:bf:0a:7e:e5:46:ba:78:
+        8a:17:fe:3a:cc:ef:ab:2f:fd:ed:ea:e2:7e:b4:c2:a7:12:c3:
+        50:70:5d:0a:3e:78:31:0b:5f:cf:b9:eb:2f:3c:55:ca:a1:02:
+        30:04:66:ae:61:b9:da:8d:41:71:60:95:f9:cc:22:e5:c9:e3:
+        9f:90:20:91:40:16:46:fc:65:18:26:01:86:be:94:72:0d:86:
+        ae:89:cd:c4:78:e3:91:a5:b6:b5:11:75:46
+-----BEGIN CERTIFICATE-----
+MIICLzCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDQ5WhcNNDYwNjA4MDg1MDQ5WjBQMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEyMDAGA1UEAwwpSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJlbGVhc2UwdjAQBgcqhkjOPQIBBgUrgQQA
+IgNiAAR7AzsvTQiU7cL02FN9z1QN6vVXB0gppP0QXc6okHGVeLyp/sNx9m9owX50
+1G7+rzVS0fCOJf8oMCnOZ7FLLlmyAdeUfjNNVuJVHqFlZNNqd2q8ixSfO7hvEqDV
+fa7/IHGjZjBkMB0GA1UdDgQWBBQfrIrhkOqychFjKj0QZjwPCin/CjAfBgNVHSME
+GDAWgBSZt5KddtQU6PERmfkMCtBUgVCA1jASBgNVHRMBAf8ECDAGAQH/AgEAMA4G
+A1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNoADBlAjEAmpk/AzKBvwp+5Ua6eIoX
+/jrM76sv/e3q4n60wqcSw1BwXQo+eDELX8+56y88VcqhAjAEZq5hudqNQXFglfnM
+IuXJ45+QIJFAFkb8ZRgmAYa+lHINhq6JzcR445GltrURdUY=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:50 2026 GMT
+            Not After : Jun  8 08:50:50 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Development
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:80:22:fb:aa:59:7b:1a:67:d9:c3:ec:f3:c0:c1:
+                    e1:c3:4c:48:3b:28:20:42:25:54:01:4a:54:b1:e3:
+                    f5:60:6e:36:65:f6:72:5f:92:bd:6a:11:34:72:74:
+                    3f:c9:dc:eb:85:21:59:af:6b:b9:0f:9b:3c:9f:5a:
+                    4a:35:00:8e:fe:65:d6:9e:b5:6a:84:92:f2:c2:55:
+                    ac:34:17:ad:02:dd:7d:1b:bd:11:cb:48:bb:b6:56:
+                    fb:53:a3:86:a4:81:55
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                4B:D0:98:37:9D:3B:90:F5:EB:3A:7C:72:FD:6E:11:63:EB:3F:9D:D9
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:66:02:31:00:de:4d:92:6e:35:41:06:33:f5:46:2e:11:c4:
+        cc:72:c1:cd:06:23:73:a2:a3:3c:7b:4e:36:cc:2e:80:9e:74:
+        47:8f:be:6e:94:29:d8:ad:de:16:7e:0f:87:b9:7e:b7:41:02:
+        31:00:d1:25:a9:4f:35:51:92:89:80:d4:7a:73:c6:4a:94:51:
+        6d:6c:2c:23:9e:c4:2d:d2:26:dd:78:43:8f:dd:ab:d4:76:76:
+        15:c3:05:6c:06:f7:8e:6f:df:c0:b8:f7:ab:3e
+-----BEGIN CERTIFICATE-----
+MIICNDCCAbmgAwIBAgIBAzAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDUwWhcNNDYwNjA4MDg1MDUwWjBUMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzE2MDQGA1UEAwwtSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIERldmVsb3BtZW50MHYwEAYHKoZIzj0CAQYF
+K4EEACIDYgAEgCL7qll7GmfZw+zzwMHhw0xIOyggQiVUAUpUseP1YG42ZfZyX5K9
+ahE0cnQ/ydzrhSFZr2u5D5s8n1pKNQCO/mXWnrVqhJLywlWsNBetAt19G70Ry0i7
+tlb7U6OGpIFVo2YwZDAdBgNVHQ4EFgQUS9CYN507kPXrOnxy/W4RY+s/ndkwHwYD
+VR0jBBgwFoAUmbeSnXbUFOjxEZn5DArQVIFQgNYwEgYDVR0TAQH/BAgwBgEB/wIB
+ADAOBgNVHQ8BAf8EBAMCAQYwCgYIKoZIzj0EAwMDaQAwZgIxAN5Nkm41QQYz9UYu
+EcTMcsHNBiNzoqM8e042zC6AnnRHj75ulCnYrd4Wfg+HuX63QQIxANElqU81UZKJ
+gNR6c8ZKlFFtbCwjnsQt0ibdeEOP3avUdnYVwwVsBveOb9/AuPerPg==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: O=HassOS, CN=HassOS Provisioning CA Root
         Validity
@@ -78,16 +240,6 @@ tiWn9807Awe7Zo9K5oTDBjhDqyvDKXzLql8jLqfma13l3dnqLFlG5fNsc5vr73RW
 k/DpPBcDV7YXP94vLh1qZdhxiG+tGUjTOgVG0mVx+pdzOAwd0oNIsRZhfPHbtgZb
 Ro1FTPSvstq2ykdU9uc3nnrWDIhYBrBJtSUWoHebWg==
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBfDBmMA0GCSqGSIb3DQEBCwUAMDcxDzANBgNVBAoMBkhhc3NPUzEkMCIGA1UE
-AwwbSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSb290Fw0xODA1MTUxNjM1NTRaFw0z
-MjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQAWfPq1Bchq5D2B+baE149H
-M9ozBTeICoZJ3xNyVPfce9F2VHQjuXngKCVzCgBxeUNJXVbFdDvd0ybs6SoOojeG
-WbIeAwzQ2uwluqy7rMx3bvn+QDVUfUP01e7Wd21m1aR+eas6FKCTwUw9CEHMr34s
-3TZOJ4av3vVlYcJbCk5mfRQ5xyf6qxsdi/tWHxchrJNi/X/e6AMy2sJmj8mBvPES
-JmjWx97JJISvMYuhWZpbycq+SlvISSbP4IcAYAekGJreHxAXuXr4ELZRQAHTeueH
-ID0K1fRJU+LVTaQCZohFoECEMqJhrBVs5CTMG2EyEeqlI3I5PTBAyjO362rNkSQz
------END X509 CRL-----
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -168,17 +320,6 @@ TqumHVTlPzl60Ukx979PMZsNHaiRaEWw+ufmni03ifxcgGQsu80ZjNdd0LZ2l6mB
 5Ct3+aMC3IHW/r0kCzZqwg+wYNkO0wO6gNRQ8Vndv8CW7iwGzAAqz91IVQ2B5nYG
 kt9GKRDV61ycgXUtlGtbLxXjYg45UxwfSoLIE8aukYxY53CeVw==
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBfzBpMA0GCSqGSIb3DQEBCwUAMDoxDzANBgNVBAoMBkhhc3NPUzEnMCUGA1UE
-AwweSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSZWxlYXNlFw0xODA1MTUxNjM1NTRa
-Fw0zMjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQBOSgkmXR88VTMZfsjY
-NYHj2eYSSoFCLLW9CepoeCfIYeb81w6DUusZm4oqyvU+yFj5SBxV6X4ZEJaIaj8r
-jZtIbx6O6ocMQp9SX1O0OoG+/JJNm/9eezyhuMEK+OEbpVaPpjw6nvizOJMzAx3G
-hdW8u7xOVc004uDyCE0KT/5DTqQifsS1C5NhRZTrXSD4b6PY1d2wJx33zNUlD0B4
-7v4f+U9CzQJKY0og7krrlRHfwl8vpMUR4OL1Lxwju8RvcT4u5Do1gp3c7DJ/NJqr
-xHQjNseGewHQPrNe4Ix6inwIDRQLimQvF74RlmHf0G+Jf9+m5ixCOWH+ySfReCQ7
-fSiy
------END X509 CRL-----
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -259,14 +400,3 @@ rDA64Snh4vCbX38eDehrqKQ8bAmXsqu/WBbMb2IL56HWBvCqfb4f5AAU0Cqcp32Z
 kHTSl3bzcsC/g0BBa5furKDsXnm6dFHv0iJ/yCCnOcaPK6iqrZ4bXv5hsNf4lGtk
 PD2f2k5Z6JX5WIFVTsrdkyTPl0oLR/KMyEnHFs1pwLZikRmuyRW6mXg=
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBgzBtMA0GCSqGSIb3DQEBCwUAMD4xDzANBgNVBAoMBkhhc3NPUzErMCkGA1UE
-AwwiSGFzc09TIFByb3Zpc2lvbmluZyBDQSBEZXZlbG9wbWVudBcNMTgwNTE1MTYz
-NTU0WhcNMzIwMTIyMTYzNTU0WjANBgkqhkiG9w0BAQsFAAOCAQEAhmHxjIYZ+J7U
-/Ih4vWTakmjSQgD+cvhOedUMxBBwxerZ2qKB2t3LGSBKjVgOThL84HppNP/Y1Hqs
-Kq3RD57aL2ZNdQeP3xXjotb/LXsO8KjNi1SeFFIdXkQ8qFVyXkrbqM2h8PJE3Cu5
-yeKJaQytPPl90scqmyS07bfI6akwNyg4W6dKQ8KDQrs3DV+Q1xGff6mUgH/6eTIa
-lg8OTjh6yI1+XZr0Yz9bNo0/3AOMTbNTYZMnZTapD6r8k2r3pr7FQ6lIyHaCAUVF
-TrWQsqmjuQ2uoj0VZvjKxje8VggNv0NFKg8W3l6p7ng1SVLdzw7i7RIVb+iF9BJC
-N373ui3HSw==
------END X509 CRL-----

--- a/buildroot-external/ota/provisioning-ca.pem
+++ b/buildroot-external/ota/provisioning-ca.pem
@@ -2,6 +2,60 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number: 1 (0x1)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:48 2026 GMT
+            Not After : Jun  9 08:50:48 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:a0:5d:4c:00:e8:37:6b:f2:ff:c4:ad:88:5d:f5:
+                    37:6f:79:fc:a6:7a:5e:a1:cc:f8:98:54:9b:ff:93:
+                    85:1a:66:62:ec:07:96:73:2f:38:2d:dc:11:63:1e:
+                    34:4d:45:b8:f7:b9:4f:f5:14:5e:58:4d:1a:3e:b5:
+                    b8:65:c9:4e:60:6c:ce:3b:06:16:ea:75:af:d5:23:
+                    53:80:f9:96:44:ff:55:af:e3:ba:eb:21:92:1b:a2:
+                    ab:a6:bb:ee:d4:9e:fb
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:64:02:30:09:d1:15:1b:f6:07:43:6c:75:ee:68:3e:c1:39:
+        47:67:39:60:71:ca:22:ce:8a:11:66:df:6d:7e:a2:5e:61:81:
+        b2:3c:c3:79:97:c2:cd:1d:a5:d4:d6:f1:64:b9:9e:af:02:30:
+        7b:2e:09:70:74:31:d0:61:45:17:ba:12:c2:67:d9:a8:0d:d8:
+        6b:df:40:40:f9:34:98:b0:48:0e:75:23:b4:0f:34:82:91:f3:
+        ad:4e:cb:de:8b:33:cd:8e:62:d9:e0:9c
+-----BEGIN CERTIFICATE-----
+MIICKDCCAa+gAwIBAgIBATAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDQ4WhcNNDYwNjA5MDg1MDQ4WjBNMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJvb3QwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AASgXUwA6Ddr8v/ErYhd9Tdvefymel6hzPiYVJv/k4UaZmLsB5ZzLzgt3BFjHjRN
+Rbj3uU/1FF5YTRo+tbhlyU5gbM47Bhbqda/VI1OA+ZZE/1Wv47rrIZIboqumu+7U
+nvujYzBhMB0GA1UdDgQWBBSZt5KddtQU6PERmfkMCtBUgVCA1jAfBgNVHSMEGDAW
+gBSZt5KddtQU6PERmfkMCtBUgVCA1jAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB
+/wQEAwIBBjAKBggqhkjOPQQDAwNnADBkAjAJ0RUb9gdDbHXuaD7BOUdnOWBxyiLO
+ihFm321+ol5hgbI8w3mXws0dpdTW8WS5nq8CMHsuCXB0MdBhRRe6EsJn2agN2Gvf
+QED5NJiwSA51I7QPNIKR861Oy96LM82OYtngnA==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: O=HassOS, CN=HassOS Provisioning CA Root
         Validity
@@ -78,35 +132,3 @@ tiWn9807Awe7Zo9K5oTDBjhDqyvDKXzLql8jLqfma13l3dnqLFlG5fNsc5vr73RW
 k/DpPBcDV7YXP94vLh1qZdhxiG+tGUjTOgVG0mVx+pdzOAwd0oNIsRZhfPHbtgZb
 Ro1FTPSvstq2ykdU9uc3nnrWDIhYBrBJtSUWoHebWg==
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBfDBmMA0GCSqGSIb3DQEBCwUAMDcxDzANBgNVBAoMBkhhc3NPUzEkMCIGA1UE
-AwwbSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSb290Fw0xODA1MTUxNjM1NTRaFw0z
-MjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQAWfPq1Bchq5D2B+baE149H
-M9ozBTeICoZJ3xNyVPfce9F2VHQjuXngKCVzCgBxeUNJXVbFdDvd0ybs6SoOojeG
-WbIeAwzQ2uwluqy7rMx3bvn+QDVUfUP01e7Wd21m1aR+eas6FKCTwUw9CEHMr34s
-3TZOJ4av3vVlYcJbCk5mfRQ5xyf6qxsdi/tWHxchrJNi/X/e6AMy2sJmj8mBvPES
-JmjWx97JJISvMYuhWZpbycq+SlvISSbP4IcAYAekGJreHxAXuXr4ELZRQAHTeueH
-ID0K1fRJU+LVTaQCZohFoECEMqJhrBVs5CTMG2EyEeqlI3I5PTBAyjO362rNkSQz
------END X509 CRL-----
------BEGIN X509 CRL-----
-MIIBfzBpMA0GCSqGSIb3DQEBCwUAMDoxDzANBgNVBAoMBkhhc3NPUzEnMCUGA1UE
-AwweSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSZWxlYXNlFw0xODA1MTUxNjM1NTRa
-Fw0zMjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQBOSgkmXR88VTMZfsjY
-NYHj2eYSSoFCLLW9CepoeCfIYeb81w6DUusZm4oqyvU+yFj5SBxV6X4ZEJaIaj8r
-jZtIbx6O6ocMQp9SX1O0OoG+/JJNm/9eezyhuMEK+OEbpVaPpjw6nvizOJMzAx3G
-hdW8u7xOVc004uDyCE0KT/5DTqQifsS1C5NhRZTrXSD4b6PY1d2wJx33zNUlD0B4
-7v4f+U9CzQJKY0og7krrlRHfwl8vpMUR4OL1Lxwju8RvcT4u5Do1gp3c7DJ/NJqr
-xHQjNseGewHQPrNe4Ix6inwIDRQLimQvF74RlmHf0G+Jf9+m5ixCOWH+ySfReCQ7
-fSiy
------END X509 CRL-----
------BEGIN X509 CRL-----
-MIIBgzBtMA0GCSqGSIb3DQEBCwUAMD4xDzANBgNVBAoMBkhhc3NPUzErMCkGA1UE
-AwwiSGFzc09TIFByb3Zpc2lvbmluZyBDQSBEZXZlbG9wbWVudBcNMTgwNTE1MTYz
-NTU0WhcNMzIwMTIyMTYzNTU0WjANBgkqhkiG9w0BAQsFAAOCAQEAhmHxjIYZ+J7U
-/Ih4vWTakmjSQgD+cvhOedUMxBBwxerZ2qKB2t3LGSBKjVgOThL84HppNP/Y1Hqs
-Kq3RD57aL2ZNdQeP3xXjotb/LXsO8KjNi1SeFFIdXkQ8qFVyXkrbqM2h8PJE3Cu5
-yeKJaQytPPl90scqmyS07bfI6akwNyg4W6dKQ8KDQrs3DV+Q1xGff6mUgH/6eTIa
-lg8OTjh6yI1+XZr0Yz9bNo0/3AOMTbNTYZMnZTapD6r8k2r3pr7FQ6lIyHaCAUVF
-TrWQsqmjuQ2uoj0VZvjKxje8VggNv0NFKg8W3l6p7ng1SVLdzw7i7RIVb+iF9BJC
-N373ui3HSw==
------END X509 CRL-----

--- a/buildroot-external/ota/rel-ca-xsign-oldroot.cert.pem
+++ b/buildroot-external/ota/rel-ca-xsign-oldroot.cert.pem
@@ -1,0 +1,68 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            26:6a:d5:45:fa:1e:36:7b:50:2a:5c:01:2c:0d:fd:67:5a:c8:f5:b0
+        Signature Algorithm: sha384WithRSAEncryption
+        Issuer: O=HassOS, CN=HassOS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:51 2026 GMT
+            Not After : May 14 16:35:54 2028 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Release
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:7b:03:3b:2f:4d:08:94:ed:c2:f4:d8:53:7d:cf:
+                    54:0d:ea:f5:57:07:48:29:a4:fd:10:5d:ce:a8:90:
+                    71:95:78:bc:a9:fe:c3:71:f6:6f:68:c1:7e:74:d4:
+                    6e:fe:af:35:52:d1:f0:8e:25:ff:28:30:29:ce:67:
+                    b1:4b:2e:59:b2:01:d7:94:7e:33:4d:56:e2:55:1e:
+                    a1:65:64:d3:6a:77:6a:bc:8b:14:9f:3b:b8:6f:12:
+                    a0:d5:7d:ae:ff:20:71
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                1F:AC:8A:E1:90:EA:B2:72:11:63:2A:3D:10:66:3C:0F:0A:29:FF:0A
+            X509v3 Authority Key Identifier: 
+                49:69:2D:A8:24:2F:B0:AC:E6:9A:02:6A:D0:FC:9A:AA:73:9B:62:71
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha384WithRSAEncryption
+    Signature Value:
+        61:15:87:59:63:f5:06:47:a4:c3:60:19:3a:ab:05:f9:7d:7e:
+        1b:59:6d:fa:12:e3:71:67:30:d6:54:ad:f5:49:ff:15:b2:3f:
+        e0:df:29:4a:76:db:16:e3:b6:7b:e6:28:fb:14:c2:e8:f7:ba:
+        a3:14:94:93:f3:4f:b8:8c:6a:fd:09:8c:ce:f4:b0:4b:75:9c:
+        d3:59:3f:fe:d4:97:49:2b:ae:cd:fa:6e:50:c0:fa:80:49:ec:
+        53:9e:44:cb:0e:b0:23:e9:11:ad:23:ee:63:79:e2:02:e7:72:
+        14:e6:ca:9b:b3:99:b2:8d:7a:f0:73:61:fe:e5:26:85:b6:01:
+        fb:15:de:54:b0:a0:c7:32:df:98:ec:74:fa:e6:c0:a0:64:19:
+        6a:7b:84:5c:8a:9f:88:2f:a3:4e:0d:41:6c:3b:ac:fb:73:4a:
+        00:1f:bc:77:0c:b4:cb:5d:ec:e9:3f:c6:91:8c:e7:58:cf:18:
+        5a:d9:d4:dc:6d:8d:d2:a3:7e:6d:dd:be:7e:51:df:ad:05:51:
+        30:59:2e:46:b4:a8:25:d7:5f:2d:35:5b:77:0f:a6:0b:d6:12:
+        fa:fb:b2:65:09:69:03:99:2d:3d:b8:4e:b7:1b:1f:31:2d:8f:
+        79:29:00:9b:43:8c:38:62:84:e5:61:14:04:f5:86:36:d6:91:
+        61:54:63:a5
+-----BEGIN CERTIFICATE-----
+MIICzTCCAbWgAwIBAgIUJmrVRfoeNntQKlwBLA39Z1rI9bAwDQYJKoZIhvcNAQEM
+BQAwNzEPMA0GA1UECgwGSGFzc09TMSQwIgYDVQQDDBtIYXNzT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDUxWhcNMjgwNTE0MTYzNTU0WjBQMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEyMDAGA1UEAwwpSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJlbGVhc2UwdjAQBgcqhkjOPQIBBgUrgQQA
+IgNiAAR7AzsvTQiU7cL02FN9z1QN6vVXB0gppP0QXc6okHGVeLyp/sNx9m9owX50
+1G7+rzVS0fCOJf8oMCnOZ7FLLlmyAdeUfjNNVuJVHqFlZNNqd2q8ixSfO7hvEqDV
+fa7/IHGjZjBkMB0GA1UdDgQWBBQfrIrhkOqychFjKj0QZjwPCin/CjAfBgNVHSME
+GDAWgBRJaS2oJC+wrOaaAmrQ/Jqqc5ticTASBgNVHRMBAf8ECDAGAQH/AgEAMA4G
+A1UdDwEB/wQEAwIBBjANBgkqhkiG9w0BAQwFAAOCAQEAYRWHWWP1Bkekw2AZOqsF
++X1+G1lt+hLjcWcw1lSt9Un/FbI/4N8pSnbbFuO2e+Yo+xTC6Pe6oxSUk/NPuIxq
+/QmMzvSwS3Wc01k//tSXSSuuzfpuUMD6gEnsU55Eyw6wI+kRrSPuY3niAudyFObK
+m7OZso168HNh/uUmhbYB+xXeVLCgxzLfmOx0+ubAoGQZanuEXIqfiC+jTg1BbDus
++3NKAB+8dwy0y13s6T/GkYznWM8YWtnU3G2N0qN+bd2+flHfrQVRMFkuRrSoJddf
+LTVbdw+mC9YS+vuyZQlpA5ktPbhOtxsfMS2PeSkAm0OMOGKE5WEUBPWGNtaRYVRj
+pQ==
+-----END CERTIFICATE-----

--- a/buildroot-external/ota/rel-ca.pem
+++ b/buildroot-external/ota/rel-ca.pem
@@ -2,6 +2,114 @@ Certificate:
     Data:
         Version: 3 (0x2)
         Serial Number: 1 (0x1)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:48 2026 GMT
+            Not After : Jun  9 08:50:48 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:a0:5d:4c:00:e8:37:6b:f2:ff:c4:ad:88:5d:f5:
+                    37:6f:79:fc:a6:7a:5e:a1:cc:f8:98:54:9b:ff:93:
+                    85:1a:66:62:ec:07:96:73:2f:38:2d:dc:11:63:1e:
+                    34:4d:45:b8:f7:b9:4f:f5:14:5e:58:4d:1a:3e:b5:
+                    b8:65:c9:4e:60:6c:ce:3b:06:16:ea:75:af:d5:23:
+                    53:80:f9:96:44:ff:55:af:e3:ba:eb:21:92:1b:a2:
+                    ab:a6:bb:ee:d4:9e:fb
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:64:02:30:09:d1:15:1b:f6:07:43:6c:75:ee:68:3e:c1:39:
+        47:67:39:60:71:ca:22:ce:8a:11:66:df:6d:7e:a2:5e:61:81:
+        b2:3c:c3:79:97:c2:cd:1d:a5:d4:d6:f1:64:b9:9e:af:02:30:
+        7b:2e:09:70:74:31:d0:61:45:17:ba:12:c2:67:d9:a8:0d:d8:
+        6b:df:40:40:f9:34:98:b0:48:0e:75:23:b4:0f:34:82:91:f3:
+        ad:4e:cb:de:8b:33:cd:8e:62:d9:e0:9c
+-----BEGIN CERTIFICATE-----
+MIICKDCCAa+gAwIBAgIBATAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDQ4WhcNNDYwNjA5MDg1MDQ4WjBNMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJvb3QwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AASgXUwA6Ddr8v/ErYhd9Tdvefymel6hzPiYVJv/k4UaZmLsB5ZzLzgt3BFjHjRN
+Rbj3uU/1FF5YTRo+tbhlyU5gbM47Bhbqda/VI1OA+ZZE/1Wv47rrIZIboqumu+7U
+nvujYzBhMB0GA1UdDgQWBBSZt5KddtQU6PERmfkMCtBUgVCA1jAfBgNVHSMEGDAW
+gBSZt5KddtQU6PERmfkMCtBUgVCA1jAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB
+/wQEAwIBBjAKBggqhkjOPQQDAwNnADBkAjAJ0RUb9gdDbHXuaD7BOUdnOWBxyiLO
+ihFm321+ol5hgbI8w3mXws0dpdTW8WS5nq8CMHsuCXB0MdBhRRe6EsJn2agN2Gvf
+QED5NJiwSA51I7QPNIKR861Oy96LM82OYtngnA==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Root
+        Validity
+            Not Before: Jun  9 08:50:49 2026 GMT
+            Not After : Jun  8 08:50:49 2046 GMT
+        Subject: O=Home Assistant OS, CN=Home Assistant OS Provisioning CA Release
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (384 bit)
+                pub:
+                    04:7b:03:3b:2f:4d:08:94:ed:c2:f4:d8:53:7d:cf:
+                    54:0d:ea:f5:57:07:48:29:a4:fd:10:5d:ce:a8:90:
+                    71:95:78:bc:a9:fe:c3:71:f6:6f:68:c1:7e:74:d4:
+                    6e:fe:af:35:52:d1:f0:8e:25:ff:28:30:29:ce:67:
+                    b1:4b:2e:59:b2:01:d7:94:7e:33:4d:56:e2:55:1e:
+                    a1:65:64:d3:6a:77:6a:bc:8b:14:9f:3b:b8:6f:12:
+                    a0:d5:7d:ae:ff:20:71
+                ASN1 OID: secp384r1
+                NIST CURVE: P-384
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                1F:AC:8A:E1:90:EA:B2:72:11:63:2A:3D:10:66:3C:0F:0A:29:FF:0A
+            X509v3 Authority Key Identifier: 
+                99:B7:92:9D:76:D4:14:E8:F1:11:99:F9:0C:0A:D0:54:81:50:80:D6
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:65:02:31:00:9a:99:3f:03:32:81:bf:0a:7e:e5:46:ba:78:
+        8a:17:fe:3a:cc:ef:ab:2f:fd:ed:ea:e2:7e:b4:c2:a7:12:c3:
+        50:70:5d:0a:3e:78:31:0b:5f:cf:b9:eb:2f:3c:55:ca:a1:02:
+        30:04:66:ae:61:b9:da:8d:41:71:60:95:f9:cc:22:e5:c9:e3:
+        9f:90:20:91:40:16:46:fc:65:18:26:01:86:be:94:72:0d:86:
+        ae:89:cd:c4:78:e3:91:a5:b6:b5:11:75:46
+-----BEGIN CERTIFICATE-----
+MIICLzCCAbWgAwIBAgIBAjAKBggqhkjOPQQDAzBNMRowGAYDVQQKDBFIb21lIEFz
+c2lzdGFudCBPUzEvMC0GA1UEAwwmSG9tZSBBc3Npc3RhbnQgT1MgUHJvdmlzaW9u
+aW5nIENBIFJvb3QwHhcNMjYwNjA5MDg1MDQ5WhcNNDYwNjA4MDg1MDQ5WjBQMRow
+GAYDVQQKDBFIb21lIEFzc2lzdGFudCBPUzEyMDAGA1UEAwwpSG9tZSBBc3Npc3Rh
+bnQgT1MgUHJvdmlzaW9uaW5nIENBIFJlbGVhc2UwdjAQBgcqhkjOPQIBBgUrgQQA
+IgNiAAR7AzsvTQiU7cL02FN9z1QN6vVXB0gppP0QXc6okHGVeLyp/sNx9m9owX50
+1G7+rzVS0fCOJf8oMCnOZ7FLLlmyAdeUfjNNVuJVHqFlZNNqd2q8ixSfO7hvEqDV
+fa7/IHGjZjBkMB0GA1UdDgQWBBQfrIrhkOqychFjKj0QZjwPCin/CjAfBgNVHSME
+GDAWgBSZt5KddtQU6PERmfkMCtBUgVCA1jASBgNVHRMBAf8ECDAGAQH/AgEAMA4G
+A1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNoADBlAjEAmpk/AzKBvwp+5Ua6eIoX
+/jrM76sv/e3q4n60wqcSw1BwXQo+eDELX8+56y88VcqhAjAEZq5hudqNQXFglfnM
+IuXJ45+QIJFAFkb8ZRgmAYa+lHINhq6JzcR445GltrURdUY=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
     Signature Algorithm: sha256WithRSAEncryption
         Issuer: O=HassOS, CN=HassOS Provisioning CA Root
         Validity
@@ -78,16 +186,6 @@ tiWn9807Awe7Zo9K5oTDBjhDqyvDKXzLql8jLqfma13l3dnqLFlG5fNsc5vr73RW
 k/DpPBcDV7YXP94vLh1qZdhxiG+tGUjTOgVG0mVx+pdzOAwd0oNIsRZhfPHbtgZb
 Ro1FTPSvstq2ykdU9uc3nnrWDIhYBrBJtSUWoHebWg==
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBfDBmMA0GCSqGSIb3DQEBCwUAMDcxDzANBgNVBAoMBkhhc3NPUzEkMCIGA1UE
-AwwbSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSb290Fw0xODA1MTUxNjM1NTRaFw0z
-MjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQAWfPq1Bchq5D2B+baE149H
-M9ozBTeICoZJ3xNyVPfce9F2VHQjuXngKCVzCgBxeUNJXVbFdDvd0ybs6SoOojeG
-WbIeAwzQ2uwluqy7rMx3bvn+QDVUfUP01e7Wd21m1aR+eas6FKCTwUw9CEHMr34s
-3TZOJ4av3vVlYcJbCk5mfRQ5xyf6qxsdi/tWHxchrJNi/X/e6AMy2sJmj8mBvPES
-JmjWx97JJISvMYuhWZpbycq+SlvISSbP4IcAYAekGJreHxAXuXr4ELZRQAHTeueH
-ID0K1fRJU+LVTaQCZohFoECEMqJhrBVs5CTMG2EyEeqlI3I5PTBAyjO362rNkSQz
------END X509 CRL-----
 Certificate:
     Data:
         Version: 3 (0x2)
@@ -168,14 +266,3 @@ TqumHVTlPzl60Ukx979PMZsNHaiRaEWw+ufmni03ifxcgGQsu80ZjNdd0LZ2l6mB
 5Ct3+aMC3IHW/r0kCzZqwg+wYNkO0wO6gNRQ8Vndv8CW7iwGzAAqz91IVQ2B5nYG
 kt9GKRDV61ycgXUtlGtbLxXjYg45UxwfSoLIE8aukYxY53CeVw==
 -----END CERTIFICATE-----
------BEGIN X509 CRL-----
-MIIBfzBpMA0GCSqGSIb3DQEBCwUAMDoxDzANBgNVBAoMBkhhc3NPUzEnMCUGA1UE
-AwweSGFzc09TIFByb3Zpc2lvbmluZyBDQSBSZWxlYXNlFw0xODA1MTUxNjM1NTRa
-Fw0zMjAxMjIxNjM1NTRaMA0GCSqGSIb3DQEBCwUAA4IBAQBOSgkmXR88VTMZfsjY
-NYHj2eYSSoFCLLW9CepoeCfIYeb81w6DUusZm4oqyvU+yFj5SBxV6X4ZEJaIaj8r
-jZtIbx6O6ocMQp9SX1O0OoG+/JJNm/9eezyhuMEK+OEbpVaPpjw6nvizOJMzAx3G
-hdW8u7xOVc004uDyCE0KT/5DTqQifsS1C5NhRZTrXSD4b6PY1d2wJx33zNUlD0B4
-7v4f+U9CzQJKY0og7krrlRHfwl8vpMUR4OL1Lxwju8RvcT4u5Do1gp3c7DJ/NJqr
-xHQjNseGewHQPrNe4Ix6inwIDRQLimQvF74RlmHf0G+Jf9+m5ixCOWH+ySfReCQ7
-fSiy
------END X509 CRL-----


### PR DESCRIPTION
Add certificates with new PKI chain to replace the old one. Until May 14th 2028, bundles signed with the old certs will be accepted as well. The transition to the new authority using bundles signed by the new certs is ensured by the intermediate certificate signed by the old CA. This, and the old CA certificates can be removed from the keyring after their expiry.

The keyrings no longer contain CRLs, but the validity of the certificates will be shortened to 4 years, as discussed in the linked issue.

Closes #4743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated OTA update certificate configuration to include intermediate CA certificate support for backward compatibility. This addition is scheduled for removal on May 14th, 2028.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->