### PR TITLE
Persist timesyncd config in /etc/systemd/timesyncd.conf.d

### DIFF
--- a/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-systemd-timesyncd.conf.d.mount
+++ b/buildroot-external/rootfs-overlay/usr/lib/systemd/system/etc-systemd-timesyncd.conf.d.mount
@@ -5,8 +5,8 @@ After=mnt-overlay.mount haos-overlay.service
 Before=systemd-timesyncd.service
 
 [Mount]
-What=/mnt/overlay/etc/systemd/timesyncd.conf
-Where=/etc/systemd/timesyncd.conf
+What=/mnt/overlay/etc/systemd/timesyncd.conf.d
+Where=/etc/systemd/timesyncd.conf.d
 Type=none
 Options=bind
 

--- a/buildroot-external/rootfs-overlay/usr/libexec/haos-overlay
+++ b/buildroot-external/rootfs-overlay/usr/libexec/haos-overlay
@@ -14,9 +14,19 @@ if [ ! -f /mnt/overlay/etc/hosts ]; then
 fi
 
 # TimeSync
-if [ ! -f /mnt/overlay/etc/systemd/timesyncd.conf ]; then
-    mkdir -p /mnt/overlay/etc/systemd
-    cp -fp /etc/systemd/timesyncd.conf /mnt/overlay/etc/systemd/timesyncd.conf
+TIMESYNCD_CONF_DIR=/mnt/overlay/etc/systemd/timesyncd.conf.d
+mkdir -p "${TIMESYNCD_CONF_DIR}"
+
+# Move settings from a persisted copy of timesyncd.conf into a drop-in,
+# can be removed in OS 19.0
+if [ -f /mnt/overlay/etc/systemd/timesyncd.conf ]; then
+    # Drop the section header, the shipped defaults, comments and blank lines
+    SETTINGS=$(grep -Ev '^(\[Time\]|FallbackNTP=time\.cloudflare\.com|ConnectionRetrySec=10|[[:space:]]*#.*|[[:space:]]*)$' \
+        /mnt/overlay/etc/systemd/timesyncd.conf)
+    if [ -n "${SETTINGS}" ] && [ ! -f "${TIMESYNCD_CONF_DIR}/20-custom.conf" ]; then
+        printf '[Time]\n%s\n' "${SETTINGS}" > "${TIMESYNCD_CONF_DIR}/20-custom.conf"
+    fi
+    rm -f /mnt/overlay/etc/systemd/timesyncd.conf
 fi
 
 if [ ! -L /mnt/overlay/etc/localtime ]; then

--- a/buildroot-external/rootfs-overlay/usr/sbin/haos-config
+++ b/buildroot-external/rootfs-overlay/usr/sbin/haos-config
@@ -90,7 +90,7 @@ fi
 if [ -f "${CONFIG_DIR}/timesyncd.conf" ]; then
     echo "[Info] Update timesyncd config"
 
-    cat "${CONFIG_DIR}/timesyncd.conf" > /etc/systemd/timesyncd.conf
+    cat "${CONFIG_DIR}/timesyncd.conf" > /etc/systemd/timesyncd.conf.d/20-custom.conf
     systemctl restart systemd-timesyncd.service > /dev/null 2>&1
 fi
 


### PR DESCRIPTION
The persistent timesyncd configuration is a single bind-mounted file over `/etc/systemd/timesyncd.conf`. The NTP configuration through OS Agent (home-assistant/os-agent#207) attempted to do atomic updates, but a temporary file cannot be created next to it in the read-only `/etc/systemd`, and replacing the file in the overlay directly changes the inode, so the bind mount keeps pointing to the old content. Also, a persisted copy of the whole file means changes to the shipped defaults never reach existing installations.

Bind-mount the `/etc/systemd/timesyncd.conf.d` directory from the overlay instead and keep the shipped `timesyncd.conf` read-only. Configuration is layered as drop-ins, from lowest priority to higher:

* `10-ntp.conf` (in `/run`): NTP servers from DHCP
* `20-custom.conf`: `timesyncd.conf` imported from the CONFIG partition
* `50-os-agent.conf`: NTP servers set through the OS Agent D-Bus API

On upgrade, settings from the previously persisted `timesyncd.conf` other than the shipped defaults are moved to `20-custom.conf`. This migration can be removed later (with #4986). `50-os-agent.conf` should be only managed by OS Agent, so we don't need to care about user's edits. Finally, if needed, drop-ins with higher priorities can be added for complex customizations.

Refs home-assistant/supervisor#6278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Time synchronization settings are now managed through drop-in configuration files, allowing custom settings to coexist with system defaults.
  - Imported time synchronization configuration is stored separately from the main system configuration.

- **Bug Fixes**
  - Existing time synchronization settings are automatically migrated to the new format, helping preserve custom configuration during upgrades.
  - Default system settings are no longer copied over or overwritten unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->