### PR TITLE
Keep Dropbear alive during Supervisor and Docker shutdown

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear.service.d/haos.conf
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/dropbear.service.d/haos.conf
@@ -1,6 +1,11 @@
 [Unit]
 RequiresMountsFor=/etc/dropbear
 ConditionFileNotEmpty=/root/.ssh/authorized_keys
+# Systemd stops units in reverse start order, so ordering dropbear before the
+# Supervisor and Docker keeps SSH available while their (potentially minutes
+# long) teardown runs. Both already require the same mounts dropbear needs, so
+# this adds no extra work to boot.
+Before=haos-supervisor.service docker.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
## Description

`dropbear.service` has no ordering relationship to `haos-supervisor.service` or `docker.service`, so systemd schedules all three stop jobs in the same batch and runs them concurrently. Dropbear exits within milliseconds while the Supervisor gets up to 450s to stop containers (`ExecStop=docker stop -t 420`), so an SSH session is dropped right when the interesting part of shutdown starts. That makes it needlessly hard to debug slow shutdowns.

This orders Dropbear before both units. Since stop order is the reverse of start order, systemd now stops it only once the Supervisor and Docker are gone.

Notes on safety:

- Ordering-only dependency. If Dropbear fails, is masked, or is skipped by its `ConditionFileNotEmpty=/root/.ssh/authorized_keys`, the ordering counts as satisfied and both units start as before.
- No added boot latency: `docker.service` already waits for the overlay partition that Dropbear needs for `/etc/dropbear`.
- No ordering cycle: `/mnt/overlay` is a separate partition with `DefaultDependencies=no`, and nothing below it depends on Docker. Verified with `systemd-analyze verify` against a built rootfs.

This only covers the unit-stop phase. Unmounting `/mnt/data` and the final `systemd-shutdown` phase still happen after Dropbear is gone, since its own mount dependencies have to be released first. Covering those would need `DefaultDependencies=no` + `IgnoreOnIsolate=yes` (debug-shell style), which is both riskier and a poor instrument — the live session's cwd on `/mnt/data` would itself become an unmount blocker. That phase is better observed on the console with `systemd.log_level=debug`.

Verified on hardware — see the comment below for the timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown sequencing to keep SSH/remote access available during supervisor and container teardown.
  * Updated service ordering so the remote access service stops after the supervisor/Docker services begin stopping, reducing interruptions during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->