### PR TITLE
Relocate Rasberry Pi FDT out of the CMA alloc-range

### DIFF
--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -67,6 +67,10 @@ else
   reset
 fi
 
+# Relocate the FDT below the firmware-provided one, otherwise it ends up just
+# below 512 MiB and fragments the CMA alloc-range (first 768 MiB on BCM2711)
+setenv fdt_high ${fdt_org}
+
 echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_org}
 

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -93,6 +93,10 @@ else
   reset
 fi
 
+# Relocate the FDT below the firmware-provided one, otherwise it ends up just
+# below 512 MiB and fragments the CMA alloc-range (first 768 MiB on BCM2711)
+setenv fdt_high ${fdt_org}
+
 echo "Starting kernel"
 booti ${kernel_addr_r} - ${fdt_org}
 


### PR DESCRIPTION
U-Boot's default bootm_size (512 MiB) makes booti relocate the FDT to just below 0x20000000. This is fragmenting the linux,cma alloc-range (first 768 MiB on BCM2711) so the default 512 MiB CMA allocation can't be made and falls back to 8 MiB. The framebuffer console then fails to allocate and HDMI output stays blank on displays larger than 1920x1080.

Set fdt_high to the firmware-provided FDT address so U-Boot places its copy right below it, above the CMA alloc-range.

Fixes #4924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Raspberry Pi boot reliability by ensuring the device tree is relocated within the firmware-provided memory range.
  - Prevented device tree placement above 512 MiB, reducing the risk of CMA memory allocation fragmentation on BCM2711 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->