### PR TITLE
Makefile: fail faster and louder when the $(O) directory is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ O := $(BUILDDIR)/output
 else
 override O := $(BUILDDIR)/$(O)
 endif
+# We may not have permission to create it inside the container.
+# Even if we had, the ownership could end up wrong.
+ifeq ($(wildcard $(O)),)
+$(error The build output directory $(O) does not exist)
+endif
 
 ################################################################################
 


### PR DESCRIPTION
For a simpler and clearer error message and user feedback, fail
immediately when $(O) (by default: /build/output) is missing instead of
waiting for a sub-make to discover and report this.

For some unknown reason, the "does not exist" error from Make itself
does not show the name of the missing directory, one must gather it from
other lines.

The new error message is also "git greppable" and can lead to the
relevant code instantly.

We could try to create the missing directory on the fly, but doing this
from inside the container can cause ownership and permissions issues.

Before this commit:
```
.
.
Successfully tagged localhost/hassos:local
c84d719804549d95e8fe7edf2781536295d7230546da93ec8fb2125d7ee47954
chown: cannot access '/build/output': No such file or directory
/usr/bin/make -C /build/buildroot O=/build/output BR2_EXTERNAL=/build/buildroot-external
make[1]: Entering directory '/build/buildroot'
Makefile:178: *** output directory "" does not exist.  Stop.
make[1]: *** [Makefile:83: _all] Error 2
make[1]: Leaving directory '/build/buildroot'
make: *** [Makefile:42: default] Error 2
```

After this commit:
```
.
.
Successfully tagged localhost/hassos:local
c84d719804549d95e8fe7edf2781536295d7230546da93ec8fb2125d7ee47954
chown: cannot access '/build/output': No such file or directory
Makefile:19: *** The build output directory /build/output does not exist.  Stop.
```
Signed-off-by: Marc Herbert <marc.herbert@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect a missing build output directory before build tasks run.
  * Provides an immediate, clear error when the build configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->