### PR TITLE
Bump OS Agent to v1.11.0

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.10.0
+OS_AGENT_VERSION = 1.11.0
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release adds ListSSHAuthKeys method to the D-Bus API.

Full changelog:
* https://github.com/home-assistant/os-agent/releases/tag/1.11.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Home Assistant OS Agent package to version 1.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->