### PR TITLE
Make RAUC tryboot backend report staged updates on RPi 5

### DIFF
--- a/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
+++ b/buildroot-external/board/raspberrypi/rpi5-64/rootfs-overlay/usr/lib/rauc/rpi-tryboot.sh
@@ -3,34 +3,91 @@
 # shellcheck source=/dev/null # Our GitHub Actions tests this separately
 . /usr/lib/rauc/cmdline.sh
 
-# RAUC hook script for Raspberry Pi firmwaree tryboot
-# Meant to be usesd as a RAUC bootloader-custom-backend script.
+# RAUC hook script for Raspberry Pi firmware tryboot
+# Meant to be used as a RAUC bootloader-custom-backend script.
 
 boot_dir="/mnt/boot"
 root_slot_a="PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd"
 root_slot_b="PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20"
+reboot_param="/run/systemd/reboot-param"
 
-get_primary() {
-    echo "tryboot get-primary" >&2
+# Slot the firmware boots by default (committed state)
+committed_slot() {
     cmdline=$(head -n1 "${boot_dir}/cmdline.txt")
     get_value rauc.slot "${cmdline}"
 }
 
+# Slot staged for tryboot, empty if no tryboot is staged
+staged_slot() {
+    if [ -f "${boot_dir}/cmdline-tryboot.txt" ]; then
+        cmdline_tryboot=$(head -n1 "${boot_dir}/cmdline-tryboot.txt")
+        get_value rauc.slot "${cmdline_tryboot}"
+    fi
+}
+
+# Whether the next reboot is armed to use the firmware tryboot mechanism
+tryboot_armed() {
+    [ -f "${reboot_param}" ] && grep -q "tryboot" "${reboot_param}"
+}
+
+# Drop a staged tryboot including its armed reboot parameter
+clear_staged() {
+    rm -f "${boot_dir}/cmdline-tryboot.txt" "${boot_dir}/tryboot.txt"
+    if tryboot_armed; then
+        rm -f "${reboot_param}"
+    fi
+}
+
+get_primary() {
+    echo "tryboot get-primary" >&2
+    staged=$(staged_slot)
+    if [ -n "${staged}" ] && tryboot_armed; then
+        # An installed update stays primary until its tryboot reboot happened
+        echo "${staged}"
+    else
+        committed_slot
+    fi
+}
+
+# Called when the booted slot is marked good after a regular (non-tryboot)
+# boot. The firmware attempts a staged tryboot exactly once: if a tryboot is
+# still staged but no tryboot reboot is armed anymore, the previous boot
+# either lost the armed reboot parameter (power cut before the activation
+# reboot, /run is volatile) or the tryboot attempt failed and the firmware
+# fell back to the default slot. Either way the staged slot missed its one
+# attempt: drop it and mark it bad, a new install stages it again.
+drop_stale_tryboot() {
+    staged=$(staged_slot)
+
+    if [ -z "${staged}" ] || tryboot_armed; then
+        # Nothing staged, or staged during this boot with the activation
+        # reboot still pending
+        return
+    fi
+
+    echo "Dropping staged tryboot to slot ${staged}, marking it bad" >&2
+    rm -f "${boot_dir}/slot-${staged}/.good"
+    clear_staged
+}
+
 case "$1" in
     get-primary)
-        # Actions to be performed when getting the primary bootloader
-        # Example: Output the path to the current primary bootloader
         get_primary
         ;;
 
     set-primary)
-        # Actions to be performed when setting the primary bootloader
-        # Example: Set the specified bootloader as the primary one
         slot_bootname="$2"
 
-        # Do nothing if we're already booted in the requested slot
-        if [ "$(get_primary)" = "${slot_bootname}" ]; then
-            echo "tryboot set-primary $slot_bootname: already set" >&2
+        if [ "${slot_bootname}" = "$(committed_slot)" ]; then
+            # The requested slot is the default boot slot already. Cancel a
+            # staged tryboot if there is one (e.g. an installed update that
+            # still awaits its activation reboot).
+            if [ -n "$(staged_slot)" ]; then
+                echo "tryboot set-primary $slot_bootname: cancelling staged tryboot to $(staged_slot)" >&2
+                clear_staged
+            else
+                echo "tryboot set-primary $slot_bootname: already set" >&2
+            fi
             exit 0
         fi
 
@@ -49,7 +106,7 @@ case "$1" in
             -e "s/^\(cmdline=\).*$/\1\/cmdline-tryboot.txt/" \
             "${boot_dir}/config.txt" > "${boot_dir}/tryboot.txt"
         # Use tryboot to try booting the new primary on reboot
-        echo "0 tryboot" > /run/systemd/reboot-param
+        echo "0 tryboot" > "${reboot_param}"
         ;;
 
     get-state)
@@ -75,6 +132,10 @@ case "$1" in
         echo "tryboot set-state $slot_bootname $new_state" >&2
 
         if [ "${new_state}" != "good" ]; then
+            # Marking the staged slot bad cancels its pending tryboot
+            if [ "$(staged_slot)" = "${slot_bootname}" ]; then
+                clear_staged
+            fi
             rm -f "${boot_dir}/slot-${slot_bootname}/.good"
             exit 0
         fi
@@ -82,16 +143,16 @@ case "$1" in
         # It seems we call set-state in any case. Use this to "commit" tryboot
         # state...
 
