### PR TITLE
Enable CONFIG_BT_INTEL_PCIE for Intel PCIe Bluetooth

### DIFF
--- a/buildroot-external/kernel/v6.18.y/device-support-wireless-pci.config
+++ b/buildroot-external/kernel/v6.18.y/device-support-wireless-pci.config
@@ -1,7 +1,7 @@
 # This fragment contains configuration options for wireless (WiFi and
-# Bluetooth) drivers that are using PCI or PCIe bus. For the WiFi drivers
-# the device-support-wireless.config fragment must be included as well as
-# it contains common options.
+# Bluetooth) drivers that use the PCI or PCIe bus. For WiFi drivers,
+# the device-support-wireless.config fragment must be included as well,
+# as it contains common options.
 
 # Atheros drivers
 CONFIG_ATH5K=m

--- a/buildroot-external/kernel/v6.18.y/device-support-wireless-pci.config
+++ b/buildroot-external/kernel/v6.18.y/device-support-wireless-pci.config
@@ -1,6 +1,7 @@
-# This fragment contains configuration options for WiFi drivers that are
-# using PCI or PCIe bus. The device-support-wireless.config fragment must
-# be included for this one to work as well as it contains common options.
+# This fragment contains configuration options for wireless (WiFi and
+# Bluetooth) drivers that are using PCI or PCIe bus. For the WiFi drivers
+# the device-support-wireless.config fragment must be included as well as
+# it contains common options.
 
 # Atheros drivers
 CONFIG_ATH5K=m
@@ -21,6 +22,8 @@ CONFIG_IWLWIFI=m
 CONFIG_IWLDVM=m
 CONFIG_IWLMVM=m
 CONFIG_IWLMLD=m
+# Intel Bluetooth over PCIe (Meteor Lake, Lunar Lake, Panther Lake)
+CONFIG_BT_INTEL_PCIE=m
 
 # Marvell drivers
 CONFIG_MWIFIEX_PCIE=m


### PR DESCRIPTION
## Summary

Recent Intel platforms (Meteor Lake, Lunar Lake, Panther Lake) expose the integrated Bluetooth controller as a native PCIe endpoint instead of attaching it behind the internal USB hub. These controllers — e.g. Scorpius Peak on Panther Lake, PCI `8086:e476` at `00:14.7` — are matched by the in-kernel `btintel_pcie` driver, but that module (`CONFIG_BT_INTEL_PCIE`) was not enabled, so the device stays unbound and no `hci0` appears.

This adds `CONFIG_BT_INTEL_PCIE=m` to `device-support-wireless-pci.config`, next to the Intel `iwl*` wireless PCIe drivers it shares vendor and platforms with. The fragment header is broadened from "WiFi" to "wireless (WiFi and Bluetooth)" to match.

All prerequisites are already satisfied:
- `CONFIG_PCI=y`, ACPI enabled, `BT_INTEL` (select), `FW_LOADER` ✅
- `BR2_PACKAGE_LINUX_FIRMWARE_IBT=y` already installs the `intel/ibt-00a0-*` firmware that Panther Lake BT needs ✅

No firmware packaging changes are required.

## Hardware

- Asus NUC 16 Pro (Intel Panther Lake, Core Ultra 5 325)
- Intel Scorpius Peak BT, PCI `8086:e476`, class `0x0d1100`

Closes #4827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Intel Bluetooth over PCIe, improving compatibility with additional wireless devices.
* **Documentation**
  * Updated wireless PCI/PCIe support messaging to clarify coverage for both WiFi and Bluetooth, and to note inclusion requirements for shared WiFi options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->