### PR TITLE
Add sanity checks for correct release channel to the build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,25 +146,30 @@ jobs:
             fi
           fi
 
-      - name: Validate deployment against publish channel
+      - name: Validate deployment and version against publish channel
         if: ${{ steps.check_publish.outputs.publish_build == 'true' }}
         env:
           CHANNEL: ${{ steps.channel.outputs.channel }}
+          VERSION_FULL: ${{ steps.version.outputs.version_full }}
         run: |
           . "${GITHUB_WORKSPACE}/buildroot-external/meta"
-          case "${DEPLOYMENT}" in
-            development) expected_channel="dev" ;;
-            staging) expected_channel="beta" ;;
-            production) expected_channel="stable" ;;
+          case "${CHANNEL}" in
+            dev)    expected_deployment="development"; version_re='^[0-9]+\.[0-9]+\.dev[0-9]+$' ;;
+            beta)   expected_deployment="staging";     version_re='^[0-9]+\.[0-9]+\.rc[0-9]+$' ;;
+            stable) expected_deployment="production";  version_re='^[0-9]+\.[0-9]+$' ;;
             *)
-              echo "::error::Refusing to publish a build from an unknown '${DEPLOYMENT}' deployment." \
-                "DEPLOYMENT in buildroot-external/meta must be 'development', 'staging' or 'production'."
+              echo "::error::Refusing to publish to an unknown '${CHANNEL}' channel." \
+                "Channel must be 'dev', 'beta' or 'stable'."
               exit 1
               ;;
           esac
-          if [ "${CHANNEL}" != "${expected_channel}" ]; then
-            echo "::error::Channel mismatch: publishing to '${CHANNEL}' but DEPLOYMENT='${DEPLOYMENT}'" \
-              "expects '${expected_channel}'. Check the meta DEPLOYMENT and the GitHub release label."
+          if [ "${DEPLOYMENT}" != "${expected_deployment}" ]; then
+            echo "::error::Deployment mismatch: publishing to '${CHANNEL}' requires DEPLOYMENT='${expected_deployment}'" \
+              "but buildroot-external/meta has DEPLOYMENT='${DEPLOYMENT}'."
+            exit 1
+          fi
+          if [[ ! "${VERSION_FULL}" =~ ${version_re} ]]; then
+            echo "::error::Version '${VERSION_FULL}' does not match the '${CHANNEL}' channel format ${version_re}."
             exit 1
           fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -146,6 +146,28 @@ jobs:
             fi
           fi
 
+      - name: Validate deployment against publish channel
+        if: ${{ steps.check_publish.outputs.publish_build == 'true' }}
+        env:
+          CHANNEL: ${{ steps.channel.outputs.channel }}
+        run: |
+          . "${GITHUB_WORKSPACE}/buildroot-external/meta"
+          case "${DEPLOYMENT}" in
+            development) expected_channel="dev" ;;
+            staging) expected_channel="beta" ;;
+            production) expected_channel="stable" ;;
+            *)
+              echo "::error::Refusing to publish a build from an unknown '${DEPLOYMENT}' deployment." \
+                "DEPLOYMENT in buildroot-external/meta must be 'development', 'staging' or 'production'."
+              exit 1
+              ;;
+          esac
+          if [ "${CHANNEL}" != "${expected_channel}" ]; then
+            echo "::error::Channel mismatch: publishing to '${CHANNEL}' but DEPLOYMENT='${DEPLOYMENT}'" \
+              "expects '${expected_channel}'. Check the meta DEPLOYMENT and the GitHub release label."
+            exit 1
+          fi
+
       - name: Create build matrix
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: generate_matrix


### PR DESCRIPTION
There's currently nothing preventing us from publishing RC build to the stable channel if the GH release is configured incorrectly. Since we have the meta file which dictates where the deployment should go, use this as a sanity check and reject the workflow if the expected configuration doesn't match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the build workflow with channel-aware pre-publish validation, ensuring deployment settings and version formats match the intended release channel. The process now stops the publish with clear error messages when configuration or version patterns are incorrect, improving release safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->