### PR TITLE
busybox: Disable seedrng applet

### DIFF
--- a/buildroot-external/busybox.config
+++ b/buildroot-external/busybox.config
@@ -823,6 +823,7 @@ CONFIG_MIM=y
 # CONFIG_RFKILL is not set
 # CONFIG_RUNLEVEL is not set
 # CONFIG_RX is not set
+# CONFIG_SEEDRNG is not set
 CONFIG_SETFATTR=y
 # CONFIG_SETSERIAL is not set
 CONFIG_STRINGS=y


### PR DESCRIPTION
## The change

Disable the busybox `seedrng` applet (`# CONFIG_SEEDRNG is not set`).

## Why

The `seedrng` applet was never a deliberate choice — it got pulled in by an `oldconfig` default when busybox was bumped to 1.37.0 (the checked-in `busybox.config` predates that, still stamped 1.35.0).

RNG seeding on HAOS is already owned by **systemd's `systemd-random-seed.service`**, which is wired into `sysinit.target.wants`. That service runs the native `systemd-random-seed` binary directly:

```
ExecStart=/usr/lib/systemd/systemd-random-seed load
```

The binary is a self-contained systemd component (from `src/random-seed/random-seed.c`) that persists the seed at `/var/lib/systemd/random-seed` — it does **not** shell out to the `seedrng` command (verified: no reference to `seedrng` in the binary).

The busybox `seedrng` applet is therefore redundant and orphaned: it only installed a bare `/usr/sbin/seedrng` symlink that nothing in the image references. Removing it drops a stray command from `PATH` (and ~1.4 KB) with zero functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the BusyBox build configuration to disable seed RNG support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->