### PR TITLE
Bump OS Agent to v1.10.0

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.9.0
+OS_AGENT_VERSION = 1.10.0
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release improves the reason evaluation when  RPi firmware update isn't available and improves SSH authorization key support.

Full changelog:
- https://github.com/home-assistant/os-agent/releases/tag/1.10.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled OS agent to version 1.10.0.
  - The displayed and reported agent version now reflects the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->