### PR TITLE
raspberrypi: Ignore UAS for Crucial X9 SSD (0634:5605)

### DIFF
--- a/buildroot-external/board/raspberrypi/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.lpm_enable=0 console=tty0 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u,0bda:9201:u
+dwc_otg.lpm_enable=0 console=tty0 usb-storage.quirks=174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u,152d:a578:u,152d:0583:u,0bda:9201:u,0634:5605:u


### PR DESCRIPTION
The Crucial X9 portable SSD (Micron, USB ID 0634:5605) suffers from constant UAS command aborts and device resets under sustained writes on Raspberry Pi, eventually remounting the filesystem read-only. Add the IGNORE_UAS quirk so the device falls back to the usb-storage (BOT) driver, matching the existing quirk entries for similarly affected bridges.

Fixes #4787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with an additional USB storage device on Raspberry Pi systems.
  * Prevented known device-related issues during USB storage initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->