### PR TITLE
Fix offline connectivity test for fancy busybox ping

### DIFF
--- a/tests/smoke_test/test_offline.py
+++ b/tests/smoke_test/test_offline.py
@@ -7,11 +7,30 @@ from labgrid.driver import ExecutionError
 _LOGGER = logging.getLogger(__name__)
 
 
+def _has_fancy_ping(shell):
+    """Detect the fancy busybox ping applet (CONFIG_FEATURE_FANCY_PING).
+
+    The minimal applet (HAOS <= 18.1) only understands `ping HOST`, sends a
+    single probe and prints "HOST is alive!"; it rejects flags like -c. The
+    fancy applet (enabled since HAOS 18.2) behaves like iputils ping: it keeps
+    pinging until a count is given, so a bare `ping HOST` never returns.
+    """
+    try:
+        shell.run_check("ping -c 1 -W 1 127.0.0.1")
+        return True
+    except ExecutionError:
+        return False
+
+
 def _check_connectivity(shell, *, connected):
+    # Bound the run: the fancy applet needs an explicit count or it never
+    # returns; the minimal one rejects -c and does a single probe anyway.
+    ping = "ping -c 1 -W 2" if _has_fancy_ping(shell) else "ping"
     for target in ["home-assistant.io", "1.1.1.1"]:
         try:
-            output = shell.run_check(f"ping {target}")
-            if f"{target} is alive!" in output:
+            output = " ".join(shell.run_check(f"{ping} {target}"))
+            # minimal applet: "HOST is alive!"; fancy applet: ping statistics
+            if f"{target} is alive!" in output or " 0% packet loss" in output:
                 if connected:
                     return True
                 else:
@@ -21,7 +40,8 @@ def _check_connectivity(shell, *, connected):
                 stdout = "\n".join(exc.stdout)
                 assert ("Network is unreachable" in stdout
                         or "bad address" in stdout
-                        or "No response" in stdout)
+                        or "No response" in stdout
+                        or "100% packet loss" in stdout)
 
     if connected:
         raise AssertionError(f"expecting connected but all targets are down")


### PR DESCRIPTION
## The problem

The QEMU test job has failed on the last two `dev` builds. The first failure is `test_ha_runs_offline`, which times out (pytest-timeout, 120s) and cascades into the `os_update`/`supervisor` modules.

Root cause: #4854 enabled `CONFIG_FEATURE_FANCY_PING` in busybox (HAOS 18.2+). The fancy applet behaves like iputils `ping` — a bare `ping HOST` pings **continuously** and never returns without an explicit count. The offline connectivity helper ran `ping 1.1.1.1`, so on 18.2+ it blocks forever instead of doing a single probe:

```
# ping 1.1.1.1
PING 1.1.1.1 (1.1.1.1): 56 data bytes    ← hangs until the test is killed
```

The minimal applet on <= 18.1 does the opposite — one-shot `ping HOST` prints `HOST is alive!` and **rejects** `-c`, so we can't just hard-code `-c 1` either.

## The fix

Detect the applet at runtime and adapt:

- **fancy** (18.2+): `ping -c 1 -W 2 HOST` — bounded, matches on the ping statistics (`0% packet loss`), and accepts `100% packet loss` as a disconnected result.
- **minimal** (<= 18.1): fall back to the one-shot `ping HOST` and the `HOST is alive!` string.

Runtime capability detection keeps the test working on both pre- and post-18.2 images without gating on `VERSION_ID`.

Verified by hand against both applets:

```
# 18.1 (minimal)              | # 18.2.dev (fancy)
ping 1.1.1.1 -> "1.1.1.1 is   | ping -c 1 1.1.1.1 -> 64 bytes ...,
  alive!"                     |   0% packet loss
ping -c 1 -> Usage: ping HOST | (bare ping never returns)
```

> [!NOTE]
> This fixes the offline test. The `os_update` failure in the same job (update to stable reports "Command completed successfully" but never installs to slot B / reboots) is a separate, Supervisor-side issue and is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved offline connectivity checks across environments with different BusyBox `ping` implementations.
  * Added support for recognizing additional success and failure messages, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->