### PR TITLE
Clamp default swap size between 1-4 GB

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-swapfile
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-swapfile
@@ -24,9 +24,16 @@ SWAPSIZE="$(size2kilobytes "${SWAPSIZE}")"
 SWAPSIZE_TOLERANCE=0
 
 if [ -z "${SWAPSIZE}" ] || [ "${SWAPSIZE}" = "-1" ]; then
-	# Default to 33% of total memory
-	SWAPSIZE="$(awk '/MemTotal/{ print int($2 * 0.33) }' /proc/meminfo)"
-	echo "[INFO] Using default swapsize of 33% RAM (${SWAPSIZE} kB)"
+	# Default to 33% of total memory, clamped between 1 GiB and 4 GiB
+	SWAPSIZE="$(awk '/MemTotal/ {
+		size = int($2 * 0.33)
+		min = 1 * 1024 * 1024
+		max = 4 * 1024 * 1024
+		if (size < min) size = min
+		if (size > max) size = max
+		print size
+	}' /proc/meminfo)"
+	echo "[INFO] Using default swapsize of 33% RAM clamped to 1-4 GiB (${SWAPSIZE} kB)"
 	SWAPSIZE_TOLERANCE=$((32*1024))  # allow for 32MB fluctuations
 fi
 


### PR DESCRIPTION
The rule using 33% of RAM for default swapfile size had flaws both for low and high RAM systems - for the former the swap was too small to provide any buffer for OOM situations, for the latter it created unnecessarily big swapfile.

Clamp the swapfile size to 1-4 GB. This means the file will somewhat grow on systems with 1 or 2 GB of RAM, but this should be within bounds of what's reported by HA as low storage. For systems with >12 GB of RAM, the swap file wouldn't be created larger than 4 GB (in fact, will be recreated if bigger). The configured size is still respected.

Closes #4481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap memory allocation to enforce a bounded 1–4 GiB range, preventing excessive or insufficient swap space based on system RAM and ensuring consistent system performance across different hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->