### PR TITLE
scripts/enter.sh: create /build/output/ directory when missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ O := $(BUILDDIR)/output
 else
 override O := $(BUILDDIR)/$(O)
 endif
+# We may not have permission to create it inside the container.
+# Even if we had, the ownership could end up wrong.
+ifeq ($(wildcard $(O)),)
+$(error The build output directory $(O) does not exist)
+endif
 
 ################################################################################
 

--- a/scripts/enter.sh
+++ b/scripts/enter.sh
@@ -29,6 +29,7 @@ if [ -t 0 ]; then
   TTY_OPTS="-it"
 fi
 
+mkdir -p -v "$(pwd)/output"
 docker run --rm --privileged \
   ${TTY_OPTS} \
   -v "$(pwd):/build" -v "${CACHE_DIR}:/cache" \


### PR DESCRIPTION
Also fail faster in louder in Makefile when $(O) directory is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build setup now clearly reports when the configured output location is unavailable, helping prevent confusing build failures.
  * The build environment automatically prepares the required output directory before starting, improving reliability in containerized workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->