### PR TITLE
Bump OS Agent to v1.13.0

### DIFF
--- a/buildroot-external/package/os-agent/os-agent.mk
+++ b/buildroot-external/package/os-agent/os-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OS_AGENT_VERSION = 1.12.0
+OS_AGENT_VERSION = 1.13.0
 OS_AGENT_SITE = $(call github,home-assistant,os-agent,$(OS_AGENT_VERSION))
 OS_AGENT_LICENSE = Apache License 2.0
 OS_AGENT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This release implements DBus API for NTP server configuration, building on #4988 and required for home-assistant/supervisor#6278.

Full changelog:
* https://github.com/home-assistant/os-agent/releases/tag/1.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the packaged OS agent to version 1.13.0.
  - Includes the latest available OS agent release in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->