### PR TITLE
Remove timeout from data partition resize service

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-expand.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-expand.service
@@ -9,6 +9,11 @@ After=dev-disk-by\x2dlabel-hassos\x2ddata.device systemd-fsck@dev-disk-by\x2dlab
 
 [Service]
 Type=oneshot
+# Resizing the data partition can take a long time on slow or previously used
+# disks. There is no point in aborting it after the default start timeout: if
+# the resize fails the system is unusable anyway, so let it run for as long as
+# it needs instead of failing the boot. See #3365.
+TimeoutStartSec=infinity
 ExecStart=/usr/libexec/haos-expand
 
 [Install]


### PR DESCRIPTION
The haos-expand.service ("HAOS data resizing") is a Type=oneshot unit without an explicit timeout, so it inherited systemd's DefaultTimeoutStartSec (90s). On slow or previously used disks the data partition resize can take longer than that, causing the service to be killed and mnt-data.mount to fail with "Dependency failed for HAOS data resizing", leaving the system unusable.

Aborting the resize serves no purpose: if it fails the installation is broken anyway. Set TimeoutStartSec=infinity so the resize runs for as long as it needs instead of failing the boot.

Fixes #3365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the startup timeout for the system expand service so long-running storage resizing can complete without being interrupted.
  * Added clearer guidance in the service configuration about why the startup process may take longer than usual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->