### PR TITLE
Manage dropbear via a systemd path unit watching authorized_keys

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear-lifecycle.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear-lifecycle.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Start or stop dropbear based on SSH authorized_keys
+RequiresMountsFor=/root/.ssh
+
+[Service]
+# Idempotent on purpose: the path unit may fire for any change in the watched
+# directory (e.g. temporary files from atomic writes), so this must converge
+# rather than toggle.
+Type=oneshot
+ExecStart=/bin/sh -c 'if [ -s /root/.ssh/authorized_keys ]; then systemctl start dropbear.service; else systemctl stop dropbear.service; fi'

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear.path
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear.path
@@ -1,0 +1,17 @@
+[Unit]
+Description=Watch SSH authorized_keys for debug SSH access
+# The watch must be armed on the bind-mounted directory (inotify events do
+# not cross mount points), and before haos-config potentially imports keys.
+RequiresMountsFor=/root/.ssh
+Before=haos-config.service
+
+[Path]
+# Edge-triggered on purpose: PathExists= pointed at a oneshot unit that does
+# not consume the file would re-trigger until the start rate limit is hit.
+# Presence of keys at boot is instead handled by dropbear.service itself,
+# which is enabled and gated by ConditionFileNotEmpty.
+PathChanged=/root/.ssh/authorized_keys
+Unit=dropbear-lifecycle.service
+
+[Install]
+WantedBy=multi-user.target

--- a/buildroot-external/rootfs-overlay/usr/sbin/haos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/haos-config
@@ -76,13 +76,10 @@ if [ -f "${CONFIG_DIR}/authorized_keys" ]; then
 
     cp -f ${CONFIG_DIR}/authorized_keys /root/.ssh/authorized_keys
     chmod 600 /root/.ssh/authorized_keys
-
-    systemctl start dropbear > /dev/null 2>&1
 else
     echo "[Info] Stop SSH debug access"
 
     rm -f /root/.ssh/authorized_keys
-    systemctl stop dropbear > /dev/null 2>&1
 fi
 
 ##


### PR DESCRIPTION
## Proposed change

Debug SSH access on port 22222 currently has two lifecycle mechanisms: `dropbear.service` is enabled and gated by `ConditionFileNotEmpty=/root/.ssh/authorized_keys` at boot, and `haos-config` explicitly starts/stops the service when importing a CONFIG partition. Keys written through any other path — most notably os-agent's `AddSSHAuthKey` D-Bus method (see home-assistant/os-agent#273), which the Supervisor is growing an API on top of — do not start dropbear until the next reboot.

This PR adds `dropbear.path`, watching `/root/.ssh/authorized_keys`, which triggers a oneshot `dropbear-lifecycle.service` that starts dropbear when the file is non-empty and stops it when it is absent. The file becomes the single source of truth for whether debug SSH runs, regardless of who wrote it (haos-config import, os-agent, or a manual write on the console), and `haos-config` drops its explicit `systemctl start/stop dropbear` calls.

Resulting behavior:

| Event | Result |
|---|---|
| Boot, keys present | `dropbear.service` starts via its own enablement + condition (unchanged) |
| Boot, no keys | Service skipped by `ConditionFileNotEmpty` (unchanged) |
| Key written at runtime (os-agent, haos-config, manual) | Path unit triggers, dropbear starts |
| File removed at runtime | Path unit triggers, dropbear stops |

### Design notes

- **`PathChanged=` only, deliberately no `PathExists=`**: an exists-trigger pointed at a oneshot that doesn't consume the file re-triggers on every deactivation until the start rate limit is hit and the path unit fails. Boot-time presence is already covered by the enabled `dropbear.service` and its `ConditionFileNotEmpty`.
- **The lifecycle service is idempotent** (converges to file state rather than toggling), since the watch can fire for any change in the directory — including temporary files from atomic writes. os-agent's new temp-file-plus-rename write lands as `IN_MOVED_TO`, which `PathChanged=` covers.
- **`RequiresMountsFor=/root/.ssh`** orders the watch after `root-.ssh.mount`: inotify events don't cross mount points, so a watch armed before the bind mount would sit on the shadowed rootfs inode and never fire. It also restarts the path unit if the mount is ever restarted, and degenerates to a no-op if the bind mount goes away in a future layout.
- **`Before=haos-config.service`** arms the watch before the config import can write the file, closing the missed-event race on first boot (`PathChanged=` is edge-triggered and does not check the initial state).
- Unit enablement comes from the existing `systemctl preset-all` in `post-build.sh` (implicit `enable *` policy); no preset change needed.
- systemd path units survive deletion/recreation of watched path components (watches are placed on every ancestor and re-armed on events), so `ClearSSHAuthKeys` / `MkdirAll` cycles from os-agent are handled.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- Related: home-assistant/os-agent#273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
