### PR TITLE
ODROID-N2: Revert U-Boot "meson_gx_mmc: reduce maximum frequency"

### DIFF
--- a/buildroot-external/board/hardkernel/patches-meson/uboot/0002-Revert-mmc-meson_gx_mmc-reduce-maximum-frequency.patch
+++ b/buildroot-external/board/hardkernel/patches-meson/uboot/0002-Revert-mmc-meson_gx_mmc-reduce-maximum-frequency.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 4 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Revert "mmc: meson_gx_mmc: reduce maximum frequency"
+
+This reverts upstream commit 8fa0db145f6b38341ac939c1e768ca37446bbaf8.
+
+That commit lowered the meson-gx eMMC maximum frequency from 100 MHz to
+40 MHz "to be compatible with more eMMC". On ODROID-N2 this interacts
+badly with the HAOS f_max HACK (patch 0001): that patch caps the first
+init attempt to 24 MHz and, for modules that fail at 24 MHz (Kingston
+class S922X eMMC), disables the cap and falls back to cfg->f_max. With
+the reduced 40 MHz ceiling those modules only partially initialize (small
+reads such as boot.scr and the boot env succeed, but large reads and
+partition enumeration fail), soft-bricking the device after the HAOS 18
+update (see #4788). Restoring the previous 100 MHz ceiling brings back the
+working fallback that shipped in HAOS 14.0.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ drivers/mmc/meson_gx_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index 76af3873e157..d1558ebe3a24 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -336,4 +336,4 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 40000000; /* 40 MHz */
++	cfg->f_max = 100000000; /* 100 MHz */
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;


### PR DESCRIPTION
Restore cfg->f_max to 100 MHz (revert upstream 8fa0db1) in hopes the 100->40 MHz reduction in U-Boot 2026.04 is what soft-bricks certain eMMC modules on ODROID-N2 after the HAOS 18 update (#4788). The f_max HACK (0001) only caps the *first* init attempt to 24 MHz; modules that fail at 24 MHz fall back to cfg->f_max, so this ceiling governs them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the higher maximum eMMC clock speed during startup and normal operation, which may improve storage performance and device responsiveness on affected hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->