### PR TITLE
Enable Intel LPSS I2C for integrated touchscreens

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -176,7 +176,6 @@ CONFIG_IRQ_REMAP=y
 
 # Pin control support
 CONFIG_PINCTRL_CANNONLAKE=m
-# Alder Lake N / Twin Lake (e.g. Intel N150) panel touch I2C pinmux
 CONFIG_PINCTRL_ALDERLAKE=m
 
 # Network devices

--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -158,9 +158,6 @@ CONFIG_I2C_CHARDEV=m
 CONFIG_I2C_MUX=y
 CONFIG_I2C_TINY_USB=m
 
-# Intel LPSS Serial IO I2C (PCI 00:15.x) used by integrated touchscreens
-# on many x86 panel PCs / mini tablets (e.g. Goodix over i2c-hid).
-# CONFIG_I2C_HID_ACPI alone is not enough without the DesignWare bus.
 CONFIG_MFD_INTEL_LPSS_PCI=m
 CONFIG_I2C_DESIGNWARE_CORE=m
 CONFIG_I2C_DESIGNWARE_PLATFORM=m

--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -158,6 +158,12 @@ CONFIG_I2C_CHARDEV=m
 CONFIG_I2C_MUX=y
 CONFIG_I2C_TINY_USB=m
 
+# Intel LPSS Serial IO I2C (PCI 00:15.x) used by integrated touchscreens
+# on many x86 panel PCs / mini tablets (e.g. Goodix over i2c-hid).
+# CONFIG_I2C_HID_ACPI alone is not enough without the DesignWare bus.
+CONFIG_MFD_INTEL_LPSS_PCI=m
+CONFIG_I2C_DESIGNWARE_CORE=m
+CONFIG_I2C_DESIGNWARE_PLATFORM=m
 CONFIG_I2C_HID_ACPI=m
 
 CONFIG_I2C_DLN2=m
@@ -173,6 +179,8 @@ CONFIG_IRQ_REMAP=y
 
 # Pin control support
 CONFIG_PINCTRL_CANNONLAKE=m
+# Alder Lake N / Twin Lake (e.g. Intel N150) panel touch I2C pinmux
+CONFIG_PINCTRL_ALDERLAKE=m
 
 # Network devices
 CONFIG_MARVELL_PHY=m


### PR DESCRIPTION
## Summary
- Enable Intel LPSS PCI and DesignWare I2C support for generic-x86-64 so integrated I2C HID touchscreens can bind.
- Add Alder Lake/Twin Lake pinctrl support for Intel N-series panel PCs where the touchscreen sits behind PCI 00:15.x Serial IO I2C.
- Fixes #4899.

## Test plan
- Not run locally; kernel config change only.
- Verified on affected HAOS 18.1 host that `GDIX1002` is present under `\_SB_.PC00.I2C2.TCS2`, but PCI `0000:00:15.2` (`8086:54ea`) has no driver with the current config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added kernel support for Intel LPSS PCI MFD, enabling Intel LPSS-based I2C device support.
  * Enabled the DesignWare I2C core and platform drivers as loadable modules.
  * Added support for Alder Lake/Twin Lake pin control (loaded as a module).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->