### PR TITLE
Adapt OS update test to Supervisor no longer auto-rebooting

### DIFF
--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -57,16 +57,22 @@ def test_os_update(shell, shell_json, target):
     # longer reboots automatically: it installs the bundle to the other slot,
     # marks it pending (exposed as "version_pending", see #7006) and raises a
     # reboot-required repair issue. Right after boot the OTA URL might not be
-    # available yet, so keep retrying until the update is installed as pending.
-    # Once it is, re-requesting the same version is rejected, so we stop then.
-    while True:
-        shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=300)
-        os_info = shell_json("ha os info --no-progress --raw-json")["data"]
-        if os_info["version_pending"] == stable_version:
+    # available yet, so retry (bounded) until the update is installed as
+    # pending. Once it is, re-requesting the same version is rejected, so stop.
+    for _ in range(10):
+        update_output = "\n".join(
+            shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=300)
+        )
+        # tolerate a transient CLI failure (e.g. Supervisor busy) like test_init
+        os_info = "\n".join(shell.run_check("ha os info --no-progress --raw-json || true"))
+        os_info = json.loads(os_info)["data"] if os_info.startswith("{") else {}
+        if os_info.get("version_pending") == stable_version:
             break
         # OTA info not ready yet (e.g. no URL for OTA updates); refresh and retry
         shell.run_check("ha su reload --no-progress")
         sleep(5)
+    else:
+        raise AssertionError(f"OS update did not reach pending state:\n{update_output}")
 
     # The update is installed but inactive; apply it by rebooting into the new
     # slot (rauc already marked it as the primary boot slot on install).
@@ -95,7 +101,7 @@ def test_os_update(shell, shell_json, target):
     # check the updated version is now running and no update is pending anymore
     os_info = shell_json("ha os info --no-progress --raw-json")["data"]
     assert os_info["version"] == stable_version, "OS did not update successfully"
-    assert not os_info["version_pending"], "OS update still pending after reboot"
+    assert not os_info.get("version_pending"), "OS update still pending after reboot"
 
 
 @pytest.mark.dependency(depends=["test_os_update"])

--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -53,17 +53,25 @@ def test_os_update(shell, shell_json, target):
     # update OS to latest stable - in tests it should never be the same version
     stable_version = shell_json("curl -sSL https://version.home-assistant.io/stable.json")["hassos"]["ova"]
 
-    # Core (and maybe Supervisor) might be downloaded at this point, so we need to keep trying
+    # Since Supervisor 2026.07 (home-assistant/supervisor#6982) an OS update no
+    # longer reboots automatically: it installs the bundle to the other slot,
+    # marks it pending (exposed as "version_pending", see #7006) and raises a
+    # reboot-required repair issue. Right after boot the OTA URL might not be
+    # available yet, so keep retrying until the update is installed as pending.
+    # Once it is, re-requesting the same version is rejected, so we stop then.
     while True:
-        shell.console.sendline(f"ha os update --no-progress --version {stable_version} || true")
-        # a successful update may reboot the system immediately, so wait for the new slot to boot
-        index, *_ = shell.console.expect(["Booting `Slot ", "Don't have an URL for OTA updates"], timeout=120)
-        # matched on "Booting `Slot "
-        if index == 0:
+        shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=300)
+        os_info = shell_json("ha os info --no-progress --raw-json")["data"]
+        if os_info["version_pending"] == stable_version:
             break
-        # no timeout -> matched on the second pattern
+        # OTA info not ready yet (e.g. no URL for OTA updates); refresh and retry
         shell.run_check("ha su reload --no-progress")
         sleep(5)
+
+    # The update is installed but inactive; apply it by rebooting into the new
+    # slot (rauc already marked it as the primary boot slot on install).
+    shell.console.sendline("ha host reboot --no-progress || true")
+    shell.console.expect("Booting `Slot ", timeout=120)
 
     # reactivate ShellDriver to handle login again
     target.deactivate(shell)
@@ -84,9 +92,10 @@ def test_os_update(shell, shell_json, target):
 
         sleep(1)
 
