### PR TITLE
ODROID-N2: Fall back to other slot when a kernel fails to load

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -72,11 +72,13 @@ fi
 # 8. SystemB
 # 9. BootInfo
 setenv bootargs
+setenv boot_attempted
 for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootargs}" != "x"; then
-    # skip remaining slots
+    # A bootable slot has already been selected, skip the remaining ones.
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test ${BOOT_A_LEFT} -gt 0; then
+      setenv boot_attempted "true"
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Trying to boot slot A, ${BOOT_A_LEFT} attempts remaining. Loading kernel ..."
       if load mmc ${devnum}:5 ${kernel_addr_r} Image; then
@@ -85,6 +87,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test ${BOOT_B_LEFT} -gt 0; then
+      setenv boot_attempted "true"
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Trying to boot slot B, ${BOOT_B_LEFT} attempts remaining. Loading kernel ..."
       if load mmc ${devnum}:7 ${kernel_addr_r} Image; then
@@ -94,19 +97,28 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   fi
 done
 
+# Persist the (possibly decremented) attempt counters in *all* cases. This way a
+# failed kernel *load* consumes an attempt just like a hang/crash after booti,
+# so repeated load failures count down and we eventually fall back to the other
+# slot instead of looping forever with the counters pinned (see issue #4788).
+run storebootstate
+
 if test -n "${bootargs}"; then
-  run storebootstate
-else
-  echo "No valid slot found, resetting tries to 3"
-  setenv BOOT_A_LEFT 3
-  setenv BOOT_B_LEFT 3
-  run storebootstate
+  printenv bootargs
+  echo "Starting kernel"
+  booti ${kernel_addr_r} - ${fdt_addr_r}
+  echo "Boot failed, resetting..."
   reset
 fi
 
-printenv bootargs
-echo "Starting kernel"
-booti ${kernel_addr_r} - ${fdt_addr_r}
-
-echo "Boot failed, resetting..."
+# No slot could be loaded. Only when no slot had any attempts left (or
+# BOOT_ORDER was invalid) do we re-arm as a last resort, instead of bricking.
+echo "No bootable slot found."
+if test "x${boot_attempted}" = "x"; then
+  echo "All slots exhausted, restoring default boot order and tries"
+  setenv BOOT_ORDER "A B"
+  setenv BOOT_A_LEFT 3
+  setenv BOOT_B_LEFT 3
+  run storebootstate
+fi
 reset


### PR DESCRIPTION
The U-Boot boot script only persisted the decremented boot-attempt counter (storebootstate) when a kernel was successfully loaded. When *neither* slot's kernel could be loaded, it instead reset both counters back to 3 and rebooted - pinning the counters and looping forever without ever falling back or giving up. A failed kernel load therefore never counted as a boot attempt, defeating the A/B rollback safety net (#4788).

Persist the (possibly decremented) counters in all cases, so a failed load consumes an attempt just like a hang/crash after booti. Repeated load failures now count down and we fall back to the other slot. Only re-arm the counters as a true last resort, when no slot had any attempts left (tracked via boot_attempted) or BOOT_ORDER was invalid, instead of on every transient load failure.

Note: this does not address the underlying eMMC read unreliability seen on some N2 units (kernel/boot.scr loads failing in U-Boot); it makes the slot-fallback logic behave correctly when a load does fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot slot handling so the device only boots from a slot that was actually attempted and selected.
  * Added clearer behavior when no bootable slot is found, avoiding unnecessary boot attempts.
  * Boot attempt counters are now saved consistently after slot checks, helping preserve boot state across restarts.
  * If no slot is available, the system can restore the default boot order and retry more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->