### PR TITLE
Make Supervisor startup resilient to transient network failures

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-supervisor.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-supervisor.service
@@ -5,7 +5,7 @@ Wants=network-online.target haos-apparmor.service time-sync.target systemd-journ
 After=docker.service rauc.service dbus.socket network-online.target haos-apparmor.service time-sync.target systemd-journal-gatewayd.socket
 RequiresMountsFor=/mnt/data /mnt/boot /mnt/overlay
 StartLimitIntervalSec=30m
-StartLimitBurst=3
+StartLimitBurst=5
 ConditionPathExists=/run/dbus/system_bus_socket
 ConditionPathExists=/run/docker.sock
 

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-apparmor
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-apparmor
@@ -14,7 +14,7 @@ if [ ! -f "${PROFILES_DIR}/hassio-supervisor" ]; then
     # Download to a temporary file and move into place only on success, so
     # a partial download never ends up at the final location. The dot file
     # is also ignored by the profile loading below.
-    if ! curl -sfL --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 \
+    if ! curl -fSsL --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 \
             -o "${PROFILES_DIR}/.hassio-supervisor.tmp" "${APPARMOR_URL}"; then
         rm -f "${PROFILES_DIR}/.hassio-supervisor.tmp"
         echo "[ERROR]: Failed to download AppArmor profile!"

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-apparmor
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-apparmor
@@ -5,12 +5,22 @@ APPARMOR_URL="https://version.home-assistant.io/apparmor.txt"
 PROFILES_DIR="/mnt/data/supervisor/apparmor"
 CACHE_DIR="${PROFILES_DIR}/cache"
 
-# Check folder structure
-if [ ! -d "${PROFILES_DIR}" ]; then
+# Check for the Supervisor profile itself: the directory might exist while
+# the profile is missing, e.g. when a previous download attempt failed.
+if [ ! -f "${PROFILES_DIR}/hassio-supervisor" ]; then
     echo "[INFO]: AppArmor profile missing, downloading..."
     mkdir -p "${PROFILES_DIR}"
     systemctl start network-online.target
-    curl -sL -o "${PROFILES_DIR}"/hassio-supervisor "${APPARMOR_URL}"
+    # Download to a temporary file and move into place only on success, so
+    # a partial download never ends up at the final location. The dot file
+    # is also ignored by the profile loading below.
+    if ! curl -sfL --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 \
+            -o "${PROFILES_DIR}/.hassio-supervisor.tmp" "${APPARMOR_URL}"; then
+        rm -f "${PROFILES_DIR}/.hassio-supervisor.tmp"
+        echo "[ERROR]: Failed to download AppArmor profile!"
+        exit 1
+    fi
+    mv "${PROFILES_DIR}/.hassio-supervisor.tmp" "${PROFILES_DIR}/hassio-supervisor"
 fi
 mkdir -p "${CACHE_DIR}"
 

--- a/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
@@ -52,8 +52,8 @@ if [ -z "${SUPERVISOR_IMAGE_ID}" ]; then
     # wipe this can race with time synchronization (TLS fails until the
     # clock is correct) or run before the network is fully up.
     if [ "${SUPERVISOR_VERSION}" = "stable" ]; then
-        stable_json="$(curl -fSs --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 --location https://version.home-assistant.io/stable.json)"
-        SUPERVISOR_VERSION="$(printf '%s' "${stable_json}" | jq -e -r '.supervisor')"
+        STABLE_JSON="$(curl -fSs --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 --location https://version.home-assistant.io/stable.json)"
+        SUPERVISOR_VERSION="$(printf '%s' "${STABLE_JSON}" | jq -e -r '.supervisor')"
     fi
 
     echo "[WARNING] Supervisor image missing, downloading a fresh one: ${SUPERVISOR_VERSION}"

--- a/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
@@ -28,10 +28,12 @@ if [ -f "${SUPERVISOR_STARTUP_MARKER}" ]; then
 
     # Make sure we delete all supervisor images
     SUPERVISOR_IMAGE_IDS=$(docker images --no-trunc --filter "reference=${SUPERVISOR_IMAGE}" --format "{{.ID}}" | sort | uniq || echo "")
-    # Intended splitting of SUPERVISOR_IMAGE_IDS
-    # Busybox sh doesn't support arrays
-    # shellcheck disable=SC2086
-    docker image rm --force ${SUPERVISOR_IMAGE_IDS} || true
+    if [ -n "${SUPERVISOR_IMAGE_IDS}" ]; then
+        # Intended splitting of SUPERVISOR_IMAGE_IDS
+        # Busybox sh doesn't support arrays
+        # shellcheck disable=SC2086
+        docker image rm --force ${SUPERVISOR_IMAGE_IDS} || true
+    fi
     SUPERVISOR_IMAGE_ID=""
 fi
 
@@ -46,9 +48,11 @@ if [ -z "${SUPERVISOR_IMAGE_ID}" ]; then
     SUPERVISOR_VERSION=$(jq -r '.supervisor // "stable"' "${SUPERVISOR_DATA}/updater.json" || echo "stable")
 
     # Get version from stable channel in case we have no local version