-        # Check if tryboot is active
-        if ! cmp -s -n 4 /proc/device-tree/chosen/bootloader/tryboot /dev/zero; then
+        # Commit the tryboot state if we booted via tryboot and the booted
+        # slot is not the default boot slot yet. The firmware's tryboot flag
+        # stays set for the entire boot, so it alone can't tell whether the
+        # commit already happened — a tryboot staged later in the same boot
+        # (e.g. an update installed after the commit) must be left alone.
+        if ! cmp -s -n 4 /proc/device-tree/chosen/bootloader/tryboot /dev/zero \
+            && [ "$(committed_slot)" != "${slot_bootname}" ]; then
             if [ ! -f "${boot_dir}/cmdline-tryboot.txt" ]; then
-                if [ -f "${boot_dir}/slot-${slot_bootname}/.good" ]; then
-                    # Most probably already handled on this boot before, do nothing
-                    exit 0
-                else
-                    echo "cmdline-tryboot.txt not found, can't commit current state." >&2
-                    exit 1
-                fi
+                echo "cmdline-tryboot.txt not found, can't commit current state." >&2
+                exit 1
             fi
             # tryboot.txt MUST exist at this point
             if [ ! -f "${boot_dir}/tryboot.txt" ]; then
@@ -109,12 +170,13 @@ case "$1" in
                 "${boot_dir}/tryboot.txt" > "${boot_dir}/config.txt"
             mv "${boot_dir}/cmdline-tryboot.txt" "${boot_dir}/cmdline.txt"
             rm "${boot_dir}/tryboot.txt"
-            rm /run/systemd/reboot-param
+            rm -f "${reboot_param}"
+        else
+            drop_stale_tryboot
         fi
 
-        if [ "${new_state}" = "good" ]; then
-            touch "${boot_dir}/slot-${slot_bootname}/.good"
-        fi
+        # Only the "good" state reaches this point, all others exit early
+        touch "${boot_dir}/slot-${slot_bootname}/.good"
         ;;
 
     get-current)


### PR DESCRIPTION
## Proposed change

Rework the RAUC custom bootloader backend script for the Raspberry Pi 5 firmware tryboot mechanism so that an installed-but-not-yet-activated OS update is visible to RAUC's `GetPrimary`, and so that tryboot state which missed its (single) boot attempt is cleaned up instead of lingering forever.

Supervisor recovers a pending OS update by comparing RAUC's primary boot slot with the booted one (home-assistant/supervisor#7006, refined in home-assistant/supervisor#7022 to run after the booted slot is marked good). On RPi 5 this could never work: `get-primary` only ever reported the committed boot slot (`rauc.slot` in `cmdline.txt`), never the staged tryboot.

### Current outcome (without this fix)

- **Supervisor restart between install and activation reboot**: the pending update is forgotten. No reboot-required issue, `/os/info` reports the still-running version, and Home Assistant offers the already-installed update again (the RPi 5 flavor of what home-assistant/supervisor#7016 / home-assistant/supervisor#7017 describe for GRUB).
- **Power cut before the activation reboot**: `/run/systemd/reboot-param` is lost, so a later plain reboot boots the old slot again — the installed update silently never activates, and the staged `cmdline-tryboot.txt`/`tryboot.txt` remain on the boot partition forever.
- **Failed tryboot** (new slot doesn't boot, firmware falls back): stale staged files remain forever, and the slot is still reported as good.
- **`rauc status mark-active` on the booted slot** while an update is staged is a no-op — inconsistent with the GRUB/U-Boot backends, where marking the booted slot active cancels the pending slot switch.
- **Installing an update in the same boot the system tryboot'ed into** (routine for back-to-back updates, since the firmware's tryboot flag stays set for the entire boot): every subsequent mark-good fails with "tryboot doesn't reflect the expected boot slot". With home-assistant/supervisor#7022 this aborts `mark_healthy()` before the pending-update detection runs.

### Outcome with this fix

- `get-primary` reports the staged slot while the tryboot reboot is armed → Supervisor detects the pending update across restarts, raises the reboot-required issue, reports the pending version in `/os/info`, and skips marking the booted slot active (so the staged update survives).
- A staged tryboot found without an armed reboot parameter has missed its one firmware attempt (power cut before the reboot, or failed tryboot): it is dropped at the next mark-good of the booted slot and the staged slot is marked bad. No stale files, and the update is offered again. (Tryboot is deliberately kept one-shot — no retry counting.)
- Marking the committed slot active (or the staged slot bad) cancels a staged tryboot — GRUB/U-Boot parity. Note that with a pre-#7022 Supervisor this means its startup mark-active cancels a staged update after a Supervisor restart, which matches how the GRUB and U-Boot backends behave today.
- The tryboot state is committed only when the booted slot is not the default boot slot yet, so mark-good keeps working after same-boot re-installs.

Tested on RPi 5 hardware (before/after evidence for all of the above: staged update visible via `GetPrimary`, pending version recovered by a #7022-based Supervisor across restart with mark-active skipped, clean commit on activation) plus a scripted simulation of the full backend state machine (staging, restart-in-window, missed-attempt drop, commit, idempotent re-marks, cancel paths).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to the supervisor)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to: home-assistant/supervisor#7006, home-assistant/supervisor#7022, home-assistant/supervisor#7016, home-assistant/supervisor#7017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raspberry Pi boot-slot handling during trial updates.
  * Automatically cancels stale or invalid trial-boot state.
  * Correctly commits a trial slot only after a successful boot confirmation.
  * Ensures failed or non-good slots are not incorrectly marked as healthy.
  * Clears pending reboot and trial-boot settings when they are no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->