### PR TITLE
Test landing page on port 80 and redirect from port 8123

### DIFF
--- a/tests/smoke_test/test_basic.py
+++ b/tests/smoke_test/test_basic.py
@@ -75,8 +75,17 @@ def test_supervisor_logs(shell):
 
 @pytest.mark.dependency(depends=["test_init"])
 def test_landing_page(shell):
-    web_index = shell.run_check("curl http://localhost:8123")
+    web_index = shell.run_check("curl http://localhost")
     assert "</html>" in " ".join(web_index)
+
+
+@pytest.mark.dependency(depends=["test_init"])
+def test_landing_page_legacy_port_redirect(shell):
+    redirect = shell.run_check(
+        "curl --silent --show-error --output /dev/null "
+        "--write-out '%{http_code} %{redirect_url}' http://localhost:8123"
+    )
+    assert " ".join(redirect) == "302 http://localhost/"
 
 
 def test_systemctl_status(shell):

--- a/tests/smoke_test/test_offline.py
+++ b/tests/smoke_test/test_offline.py
@@ -81,5 +81,5 @@ def test_ha_runs_offline(shell):
         shell.run_check("docker logs hassio_supervisor")
         raise AssertionError("homeassistant or hassio_cli not running after 60s")
 
-    web_index = shell.run_check("curl http://localhost:8123")
+    web_index = shell.run_check("curl http://localhost")
     assert "</html>" in " ".join(web_index)


### PR DESCRIPTION
Since 2026.08.0 landingpage uses port 80 as the default and redirects there from port 8123. Check this behavior in tests.

Refs #4949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The web interface is now available through standard HTTP access on port 80.
  * Requests to port 8123 redirect to the main web interface.

* **Tests**
  * Added smoke-test coverage for the port 8123 redirect.
  * Updated offline checks to validate the interface through the standard local address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->