-    # information.
+    # information. Retry for a while: especially on first boot after a data
+    # wipe this can race with time synchronization (TLS fails until the
+    # clock is correct) or run before the network is fully up.
     if [ "${SUPERVISOR_VERSION}" = "stable" ]; then
-        SUPERVISOR_VERSION="$(curl -s --location https://version.home-assistant.io/stable.json | jq -e -r '.supervisor')"
+        SUPERVISOR_VERSION="$(curl -sf --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 --location https://version.home-assistant.io/stable.json | jq -e -r '.supervisor')"
     fi
 
     echo "[WARNING] Supervisor image missing, downloading a fresh one: ${SUPERVISOR_VERSION}"

--- a/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
+++ b/buildroot-external/rootfs-overlay/usr/sbin/haos-supervisor
@@ -52,7 +52,8 @@ if [ -z "${SUPERVISOR_IMAGE_ID}" ]; then
     # wipe this can race with time synchronization (TLS fails until the
     # clock is correct) or run before the network is fully up.
     if [ "${SUPERVISOR_VERSION}" = "stable" ]; then
-        SUPERVISOR_VERSION="$(curl -sf --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 --location https://version.home-assistant.io/stable.json | jq -e -r '.supervisor')"
+        stable_json="$(curl -fSs --retry 5 --retry-delay 10 --retry-all-errors --max-time 30 --location https://version.home-assistant.io/stable.json)"
+        SUPERVISOR_VERSION="$(printf '%s' "${stable_json}" | jq -e -r '.supervisor')"
     fi
 
     echo "[WARNING] Supervisor image missing, downloading a fresh one: ${SUPERVISOR_VERSION}"


### PR DESCRIPTION
## Summary

Issue #4863 exposed two independent first-boot fragilities that turn a *transient* network failure into a *permanent* one. Both sit on the recovery path after a factory reset / data wipe, where the pre-seeded data partition content is gone and the OS must fetch things from the network on first boot.

### 1. Supervisor version fetch (permanent until reboot)

When the Supervisor image is missing and no local updater information exists, `haos-supervisor` fetches the current stable version from `version.home-assistant.io` in a single attempt with no error handling: if it fails, `jq -e` exits with code 4 under `set -e` and the script dies within ~400ms.

- Since #3669 we only wait up to 15s for time synchronization, so the script can legitimately run with an unsynced clock (TLS validation fails → curl returns nothing) or before the network is fully functional.
- `RestartSec=5s` + `StartLimitBurst=3` + `StartLimitIntervalSec=30m` means three quick failures trip the start rate limit within ~15 seconds, and the unit then stays failed **until reboot** — even if NTP syncs moments later (`status=4/NOPERMISSION` ×3 → "Start request repeated too quickly" in the #4863 journal).

### 2. AppArmor profile download (permanent across reboots)

`haos-apparmor` only downloads the Supervisor profile when the profile *directory* is missing — but it creates the directory *before* attempting the download. One failed first download (no DNS on first boot after wipe) poisons the state: every subsequent boot skips the download because the directory exists, the unit exits successfully having loaded nothing, and the Supervisor container fails to start forever with `apparmor failed to apply profile: write .../attr/apparmor/exec: no such file or directory` — exactly what the #4863 reporter hit after fixing their DNS.

## Changes

- `haos-supervisor`: let curl retry the version fetch itself: `--retry 5 --retry-delay 10 --retry-all-errors --max-time 30`. `--retry-all-errors` is needed so DNS and TLS failures (the unsynced-clock case) are retried too, not just transient HTTP errors.
- `haos-supervisor.service`: increase the start rate limit from 3 to 5 attempts per 30 minutes. The rate limit stays in place to avoid hammering the update infrastructure, but a slightly longer network/time-sync hiccup at boot no longer permanently disables the unit.
- `haos-supervisor`: guard the `docker image rm` in the startup-marker recovery path against an empty image list, which currently logs a spurious `docker: 'docker image rm' requires at least 1 argument` usage error.
- `haos-apparmor`: key the profile download on the profile *file* instead of the directory (self-healing on the next boot), download to a temporary file moved into place only on success, add `-f` and the same curl retry flags, and fail the unit loudly when the download does not succeed.

## Testing

- `sh -n` and shellcheck pass on both scripts.
- Verified the curl flags retry on DNS resolution errors (exit 6 only after the configured retries elapse).
- Simulated the poisoned AppArmor state (directory exists, profile missing, download failing then succeeding): the failed attempt now exits 1 without leaving stray files, and the next run re-downloads and installs the profile despite the pre-existing directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Supervisor startup reliability when a previous start was interrupted.
  * Prevented unnecessary cleanup errors by only removing old Supervisor images when applicable.
  * Made stable-channel Supervisor version retrieval more resilient via retries with bounded time.
  * Improved AppArmor supervisor profile download reliability with fail-fast retries and atomic updates.
  * Increased the Supervisor service’s restart tolerance to reduce failures from repeated starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->