### PR TITLE
Fix Ethernet failure after runtime MTU change on stmmac devices

### DIFF
--- a/buildroot-external/patches/linux/0002-net-stmmac-resume-PHY-before-hardware-setup-when-op.patch
+++ b/buildroot-external/patches/linux/0002-net-stmmac-resume-PHY-before-hardware-setup-when-op.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Tue, 7 Jul 2026 16:50:00 +0200
+Subject: [PATCH] net: stmmac: resume PHY before hardware setup when
+ opening the interface
+
+Since the referenced commit, changing the MTU on a running interface no
+longer disconnects and reconnects the PHY; __stmmac_release() merely
+stops phylink, which also suspends the PHY (BMCR power-down) when WoL
+is not enabled. __stmmac_open() then performs the DMA software reset in
+stmmac_hw_setup() before phylink_start() resumes the PHY again.
+
+IEEE 802.3 22.2.4.1.5 allows a PHY to stop its receive clock while
+powered down, and stmmac requires a running receive clock for the DMA
+software reset to complete (the phylink config sets mac_requires_rxc).
+On such setups, e.g. the RK3566-based Home Assistant Green with an
+RTL8211F-VD PHY in RGMII mode, any runtime MTU change now times out and
+leaves the interface dead:
+
+  rk_gmac-dwmac fe010000.ethernet end0: Failed to reset the dma
+  rk_gmac-dwmac fe010000.ethernet end0: stmmac_hw_setup: DMA engine initialization failed
+  rk_gmac-dwmac fe010000.ethernet end0: __stmmac_open: Hw setup failed
+  rk_gmac-dwmac fe010000.ethernet end0: failed reopening the interface after MTU change
+
+In the field this is triggered by NetworkManager applying an MTU while
+activating the connection, breaking networking entirely.
+
+Resume the PHY in __stmmac_open() before the hardware setup, making it
+the counterpart of the phylink_stop() in __stmmac_release(), like
+stmmac_resume() already does for the same reason. phylink_start() also
+resumes the PHY, but only after stmmac_hw_setup(), and it cannot be
+moved before the hardware setup since it may bring the link up
+immediately from a workqueue, racing with the initialization (see the
+comment in stmmac_resume()). For the regular ndo_open path the PHY has
+just been attached and is not suspended, in which case
+phylink_prepare_resume() does nothing.
+
+Fixes: db299a0c09e9 ("net: stmmac: move PHY handling out of __stmmac_open()/release()")
+Link: https://github.com/home-assistant/operating-system/issues/4858
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+Changes in v2:
+- Move the PHY resume from stmmac_change_mtu() into __stmmac_open() so
+  that it also counters the PHY suspend caused by __stmmac_release()
+  (suggested by Andrew Lunn), placed before stmmac_reset_queues_param()
+  to match the ordering used in stmmac_resume()
+
+ drivers/net/ethernet/stmicro/stmmac/stmmac_main.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -3911,6 +3911,15 @@
+ 			dma_conf->tx_queue[i].tbs = priv->dma_conf.tx_queue[i].tbs;
+ 	memcpy(&priv->dma_conf, dma_conf, sizeof(*dma_conf));
+ 
++	/* The PHY is suspended when the interface is reopened without
++	 * disconnecting the PHY, e.g. on MTU change. IEEE 802.3 allows PHYs
++	 * to stop their receive clock while powered down, but the DMA
++	 * software reset in stmmac_hw_setup() requires a running receive
++	 * clock, and phylink_start() below resumes the PHY only after the
++	 * hardware setup. Resume a suspended PHY here first.
++	 */
++	phylink_prepare_resume(priv->phylink);
++
+ 	stmmac_reset_queues_param(priv);
+ 
+ 	if (!(priv->plat->flags & STMMAC_FLAG_SERDES_UP_AFTER_PHY_LINKUP) &&
+-- 
+2.49.0


### PR DESCRIPTION
## Summary

Since kernel 6.18, the stmmac driver no longer disconnects and reconnects the PHY when the MTU is changed on a running interface (upstream commit [db299a0c09e9](https://github.com/torvalds/linux/commit/db299a0c09e98e5fc7e7b181d7f2b94560330a8c) ("net: stmmac: move PHY handling out of __stmmac_open()/release()")). The interface reopen now performs the MAC's DMA software reset while the PHY is suspended. IEEE 802.3 allows PHYs to stop their receive clock while powered down, and the stmmac DMA software reset requires a running receive clock, so on affected boards — e.g. the Home Assistant Green (RK3566 with RTL8211F-VD PHY in RGMII mode) — a runtime MTU change kills networking entirely:

```
rk_gmac-dwmac fe010000.ethernet end0: Failed to reset the dma
rk_gmac-dwmac fe010000.ethernet end0: stmmac_hw_setup: DMA engine initialization failed
rk_gmac-dwmac fe010000.ethernet end0: __stmmac_open: Hw setup failed
rk_gmac-dwmac fe010000.ethernet end0: failed reopening the interface after MTU change
```

In the field this is triggered by NetworkManager applying an MTU while activating the connection, leaving affected Green systems without network after updating to HAOS 18.x (see #4858).

Add a kernel patch which resumes the PHY (using `phylink_prepare_resume()`) before reopening the interface, mirroring what the driver already does in its system resume path for exactly this reason. The patch will be submitted upstream.

## Testing

Verified on a Home Assistant Green running HAOS 18.x/kernel 6.18.37:
- Without the patch, `ip link set end0 mtu 1400` reliably reproduces the DMA reset failure (while the same command on 17.3/kernel 6.12.85 works).
- With the patch, the MTU change completes and the link renegotiates and comes back up, matching the 6.12 behavior.

Fixes #4858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethernet network interface reopening so it recovers more reliably after changes such as MTU updates.
  * Fixed a timing issue where the PHY could resume after hardware configuration, which could prevent receive hardware setup from succeeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->