### PR TITLE
Avoid polling for SD card on CM5 Lite on Yellow

### DIFF
--- a/buildroot-external/board/raspberrypi/yellow/patches/linux/0006-ARM-dts-bcm2712-Scan-sdio1-only-once-at-boot.patch
+++ b/buildroot-external/board/raspberrypi/yellow/patches/linux/0006-ARM-dts-bcm2712-Scan-sdio1-only-once-at-boot.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20=C4=8Cerm=C3=A1k?= <sairon@sairon.cz>
+Date: Mon, 17 Aug 2026 14:48:21 +0200
+Subject: [PATCH] ARM: dts: bcm2712: Scan sdio1 only once at boot
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Yellow has no SD card slot and without the non-removable property it
+keeps polling the onboard eMMC on CM5 Lite forever. Fix it by indicating
+it's non-removable, polling the interface only once at boot.
+
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+index 0dbb19898636..b85fa4c0b777 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-cm5-ha-yellow.dts
+@@ -97,6 +97,11 @@ &uart10 {
+ 	skip-init;
+ };
+ 
++/* Scan the eMMC only once at boot, Yellow has no microSD slot. */
++&sdio1 {
++	non-removable;
++};
++
+ /* RP1 USB ports are not connected on Yellow. */
+ &rp1_usb0 {
+ 	status = "disabled";


### PR DESCRIPTION
On CM5 Lite, kernel keeps polling the mmc0 interface indefinitely as it doesn't indicate the non-removable property while it has no SD card slot. Patch the BCM2712 Yellow device tree to poll only once.

Fixes #4961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved boot behavior on the CM5 Yellow board by preventing repeated scanning of the onboard eMMC.
  - The onboard storage is now recognized as permanently connected, reducing unnecessary polling during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->