### PR TITLE
Enable Intel VMD support for generic x86-64

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -171,6 +171,9 @@ CONFIG_BMP280=m
 # Required for some PCIe devices such as ath12k
 CONFIG_IRQ_REMAP=y
 
+# Internal NVMe devices behind Intel Volume Management Device
+CONFIG_VMD=y
+
 # Pin control support
 CONFIG_PINCTRL_CANNONLAKE=m
 


### PR DESCRIPTION
## Summary
- Enable Intel Volume Management Device support for `generic-x86-64` so NVMe drives behind a VMD PCI domain are available during early boot.
- Build VMD into the kernel with `CONFIG_VMD=y`, since the root device itself may be inaccessible until the VMD driver initializes.
- Related to #3494, which reports another generic x86-64 system with an NVMe device behind Intel VMD.

## Test plan
- Built the HAOS 18.1 `generic-x86-64` image successfully with this kernel configuration change.
- Verified the generated Linux 6.18.37 configuration contains:
  - `CONFIG_VMD=y`
  - `CONFIG_NVME_CORE=y`
  - `CONFIG_BLK_DEV_NVME=y`
- Verified the linked kernel contains the `vmd_probe` and `vmd_remove` symbols and does not contain a separate VMD module.
- Tested on an affected Intel Tiger Lake system with:
  - `0000:00:0e.0 Intel Volume Management Device NVMe RAID Controller [8086:9a0b]`
  - a KIOXIA NVMe device exposed in the downstream VMD PCI domain
- The stock HAOS 18.1 image could not find the root device and stopped with `unknown-block(0,0)`.
- The custom image with only this VMD configuration change boots successfully from the internal NVMe and runs normally.
- `git diff --check` passes against the current `dev` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Intel Volume Management Device (VMD), enabling access to compatible internal NVMe storage devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->