### PR TITLE
Re-add rootfstype to kernel command line

### DIFF
--- a/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
+++ b/buildroot-external/board/arm-uefi/generic-aarch64/grub.cfg
@@ -69,17 +69,17 @@ file_env -f ($root)/cmdline.txt cmdline
 regexp --set 1:boothd (.+),.+ ${root}
 
 menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
-    linux (${boothd},gpt2)/Image root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A
+    linux (${boothd},gpt2)/Image root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs $default_cmdline $cmdline rauc.slot=A
 }
 
 menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
-    linux (${boothd},gpt4)/Image root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B
+    linux (${boothd},gpt4)/Image root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs $default_cmdline $cmdline rauc.slot=B
 }
 
 menuentry "Slot A (rescue shell)" {
-    linux (${boothd},gpt2)/Image root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target
+    linux (${boothd},gpt2)/Image root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target
 }
 
 menuentry "Slot B (rescue shell)" {
-    linux (${boothd},gpt4)/Image root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target
+    linux (${boothd},gpt4)/Image root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target
 }

--- a/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c2/uboot-boot.ush
@@ -25,8 +25,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=48617373-06 ro rootwait"
-setenv bootargs_b "root=PARTUUID=48617373-08 ro rootwait"
+setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=erofs ro rootwait"
 
 # Load environment from haos-config.txt
 if test -e mmc ${devnum}:1 haos-config.txt; then

--- a/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-c4/uboot-boot.ush
@@ -25,8 +25,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} clk_ignore_unused usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=48617373-06 ro rootwait"
-setenv bootargs_b "root=PARTUUID=48617373-08 ro rootwait"
+setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=erofs ro rootwait"
 
 # Load environment from haos-config.txt
 if test -e mmc ${devnum}:1 haos-config.txt; then

--- a/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1/uboot-boot.ush
@@ -23,8 +23,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rootwait"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro rootwait"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro rootwait"
 
 part number ${devtype} ${devnum} hassos-boot boot_partnum
 

--- a/buildroot-external/board/hardkernel/odroid-m1s/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-m1s/uboot-boot.ush
@@ -23,8 +23,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rootwait"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro rootwait"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro rootwait"
 
 part number ${devtype} ${devnum} hassos-boot boot_partnum
 

--- a/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
+++ b/buildroot-external/board/hardkernel/odroid-n2/uboot-boot.ush
@@ -25,8 +25,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=48617373-06 ro rootwait"
-setenv bootargs_b "root=PARTUUID=48617373-08 ro rootwait"
+setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=erofs ro rootwait"
 
 # Load environment from haos-config.txt
 if test -e mmc ${devnum}:1 haos-config.txt; then

--- a/buildroot-external/board/khadas/vim3/uboot-boot.ush
+++ b/buildroot-external/board/khadas/vim3/uboot-boot.ush
@@ -25,8 +25,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 systemd.machine_id=${MACHINE_ID} fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=48617373-06 ro rootwait"
-setenv bootargs_b "root=PARTUUID=48617373-08 ro rootwait"
+setenv bootargs_a "root=PARTUUID=48617373-06 rootfstype=erofs ro rootwait"
+setenv bootargs_b "root=PARTUUID=48617373-08 rootfstype=erofs ro rootwait"
 
 # Load environment from haos-config.txt
 if test -e ${devtype} ${devnum}:1 haos-config.txt; then

--- a/buildroot-external/board/nabucasa/green/uboot-boot.ush
+++ b/buildroot-external/board/nabucasa/green/uboot-boot.ush
@@ -58,8 +58,8 @@ while test ${counter} -lt 2; do
 done
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro"
 
 part number ${devtype} ${devnum} hassos-boot boot_partnum
 

--- a/buildroot-external/board/pc/grub.cfg
+++ b/buildroot-external/board/pc/grub.cfg
@@ -69,17 +69,17 @@ file_env -f ($root)/cmdline.txt cmdline
 regexp --set 1:boothd (.+),.+ ${root}
 
 menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
-    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A
+    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs $default_cmdline $cmdline rauc.slot=A
 }
 
 menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