-    # check the updated version
-    os_info = shell_json("ha os info --no-progress --raw-json")
-    assert os_info["data"]["version"] == stable_version, "OS did not update successfully"
+    # check the updated version is now running and no update is pending anymore
+    os_info = shell_json("ha os info --no-progress --raw-json")["data"]
+    assert os_info["version"] == stable_version, "OS did not update successfully"
+    assert not os_info["version_pending"], "OS update still pending after reboot"
 
 
 @pytest.mark.dependency(depends=["test_os_update"])

--- a/tests/smoke_test/test_os_update.py
+++ b/tests/smoke_test/test_os_update.py
@@ -59,13 +59,14 @@ def test_os_update(shell, shell_json, target):
     # reboot-required repair issue. Right after boot the OTA URL might not be
     # available yet, so retry (bounded) until the update is installed as
     # pending. Once it is, re-requesting the same version is rejected, so stop.
-    for _ in range(10):
+    for _ in range(4):
         update_output = "\n".join(
-            shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=300)
+            shell.run_check(f"ha os update --no-progress --version {stable_version} || true", timeout=120)
         )
-        # tolerate a transient CLI failure (e.g. Supervisor busy) like test_init
-        os_info = "\n".join(shell.run_check("ha os info --no-progress --raw-json || true"))
-        os_info = json.loads(os_info)["data"] if os_info.startswith("{") else {}
+        # tolerate a transient CLI failure (e.g. Supervisor busy) like test_init;
+        # "data" is null on an error result, so coerce it to an empty dict
+        raw_info = "\n".join(shell.run_check("ha os info --no-progress --raw-json || true"))
+        os_info = (json.loads(raw_info).get("data") or {}) if raw_info.startswith("{") else {}
         if os_info.get("version_pending") == stable_version:
             break
         # OTA info not ready yet (e.g. no URL for OTA updates); refresh and retry


### PR DESCRIPTION
## The problem

The QEMU test job fails on the dev builds. Besides the offline test (see #4905), `test_os_update` fails: `ha os update` returns `Command completed successfully` but the test times out waiting for `Booting \`Slot ` — and that cascades into `test_supervisor` (setup can't reach a shell).

## Root cause

Since **home-assistant/supervisor#6982** (merged 2026-06-30, an intentional breaking change) a successful `/os/update` **no longer reboots the host automatically**. Instead the Supervisor:

- installs the bundle to the other slot and marks it as the primary/pending boot slot,
- exposes it as `version_pending` in `/os/info` (**home-assistant/supervisor#7006**, which is why `version`/`version_pending` both read as the target),
- raises a `reboot_required` repair issue with an `execute_reboot` suggestion,

and leaves the reboot to the user. `test_os_update` still assumed the old "update → immediate reboot" behavior.

Timeline confirms it: the last green run (Jun 29) ran against a 2026.06 Supervisor (still auto-rebooted); the Jul 7 / Jul 10 failures ran against 2026.07 Supervisor (post-#6982). Since tests always pull the latest Supervisor, the test is what must adapt.

Reproduced and captured from the Supervisor log:
```
[supervisor.os.manager] Install of Home Assistant Operating System 18.1 success; reboot required
[supervisor.resolution.module] Create new suggestion execute_reboot - system / None
[supervisor.resolution.module] Create new issue reboot_required - system / None
```
No auto-reboot within 150s; `version_pending: 18.1` persists.

## The fix

Adapt `test_os_update` to the new flow:
- run `ha os update` and wait until the update is installed as pending (`version_pending == target`), retrying only while the OTA URL isn't available yet (right after boot);
- apply the pending update with `ha host reboot` and wait for the new slot to boot;
- assert the new version is running and nothing is pending anymore.

## Verification

Driven end-to-end in QEMU against the current dev image + latest Supervisor:
```
install update to 18.1  -> version_pending=18.1, booted_slot=A   (no reboot)
ha host reboot          -> Booting `Slot ' detected
AFTER REBOOT: version=18.1  version_pending=None  boot=B  A=18.2.dev  B=18.1
RESULT: PASS
```

Together with #4905 (offline `ping` fix) this should restore the QEMU test job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the OS update smoke test to align with the latest Supervisor OS update behavior.
  * Triggers the update and polls until the “update pending” state reflects the target version.
  * Refreshes Supervisor state and retries while the pending version hasn’t appeared.
  * Reboots, confirms the running OS matches the target version, and verifies no OS update remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->