### PR TITLE
Enable Intel RAPL / powercap on generic-x86-64

### DIFF
--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -126,8 +126,6 @@ CONFIG_THINKPAD_ACPI=m
 CONFIG_SENSORS_K10TEMP=m
 CONFIG_SENSORS_CORETEMP=m
 
-# Power capping framework and RAPL, exposes CPU/package energy counters via
-# /sys/class/powercap (Intel since Sandy Bridge, AMD Zen via intel_rapl_msr)
 CONFIG_POWERCAP=y
 CONFIG_INTEL_RAPL=m
 

--- a/buildroot-external/board/pc/generic-x86-64/kernel.config
+++ b/buildroot-external/board/pc/generic-x86-64/kernel.config
@@ -126,6 +126,11 @@ CONFIG_THINKPAD_ACPI=m
 CONFIG_SENSORS_K10TEMP=m
 CONFIG_SENSORS_CORETEMP=m
 
+# Power capping framework and RAPL, exposes CPU/package energy counters via
+# /sys/class/powercap (Intel since Sandy Bridge, AMD Zen via intel_rapl_msr)
+CONFIG_POWERCAP=y
+CONFIG_INTEL_RAPL=m
+
 CONFIG_UHID=y
 
 CONFIG_LPC_ICH=y


### PR DESCRIPTION
## The changes

Enable the powercap framework and the Intel RAPL driver in the generic-x86-64 kernel:

- `CONFIG_POWERCAP=y`
- `CONFIG_INTEL_RAPL=m`

This exposes CPU/package energy counters via `/sys/class/powercap/intel-rapl:*/energy_uj`, allowing Home Assistant to monitor the power consumption of the host it runs on (e.g. via a `command_line` sensor feeding the Energy dashboard) without any external smart plug.

Previously the merged kernel config had `# CONFIG_POWERCAP is not set`, so `CONFIG_INTEL_RAPL` was dropped by kconfig and `/sys/class/powercap` did not exist.

The `intel_rapl_msr` driver also covers modern AMD (Zen) CPUs, so this benefits both vendors. `energy_uj` has been root-readable only since kernel 5.10, so this does not reintroduce the PLATYPUS side-channel concern.

Closes #4907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added power capping framework support for compatible systems.
  * Enabled Intel RAPL power and energy counters as an optional loadable component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->