-    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B
+    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs $default_cmdline $cmdline rauc.slot=B
 }
 
 menuentry "Slot A (rescue shell)" {
-    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target debug
+    linux (${boothd},gpt2)/bzImage root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs $default_cmdline $cmdline rauc.slot=A systemd.unit=recovery.target debug
 }
 
 menuentry "Slot B (rescue shell)" {
-    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target debug
+    linux (${boothd},gpt4)/bzImage root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs $default_cmdline $cmdline rauc.slot=B systemd.unit=recovery.target debug
 }

--- a/buildroot-external/board/raspberrypi/rpi5-64/cmdline.txt
+++ b/buildroot-external/board/raspberrypi/rpi5-64/cmdline.txt
@@ -1,1 +1,1 @@
-zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty0 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro rauc.slot=A
+zram.enabled=1 zram.num_devices=3 rootwait cgroup_enable=memory fsck.repair=yes console=tty0 root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro rauc.slot=A

--- a/buildroot-external/board/raspberrypi/uboot-boot.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot.ush
@@ -24,8 +24,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro"
 
 # Preserve origin bootargs
 setenv bootargs_rpi

--- a/buildroot-external/board/raspberrypi/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/uboot-boot64.ush
@@ -24,8 +24,8 @@ test -n "${MACHINE_ID}" || setenv BOOT_CONDITION "systemd.condition-first-boot=t
 setenv bootargs_haos "zram.enabled=1 zram.num_devices=3 rootwait systemd.machine_id=${MACHINE_ID} cgroup_enable=memory fsck.repair=yes ${BOOT_CONDITION}"
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro"
 
 # Preserve origin bootargs
 setenv bootargs_rpi

--- a/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
+++ b/buildroot-external/board/raspberrypi/yellow/uboot-boot64.ush
@@ -50,8 +50,8 @@ elif gpio input GPIO26; then
 fi
 
 # HAOS system A/B
-setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd ro"
-setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 ro"
+setenv bootargs_a "root=PARTUUID=8d3d53e3-6d49-4c38-8349-aff6859e82fd rootfstype=erofs ro"
+setenv bootargs_b "root=PARTUUID=a3ec664e-32ce-4665-95ea-7ae90ce9aa20 rootfstype=erofs ro"
 
 # Preserve origin bootargs
 setenv bootargs_rpi

--- a/buildroot-external/ota/rauc-hook
+++ b/buildroot-external/ota/rauc-hook
@@ -30,7 +30,10 @@ install_boot() {
     if [ "$RAUC_SYSTEM_COMPATIBLE" = "haos-rpi5-64" ]; then
         rm -rf "${BOOT_MNT}/slot-default"
         cp -r "${BOOT_NEW}/slot-A" "${BOOT_MNT}/slot-default"
-        sed -i "1 s/rootfstype=squashfs //" /mnt/boot/cmdline.txt
+        # Add rootfstype=erofs to cmdline.txt, can be removed in HAOS 19.0
+        if ! grep -q "rootfstype=" "${BOOT_MNT}/cmdline.txt"; then
+            sed -i "1 s/root=[^ ]*/& rootfstype=erofs/" "${BOOT_MNT}/cmdline.txt"
+        fi
     else
         # Backup boot config
         cp -f "${BOOT_MNT}"/*.txt "${BOOT_TMP}/" || true


### PR DESCRIPTION
The rootfstype parameter was removed in HAOS 13.0 when the root filesystem switched from SquashFS to EROFS in #3456, because during the transition one slot could still contain a SquashFS rootfs. The enforced upgrade path now only allows upgrading from 15.2 or newer, so after an update both slots are guaranteed to contain an EROFS rootfs and the parameter can be added back. Specifying rootfstype avoids probing other filesystem types when mounting the rootfs.

For U-Boot boards add rootfstype=erofs to the boot scripts and to the grub.cfg on UEFI targets. On Raspberry Pi 5 the cmdline.txt on the boot partition persists across updates, so adjust it in a targeted migration in the RAUC hook. The migration replaces the obsolete removal of rootfstype=squashfs, which is already handled on all systems the update can be installed from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boot configurations now explicitly identify the root filesystem as EROFS across supported devices and boot slots.
  * Raspberry Pi 5 installations add the EROFS filesystem setting when it is not already present.

* **Bug Fixes**
  * Improved reliability when mounting the read-only system partition during normal and rescue boots.
  * Preserved existing filesystem configuration instead of removing EROFS-related settings during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->