### PR TITLE
Do not start Supervisor from HA CLI and serial getty units

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/ha-cli@.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Home Assistant CLI
-Wants=haos-supervisor.service
 After=systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target haos-supervisor.service
 Conflicts=getty@%i.service
 

--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/serial-getty@.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/serial-getty@.service.d/haos.conf
@@ -1,3 +1,2 @@
 [Unit]
-Wants=haos-supervisor.service
 After=haos-supervisor.service


### PR DESCRIPTION
The HA CLI unit (and the serial getty drop-in) pulled in `haos-supervisor.service` via `Wants=`. Since #4326 the CLI unit is
configured to never reach its start limit (`RestartSec=100ms`, `RestartMaxDelaySec=3s`, `StartLimitIntervalSec=3s`), so it restarts indefinitely - and every restart starts the Supervisor again.

This makes it impossible to stop the Supervisor for debugging: stopping `haos-supervisor.service` and removing the containers terminates `hassio_cli`, which makes `ha-cli@tty1.service` exit and restart, which immediately starts the Supervisor back up:

```
10:00:48 systemd[1]: ha-cli@tty1.service: Scheduled restart job, restart counter is at 14.
10:00:48 systemd[1]: Starting HAOS supervisor...
```

The `Wants=` is not needed: `haos-supervisor.service` is `WantedBy=multi-user.target` and gets started on boot regardless. Drop it and keep only the `After=` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup behavior by preserving startup order without automatically starting the Home Assistant Supervisor for CLI and serial console services.
  * Reduced unnecessary service activation during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->