### PR TITLE
ODROID-N2: Fall back to other slot when a kernel fails to load

### DIFF
--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -97,9 +97,14 @@ done
 if test -n "${bootargs}"; then
   run storebootstate
 else
-  echo "No valid slot found, resetting tries to 3"
-  setenv BOOT_A_LEFT 3
-  setenv BOOT_B_LEFT 3
+  # A failed kernel load must consume a boot attempt too, otherwise the counters
+  # never count down and we never fall back. Persist the decremented counters
+  # and only re-arm once both slots are exhausted, not on every failure (#4788).
+  if test ${BOOT_A_LEFT} -le 0 && test ${BOOT_B_LEFT} -le 0; then
+    echo "No valid slot found, resetting tries to 3"
+    setenv BOOT_A_LEFT 3
+    setenv BOOT_B_LEFT 3
+  fi
   run storebootstate
   reset
 fi


### PR DESCRIPTION
The U-Boot boot script only persisted the decremented boot-attempt counter (`storebootstate`) when a kernel was successfully loaded. When *neither* slot's kernel could be loaded, it instead reset both counters back to 3 and rebooted — pinning them and looping forever without ever counting down or falling back. A failed kernel load therefore never consumed an attempt, defeating the A/B rollback safety net (#4788).

This persists the (decremented) counters on a failed load too, and only re-arms them once both slots are actually exhausted instead of on every failure. Repeated load failures now count down and we fall back to the other slot.

Note: this does **not** address the underlying eMMC read unreliability seen on some N2 units (kernel / `boot.scr` loads failing in U-Boot); it only makes the slot-fallback logic behave correctly when a load does fail.

## Comparison to #4823

This is a deliberately minimal alternative to #4823. **Both fix the same bug identically** — a failed kernel *load* now decrements the attempt counter and the boot falls back to the other slot. They differ only in last-resort handling:

- **#4823** adds a `boot_attempted` flag and restores `BOOT_ORDER` on the failure path, so it can additionally self-heal a malformed/garbage `BOOT_ORDER` and prefer the good slot after exhaustion — at the cost of a larger change (+23/−11), a new state variable, and a restructured `booti` path.
- **This PR** keeps the existing `if/else` structure and only guards the existing reset-to-3 behind "both slots exhausted" (+8/−3, no new variable, `BOOT_ORDER` left untouched — matching today's behavior).

The tradeoff: this version does **not** self-heal a corrupt *non-empty* `BOOT_ORDER` (RAUC always writes a valid two-slot order, and an empty value already falls back to the `A B` default), in exchange for a much smaller, lower-risk diff in critical boot code.

## Testing

Validated on an ODROID-N2+ U-Boot console:
- The new `test ${BOOT_A_LEFT} -le 0 && test ${BOOT_B_LEFT} -le 0` guard parses and branches correctly (`2/1` → keep, `0/2` → keep, `0/0` → reset).
- A simulated failed slot-B load decrements `BOOT_B_LEFT` and falls back to slot A in the same cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot failover behavior for devices using A/B updates.
  * Failed boot attempts are now counted more reliably, preventing the retry counters from resetting too early.
  * The system will only restore full boot attempts after both boot slots have been exhausted, making boot recovery behavior more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->