### PR TITLE
Add service to reset Docker storage when requested

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-docker-reset.service
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/haos-docker-reset.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Reset Docker Storage
+DefaultDependencies=no
+RefuseManualStart=true
+RefuseManualStop=true
+RequiresMountsFor=/mnt/data
+Before=var-lib-docker.mount docker-prepare.service docker.service containerd.service
+ConditionPathExists=/mnt/data/docker/.wipe-scheduled
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/haos-docker-reset
+
+[Install]
+WantedBy=multi-user.target

--- a/buildroot-external/rootfs-overlay/usr/libexec/docker-prepare
+++ b/buildroot-external/rootfs-overlay/usr/libexec/docker-prepare
@@ -3,7 +3,7 @@
 set -e
 
 # Remove leftovers of an interrupted Docker storage reset
-rm -rf /mnt/data/docker.wipe*
+rm -rf /mnt/data/docker.wipe.*
 
 if [ ! -d /mnt/data/docker ] || [ -z "$(ls -A /mnt/data/docker)" ]; then
     echo "[INFO] Docker data is wiped, creating containerd snapshotter flag"

--- a/buildroot-external/rootfs-overlay/usr/libexec/docker-prepare
+++ b/buildroot-external/rootfs-overlay/usr/libexec/docker-prepare
@@ -2,6 +2,9 @@
 
 set -e
 
+# Remove leftovers of an interrupted Docker storage reset
+rm -rf /mnt/data/docker.wipe*
+
 if [ ! -d /mnt/data/docker ] || [ -z "$(ls -A /mnt/data/docker)" ]; then
     echo "[INFO] Docker data is wiped, creating containerd snapshotter flag"
     touch /mnt/data/.docker-use-containerd-snapshotter

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
@@ -14,8 +14,6 @@ if [ -e "${DOCKER_DIR}" ]; then
     mv "${DOCKER_DIR}" "${WIPED_DIR}"
 fi
 
-mkdir -m 0710 "${DOCKER_DIR}"
-
 # Leftovers are removed by docker-prepare if this is interrupted
 echo "[INFO] Removing old Docker storage"
 rm -rf "${DOCKER_DIR}".wipe.*

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
@@ -18,4 +18,4 @@ mkdir -m 0710 "${DOCKER_DIR}"
 
 # Leftovers are removed by docker-prepare if this is interrupted
 echo "[INFO] Removing old Docker storage"
-rm -rf "${DOCKER_DIR}".wiped*
+rm -rf "${DOCKER_DIR}".wipe.*

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-docker-reset
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+DOCKER_DIR="/mnt/data/docker"
+
+if findmnt /var/lib/docker > /dev/null; then
+    echo "[ERROR] Unable to reset Docker storage while /var/lib/docker is mounted"
+    exit 1
+fi
+
+if [ -e "${DOCKER_DIR}" ]; then
+    WIPED_DIR="${DOCKER_DIR}.wipe.$(date +%s)"
+    echo "[INFO] Moving Docker storage to ${WIPED_DIR}"
+    mv "${DOCKER_DIR}" "${WIPED_DIR}"
+fi
+
+mkdir -m 0710 "${DOCKER_DIR}"
+
+# Leftovers are removed by docker-prepare if this is interrupted
+echo "[INFO] Removing old Docker storage"
+rm -rf "${DOCKER_DIR}".wiped*


### PR DESCRIPTION
Corrupted Docker image layers cannot be always fixed by removing and re-pulling a single image, because layers are shared between images. The only (easy) way to recover is wiping all of Docker's storage which is currently cumbersome and requires OS shell access.

Add service triggered by /mnt/data/docker/.wipe-scheduled flag file which wipes the Docker directory by atomically renaming it and deleting synchronously. If this is interrupted, docker-prepare script removes the leftovers before Docker is started on every boot.

It should be noted that docker-prepare also forces the switch to containerd snapshotter after the wipe.

Refs home-assistant/supervisor#6555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic Docker storage reset when a reset is scheduled.
  - Safely moves existing Docker storage aside to support recovery from interrupted resets.
  - Cleans up temporary storage from completed or interrupted resets.

- **Bug Fixes**
  - Prevents Docker storage reset while the Docker data directory is mounted.
  - Limits startup cleanup to Docker reset leftovers, avoiding removal of unrelated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->