### PR TITLE
Force filesystem sync when unpacking container image layers

### DIFF
--- a/buildroot-external/rootfs-overlay/etc/containerd/config.toml
+++ b/buildroot-external/rootfs-overlay/etc/containerd/config.toml
@@ -7,3 +7,12 @@ disabled_plugins = [
   "io.containerd.tracing.processor.v1.otlp",
   "io.containerd.internal.v1.tracing"
 ]
+
+# containerd only fsyncs its metadata database, not unpacked layer content, so
+# a power loss shortly after an image pull leaves layers with zero-byte files
+# while the snapshot is durably recorded as valid. Such corruption survives
+# delete/re-pull since existing snapshots are never re-verified. Force a
+# syncfs(2) after each applied layer to make unpacked data as durable as the
+# metadata that references it.
+[plugins."io.containerd.service.v1.diff-service"]
+  sync_fs = true


### PR DESCRIPTION
## Summary

Enable the containerd diff-service `sync_fs` option so the daemon issues one `syncfs(2)` after each unpacked image layer. containerd fsyncs its metadata database when committing a snapshot, but never syncs the unpacked layer data itself — after an unclean shutdown shortly after an image pull this leaves layers with zero-byte files (correct names/modes/mtimes, no data) while the snapshot stays durably recorded as valid. Because committed snapshots are never re-verified or re-unpacked, the corruption even survives deleting and re-pulling the image (moby/moby#49784, containerd/containerd#8973), and with shared base layers it is only recoverable by wiping the Docker storage.

This is the failure signature behind a growing number of corruption reports, e.g. the 0-byte coredns in home-assistant/plugin-dns#207, home-assistant/supervisor#6476, home-assistant/supervisor#6835, #4913. Upstream background: containerd/containerd#8895, fixed opt-in via containerd/containerd#10284 (containerd >= 2.0). The daemon-side option applies to all clients of the daemon, including dockerd with the containerd image store (the default since HAOS 17). Installs still on the overlay2 graphdriver unpack inside dockerd and are unaffected either way.

## Verification (QEMU, HAOS 18.3.dev, Docker 29.6.2 / containerd 2.2.6)

- **Stock settings, power cut <1s after `docker pull` of the DNS plugin image**: corrupts 2/2 runs — one run zeroed `/usr/bin/coredns` entirely, the other zeroed the s6 scripts and left coredns truncated (20021248 of 25919650 bytes), matching the two damage profiles reported in plugin-dns#207.
- **Deterministic A/B with kernel background writeback suppressed** (survival can then only come from the stack syncing explicitly): baseline ends with 1215 zero-byte files and `exec format error`; with `sync_fs` the image survives the identical power cut intact (152 kB dirty at the cut vs 76 MB).
- **strace on containerd**: 0 `syncfs` calls per image load before, exactly one per layer after — also confirming dockerd pulls route through the daemon's diff service where this option takes effect.
- **Cost** (load+unpack of the 2 GB Core image): 41.6s → 42.2s on a fast disk; 226s → 230s (+1.9%) on a 30 MB/s / 250 IOPS throttled disk. QEMU throttling does not model SD-card sync latency, so the slowest cards may pay somewhat more, but the cost is bounded at one `syncfs` per layer rather than per file.

Given HAOS commonly runs on SD cards without a UPS, trading a slightly slower pull for image data that is actually on disk when the pull completes seems like the right default.

Related: home-assistant/supervisor#6555 (Docker storage reset, the recovery path for already-corrupted installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved data durability when applying container image layers.
  * Reduced the risk of losing unpacked image data after unexpected power loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->